### PR TITLE
Set the playlist context menu popup location relative to the mouse cu…

### DIFF
--- a/src/com/transgressoft/musicott/view/NavigationController.java
+++ b/src/com/transgressoft/musicott/view/NavigationController.java
@@ -72,8 +72,8 @@ public class NavigationController implements MusicottController {
 
 		newPlaylistButton.setContextMenu(newPlaylistButtonContextMenu);
 		newPlaylistButton.addEventFilter(MouseEvent.MOUSE_CLICKED, e -> {
-			double newPlaylistButtonX = newPlaylistButton.getLayoutX() + 150;
-			double newPlaylistButtonY = newPlaylistButton.getLayoutY();
+			double newPlaylistButtonX = e.getScreenX() + 10;
+			double newPlaylistButtonY = e.getScreenY() + 10;
 			newPlaylistButtonContextMenu.show(newPlaylistButton, newPlaylistButtonX, newPlaylistButtonY);
 		});
 


### PR DESCRIPTION
Hey Otto,

The new playlist context menu opens up well away from the stage. Basically at the other side of the screen from the app window!

I can't find a way to get a node's X, Y *after* layout has been performed. Instead i anchored it to the mouse cursor position (since that is on the button).

I stumbled across your project while i was looking to see if i should try JavaFX. I think you have a nice ui so rather than start my own toy project i figured i'd start with yours!

All the best,

Craig