### PR TITLE
Bug fix wave: play queue, search, and metadata editor

### DIFF
--- a/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceStorageIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceStorageIT.java
@@ -1,0 +1,225 @@
+package net.transgressoft.musicott.services;
+
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
+
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.ObservableList;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration test for {@link PlayerService} storage contract, exercising a REAL
+ * {@code PlayerService} instance (not a Mockito mock) so the list-mutation ripple in
+ * {@code next()}, {@code previous()}, {@code addToQueue()}, {@code playFromQueue()},
+ * and {@code enforceHistoryCap()} is verifiable in CI.
+ */
+@ExtendWith(ApplicationExtension.class)
+@DisplayName("PlayerService storage")
+class PlayerServiceStorageIT {
+
+    ApplicationEventPublisher applicationEventPublisher;
+    PlayerService playerService;
+
+    @Start
+    void start(Stage stage) {
+        // No scene needed — only the JavaFX toolkit must be running so TrackQueueRow (extends GridPane) can be constructed.
+        applicationEventPublisher = mock(ApplicationEventPublisher.class);
+        playerService = new PlayerService(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("next inverts queue pop direction so size-1 element plays next")
+    void nextInvertsQueuePopDirectionSoSizeMinusOneElementPlaysNext() throws Exception {
+        ObservableAudioItem itemA = newPlayableAudioItem("A");
+        ObservableAudioItem itemB = newPlayableAudioItem("B");
+        ObservableAudioItem itemC = newPlayableAudioItem("C");
+
+        // Inverted-storage contract for addToQueue: input [A, B, C] (A selected first) maps to
+        // storage [C, B, A] so A — the first track the user wants played — is at size-1 (next-up,
+        // bottom of the popover) and C — the last selected — is at index 0 (farthest-out, top).
+        playerService.addToQueue(List.of(itemA, itemB, itemC));
+
+        ObservableList<TrackQueueRow> queue = playerService.getPlayQueueList();
+        assertThat(queue).hasSize(3);
+        assertThat(queue.get(0).getTrack()).isSameAs(itemC);
+        assertThat(queue.get(queue.size() - 1).getTrack()).isSameAs(itemA);
+        // Note: we do NOT call playerService.next() because next() invokes play(...) which
+        // attempts to start the JavaFX media subsystem (jfxmedia) — unreliable headless.
+        // The size-1 == next-up storage contract IS the assertion that proves the inversion.
+    }
+
+    // Windows Media Foundation crashes the JVM (STATUS_ACCESS_VIOLATION 0xC0000005) when
+    // JavaFxPlayer is constructed against the empty mp3 stub used here. Linux + macOS bundle
+    // codecs that fail with a Java exception we can swallow; Windows fails in native code where
+    // try/catch can't reach. Storage-contract coverage from the Linux + macOS CI legs is
+    // sufficient for the assertions below — the platform-independent list mutations.
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "JavaFxPlayer construction crashes Windows headless JVM (jfxmedia native access violation)")
+    @Test
+    @DisplayName("previous appends to playQueueList end and pops historyQueueList from end")
+    void previousAppendsToPlayQueueListEndAndPopsHistoryQueueListFromEnd() throws Exception {
+        ObservableAudioItem itemH1 = newPlayableAudioItem("H1");
+        ObservableAudioItem itemH2 = newPlayableAudioItem("H2");
+        ObservableAudioItem itemCurrent = newPlayableAudioItem("Current");
+
+        // Seed historyQueueList directly via the public accessor.
+        ObservableList<TrackQueueRow> history = playerService.getHistoryQueueList();
+        history.add(new TrackQueueRow(itemH1));
+        history.add(new TrackQueueRow(itemH2));
+
+        // Seed currentTrack via reflection (private field).
+        ReflectionTestUtils.setField(playerService, "currentTrack", Optional.of(itemCurrent));
+
+        // previous() ends with setPlayer(...) which constructs JavaFxPlayer — guard with try/catch.
+        // List mutations happen BEFORE setPlayer so assertions remain valid even if media fails.
+        // Catches Throwable because jfxmedia unavailability throws UnsatisfiedLinkError (an Error, not RuntimeException).
+        try {
+            playerService.previous();
+        } catch (Throwable ignored) {
+            // Media subsystem may be unavailable headless; list mutations already occurred.
+        }
+
+        ObservableList<TrackQueueRow> queue = playerService.getPlayQueueList();
+        // The currentTrack was appended to playQueueList at the end (size-1).
+        assertThat(queue).hasSize(1);
+        assertThat(queue.get(queue.size() - 1).getTrack()).isSameAs(itemCurrent);
+
+        // historyQueueList popped from size-1 (end): [H1, H2] → [H1].
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).getTrack()).isSameAs(itemH1);
+    }
+
+    @Test
+    @DisplayName("addToQueue places the first selected item at the next-up end and the last selected at the farthest end")
+    void addToQueuePlacesFirstSelectedAtNextUpEndAndLastSelectedAtFarthestEnd() throws Exception {
+        ObservableAudioItem itemA = newPlayableAudioItem("A");
+        ObservableAudioItem itemB = newPlayableAudioItem("B");
+        ObservableAudioItem itemC = newPlayableAudioItem("C");
+        ObservableAudioItem itemD = newPlayableAudioItem("D");
+        ObservableAudioItem itemE = newPlayableAudioItem("E");
+
+        // First batch [A, B, C] (A selected first) → storage [C, B, A]:
+        // A at size-1 = next-up (bottom of popover, plays first); C at index 0 = farthest-out
+        // (top, plays last). Display follows storage 1:1.
+        playerService.addToQueue(List.of(itemA, itemB, itemC));
+
+        ObservableList<TrackQueueRow> queue = playerService.getPlayQueueList();
+        assertThat(queue).hasSize(3);
+        assertThat(queue.get(0).getTrack()).isSameAs(itemC);
+        assertThat(queue.get(1).getTrack()).isSameAs(itemB);
+        assertThat(queue.get(2).getTrack()).isSameAs(itemA);
+
+        // Second batch [D, E] queues behind everything already queued — D and E play AFTER C.
+        // Inverted storage means new rows prepend; the first new item (D) ends up just behind
+        // the previously-farthest C, and the last new item (E) ends up at the new far-end (index 0).
+        // Final storage [E, D, C, B, A].
+        playerService.addToQueue(List.of(itemD, itemE));
+
+        assertThat(queue).hasSize(5);
+        assertThat(queue.get(0).getTrack()).isSameAs(itemE);
+        assertThat(queue.get(1).getTrack()).isSameAs(itemD);
+        assertThat(queue.get(2).getTrack()).isSameAs(itemC);
+        assertThat(queue.get(3).getTrack()).isSameAs(itemB);
+        assertThat(queue.get(4).getTrack()).isSameAs(itemA);
+    }
+
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "JavaFxPlayer construction crashes Windows headless JVM (jfxmedia native access violation)")
+    @Test
+    @DisplayName("playFromQueue appends the previous current track to history (not the selected one)")
+    void playFromQueueAppendsPreviousCurrentTrackToHistory() throws Exception {
+        ObservableAudioItem itemPrev = newPlayableAudioItem("Prev");
+        ObservableAudioItem itemA = newPlayableAudioItem("A");
+
+        // Simulate a track already playing — when the user double-clicks itemA in the queue,
+        // itemPrev is the track being LEFT and is what should land in history. itemA is the
+        // track being started; it will be appended to history when it finishes via next().
+        ReflectionTestUtils.setField(playerService, "currentTrack", Optional.of(itemPrev));
+
+        playerService.addToQueue(List.of(itemA));
+        ObservableList<TrackQueueRow> queue = playerService.getPlayQueueList();
+        TrackQueueRow rowA = queue.get(0);
+
+        // playFromQueue calls setPlayer (jfxmedia) — guard with try/catch.
+        // List mutations (history-append + queue-remove) happen BEFORE setPlayer in the method body.
+        // Catches Throwable because jfxmedia unavailability throws UnsatisfiedLinkError (an Error, not RuntimeException).
+        try {
+            playerService.playFromQueue(rowA);
+        } catch (Throwable ignored) {
+            // Media subsystem may be unavailable headless; list mutations already occurred.
+        }
+
+        // History should contain the LEFT track only — itemA is now currentTrack and goes to
+        // history later via next() when playback finishes.
+        ObservableList<TrackQueueRow> history = playerService.getHistoryQueueList();
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).getTrack()).isSameAs(itemPrev);
+
+        // Queue had rowA removed.
+        assertThat(queue).isEmpty();
+    }
+
+    @Test
+    @DisplayName("enforceHistoryCap evicts oldest entries from index 0")
+    void enforceHistoryCapEvictsOldestEntriesFromIndexZero() throws Exception {
+        ObservableList<TrackQueueRow> history = playerService.getHistoryQueueList();
+
+        // Seed 152 rows; each track is identifiable by its title index.
+        ObservableAudioItem[] items = new ObservableAudioItem[152];
+        for (int i = 0; i < 152; i++) {
+            items[i] = newPlayableAudioItem("track-" + i);
+            history.add(new TrackQueueRow(items[i]));
+        }
+        assertThat(history).hasSize(152);
+
+        ReflectionTestUtils.invokeMethod(playerService, "enforceHistoryCap");
+
+        // overflow = 152 - 150 = 2; evict from index 0..1 (oldest).
+        assertThat(history).hasSize(150);
+        assertThat(history.get(0).getTrack()).isSameAs(items[2]);
+        assertThat(history.get(history.size() - 1).getTrack()).isSameAs(items[151]);
+    }
+
+    @SuppressWarnings("unchecked")
+    ObservableAudioItem newPlayableAudioItem(String title) throws Exception {
+        ObservableAudioItem item = mock(ObservableAudioItem.class);
+        // Playable extension required by JavaFxPlayer.Companion.isPlayable
+        Path tempFile = Files.createTempFile("musicott-storage-it-", ".mp3");
+        tempFile.toFile().deleteOnExit();
+        when(item.getPath()).thenReturn(tempFile);
+        when(item.getExtension()).thenReturn("mp3");
+        when(item.getTitleProperty()).thenReturn(new SimpleStringProperty(title));
+
+        var artist = mock(net.transgressoft.commons.music.audio.Artist.class);
+        when(artist.getName()).thenReturn("Test Artist");
+        when(item.getArtistProperty()).thenReturn(new SimpleObjectProperty<>(artist));
+
+        var album = mock(net.transgressoft.commons.music.audio.Album.class);
+        when(album.getName()).thenReturn("Test Album");
+        when(item.getAlbumProperty()).thenReturn(new SimpleObjectProperty<>(album));
+
+        when(item.getCoverImageProperty()).thenReturn(new SimpleObjectProperty<>(Optional.empty()));
+        when(item.getPlayCountProperty()).thenReturn(new SimpleIntegerProperty(0));
+        when(item.getDuration()).thenReturn(Duration.ofSeconds(5));
+        return item;
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceStorageIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceStorageIT.java
@@ -179,6 +179,26 @@ class PlayerServiceStorageIT {
     }
 
     @Test
+    @DisplayName("next appends finished track to historyQueueList when queue is empty")
+    void nextAppendsFinishedTrackToHistoryQueueListWhenQueueIsEmpty() throws Exception {
+        ObservableAudioItem item = newPlayableAudioItem("Solo");
+
+        // Simulate direct table double-click (no queue add): currentTrack populated, queue empty.
+        ReflectionTestUtils.setField(playerService, "currentTrack", Optional.of(item));
+
+        assertThat(playerService.getPlayQueueList()).isEmpty();
+        assertThat(playerService.getHistoryQueueList()).isEmpty();
+
+        // next() will hit the empty-queue branch — post-Task-1, the history append still runs.
+        // next() ends with stop() in this branch (no setPlayer/jfxmedia call).
+        playerService.next();
+
+        ObservableList<TrackQueueRow> history = playerService.getHistoryQueueList();
+        assertThat(history).hasSize(1);
+        assertThat(history.get(0).getTrack()).isSameAs(item);
+    }
+
+    @Test
     @DisplayName("enforceHistoryCap evicts oldest entries from index 0")
     void enforceHistoryCapEvictsOldestEntriesFromIndexZero() throws Exception {
         ObservableList<TrackQueueRow> history = playerService.getHistoryQueueList();

--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
+import javafx.scene.control.ListView;
 import javafx.scene.control.SplitPane;
 import net.rgielen.fxweaver.core.FxControllerAndView;
 import net.rgielen.fxweaver.core.FxWeaver;
@@ -12,6 +13,7 @@ import net.rgielen.fxweaver.spring.SpringFxWeaver;
 import net.transgressoft.lirp.event.LirpEventPublisher;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.musicott.events.SearchTextTypedEvent;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -87,6 +89,72 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
 
         // Artist list view remains accessible after artist selection
         assertThat(fxRobot.lookup("#artistsListView").tryQuery()).isPresent();
+    }
+
+    @Test
+    @DisplayName("ArtistViewController auto-selects the first filtered artist when search query matches")
+    void autoSelectsFirstFilteredArtistWhenSearchQueryMatches(FxRobot fxRobot) {
+        ArtistViewController controller = artistViewAndController.getController();
+        // Clear accumulated state from previous tests and reset the predicate.
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            controller.searchTextTypedEvent(new SearchTextTypedEvent("", this));
+        });
+        waitForFxEvents();
+
+        Platform.runLater(() -> {
+            artistsProperty.add(of("Abel"));
+            artistsProperty.add(of("Abba"));
+            artistsProperty.add(of("Beatles"));
+        });
+        waitForFxEvents();
+
+        // Direct invocation bypasses the mocked ApplicationEventPublisher bean — publishEvent(...)
+        // on a mock is a no-op, so the @EventListener method is driven directly here.
+        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("Abe", this)));
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        assertThat(artistsListView.getItems()).hasSize(1);
+        assertThat(artistsListView.getItems().get(0).getName()).isEqualTo("Abel");
+
+        Artist selected = artistsListView.getSelectionModel().getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected).isSameAs(artistsListView.getItems().get(0));
+    }
+
+    @Test
+    @DisplayName("ArtistViewController restores the full artist list and selects the first artist when search query clears")
+    void restoresFullArtistListAndSelectsFirstArtistWhenSearchQueryClears(FxRobot fxRobot) {
+        ArtistViewController controller = artistViewAndController.getController();
+        // Clear accumulated state from previous tests and reset the predicate.
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            controller.searchTextTypedEvent(new SearchTextTypedEvent("", this));
+        });
+        waitForFxEvents();
+
+        Platform.runLater(() -> {
+            artistsProperty.add(of("Abel"));
+            artistsProperty.add(of("Abba"));
+            artistsProperty.add(of("Beatles"));
+        });
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+
+        // Filter to a single match.
+        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("Abe", this)));
+        waitForFxEvents();
+        assertThat(artistsListView.getItems()).hasSize(1);
+
+        // Clear the query — emulates MainController publishing "" for length < 3 or empty input.
+        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("", this)));
+        waitForFxEvents();
+
+        assertThat(artistsListView.getItems()).hasSize(3);
+        assertThat(artistsListView.getSelectionModel().getSelectedItem()).isNotNull();
+        assertThat(artistsListView.getSelectionModel().getSelectedItem()).isSameAs(artistsListView.getItems().get(0));
     }
 }
 

--- a/src/integrationTest/java/net/transgressoft/musicott/view/EditControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/EditControllerIT.java
@@ -23,9 +23,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
-import org.testfx.util.WaitForAsyncUtils;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -82,6 +84,32 @@ class EditControllerIT {
         verify(applicationEventPublisher).publishEvent(captor.capture());
         assertThat(captor.getValue().invalidAudioItems).hasSize(1);
         assertThat(captor.getValue().invalidAudioItems.get(0)).isEqualTo(mockItem);
+    }
+
+    @Test
+    @DisplayName("commonString returns dash when entries differ and tolerates nulls without throwing")
+    void commonStringReturnsDashWhenEntriesDifferAndToleratesNulls() {
+        // Mixed: one null and one non-null — the legacy lambda invoked equalsIgnoreCase on the null,
+        // throwing NullPointerException and crashing the JavaFX Application Thread when Ctrl+I was
+        // pressed for a track whose getComments() returned null.
+        assertThat((String) ReflectionTestUtils.invokeMethod(editController, "commonString",
+                Arrays.asList(null, "hello"))).isEqualTo("-");
+        assertThat((String) ReflectionTestUtils.invokeMethod(editController, "commonString",
+                Arrays.asList("hello", null))).isEqualTo("-");
+
+        // All-null and empty cases collapse to empty string (no NPE, no spurious dash).
+        assertThat((String) ReflectionTestUtils.invokeMethod(editController, "commonString",
+                Arrays.asList(null, null))).isEmpty();
+        assertThat((String) ReflectionTestUtils.invokeMethod(editController, "commonString",
+                Collections.<String>emptyList())).isEmpty();
+
+        // Differing non-null values still produce the dash.
+        assertThat((String) ReflectionTestUtils.invokeMethod(editController, "commonString",
+                List.of("hello", "world"))).isEqualTo("-");
+
+        // All-equal (case-insensitive) returns the first value, preserving prior behaviour.
+        assertThat((String) ReflectionTestUtils.invokeMethod(editController, "commonString",
+                List.of("Hello", "hello", "HELLO"))).isEqualTo("Hello");
     }
 
     @Test

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlayQueueControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlayQueueControllerIT.java
@@ -1,20 +1,26 @@
 package net.transgressoft.musicott.view;
 
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.musicott.services.PlayerService;
 import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
 
+import javafx.application.Platform;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ToggleButton;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
@@ -40,12 +46,14 @@ class PlayQueueControllerIT {
 
     PlayQueueController controller;
 
+    ObservableList<TrackQueueRow> historyQueue;
+
     @Start
     void start(Stage stage) throws Exception {
         playerService = mock(PlayerService.class);
         audioLibrary = mock(ObservableAudioLibrary.class);
         ObservableList<TrackQueueRow> playQueue = FXCollections.observableArrayList();
-        ObservableList<TrackQueueRow> historyQueue = FXCollections.observableArrayList();
+        historyQueue = FXCollections.observableArrayList();
         when(playerService.getPlayQueueList()).thenReturn(playQueue);
         when(playerService.getHistoryQueueList()).thenReturn(historyQueue);
 
@@ -84,5 +92,48 @@ class PlayQueueControllerIT {
         assertThat(titleLabel.getText()).isEqualTo("Recently played");
         ToggleButton historyButton = fxRobot.lookup("#historyQueueButton").queryAs(ToggleButton.class);
         assertThat(historyButton.isSelected()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PlayQueueController registers a delete handler on rows added to historyQueueList")
+    void registersDeleteHandlerOnRowsAddedToHistoryQueueList() {
+        // Option B: verify via reflection that the delete-button action handler is set after the
+        // listener fires (change.next() must be called for getAddedSubList() to be populated).
+        // Option A (robot.lookup("#deleteButton-white")) is skipped because the button starts
+        // invisible (visible only on mouse hover) and headless Monocle does not synthesize hover,
+        // making scene lookup unreliable in CI.
+        ObservableAudioItem item = mock(ObservableAudioItem.class);
+        when(item.getTitleProperty()).thenReturn(new SimpleStringProperty("Test Track"));
+        var artist = mock(net.transgressoft.commons.music.audio.Artist.class);
+        when(artist.getName()).thenReturn("Test Artist");
+        when(item.getArtistProperty()).thenReturn(new SimpleObjectProperty<>(artist));
+        var album = mock(net.transgressoft.commons.music.audio.Album.class);
+        when(album.getName()).thenReturn("Test Album");
+        when(item.getAlbumProperty()).thenReturn(new SimpleObjectProperty<>(album));
+
+        // TrackQueueRow extends GridPane and must be created on the FX thread.
+        TrackQueueRow[] rowHolder = new TrackQueueRow[1];
+        Platform.runLater(() -> {
+            rowHolder[0] = new TrackQueueRow(item);
+            historyQueue.add(rowHolder[0]);
+        });
+        waitForFxEvents();
+
+        TrackQueueRow row = rowHolder[0];
+        assertThat(historyQueue).containsExactly(row);
+
+        // The historyQueueList listener (now wrapped in while (change.next())) must have called
+        // TrackQueueRow.setOnDeleteButtonClickedHandler, which sets a non-null action on the button.
+        Button deleteButton = (Button) ReflectionTestUtils.getField(row, "deleteTrackQueueRowButton");
+        assertThat(deleteButton).isNotNull();
+        assertThat(deleteButton.getOnAction())
+                .as("delete handler registered by historyQueueList listener")
+                .isNotNull();
+
+        // Fire the action directly to prove the handler removes the row from the list.
+        Platform.runLater(() -> deleteButton.getOnAction().handle(null));
+        waitForFxEvents();
+
+        assertThat(historyQueue).isEmpty();
     }
 }

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlayQueueControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlayQueueControllerIT.java
@@ -110,6 +110,7 @@ class PlayQueueControllerIT {
         var album = mock(net.transgressoft.commons.music.audio.Album.class);
         when(album.getName()).thenReturn("Test Album");
         when(item.getAlbumProperty()).thenReturn(new SimpleObjectProperty<>(album));
+        when(item.getCoverImageProperty()).thenReturn(new SimpleObjectProperty<>(java.util.Optional.empty()));
 
         // TrackQueueRow extends GridPane and must be created on the FX thread.
         TrackQueueRow[] rowHolder = new TrackQueueRow[1];

--- a/src/integrationTest/java/net/transgressoft/musicott/view/SearchFlowIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/SearchFlowIT.java
@@ -1,0 +1,330 @@
+package net.transgressoft.musicott.view;
+
+import javafx.application.Platform;
+import javafx.beans.property.*;
+import javafx.collections.*;
+import javafx.scene.Node;
+import javafx.scene.control.ListView;
+import javafx.scene.control.SplitPane;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import net.transgressoft.lirp.event.LirpEventPublisher;
+import net.transgressoft.commons.fx.music.audio.ObservableArtistCatalog;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.audio.Album;
+import net.transgressoft.commons.music.audio.AlbumSet;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.audio.Label;
+import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.table.ArtistAlbumListRow;
+import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
+import net.transgressoft.musicott.view.custom.table.SimpleAudioItemTableView;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.nio.file.Path;
+
+import static net.transgressoft.commons.music.audio.ImmutableArtist.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration test verifying that the global search field triggers live filtering across all
+ * subscriber views — the audio item table ({@link FullAudioItemTableView}) and the artist list
+ * ({@link ArtistViewController}) — and that clearing the query restores each view to its
+ * full unfiltered state.
+ *
+ * <p>Events are dispatched through the real Spring {@link ApplicationEventPublisher} so the
+ * test exercises the production wire: the multicaster, the {@code @EventListener} method
+ * resolution, and the bean scope of each subscriber. Direct method invocation would mask
+ * scope bugs (e.g. a prototype-scoped table view never registering with the multicaster).
+ */
+@JavaFxSpringTest(classes = SearchFlowITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("Search flow")
+class SearchFlowIT extends ApplicationTestBase<SplitPane> {
+
+    @Autowired
+    SetProperty<Artist> artistsProperty;
+
+    @Autowired
+    FxControllerAndView<ArtistViewController, SplitPane> artistViewAndController;
+
+    @Autowired
+    FullAudioItemTableView audioItemTableView;
+
+    @Autowired
+    ObservableAudioLibrary audioRepository;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    protected SplitPane javaFxComponent() {
+        return artistViewAndController.getView().get();
+    }
+
+    @Override
+    @BeforeEach
+    protected void beforeEach() {
+        super.beforeEach();
+    }
+
+    @Test
+    @DisplayName("AudioItemTableViewBase filters its predicate when SearchTextTypedEvent fires with a non-empty query")
+    void filtersAudioItemTablePredicateOnNonEmptyQuery(FxRobot fxRobot) {
+        ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
+                mockAudioItem("Apple", "Artist A", "Album A"),
+                mockAudioItem("Banana", "Artist B", "Album B"),
+                mockAudioItem("Cherry", "Artist C", "Album C")
+        );
+
+        Platform.runLater(() -> audioItemTableView.setSourceItems(items));
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(3);
+
+        // Publish through the real Spring multicaster so the test catches scope/registration bugs
+        // that would silently drop the event before reaching the table's @EventListener.
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("App", this)));
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(1);
+        assertThat(audioItemTableView.getItems().get(0).getTitle()).isEqualTo("Apple");
+    }
+
+    @Test
+    @DisplayName("ArtistViewController filters its predicate when SearchTextTypedEvent fires with a non-empty query")
+    void filtersArtistListPredicateOnNonEmptyQuery(FxRobot fxRobot) {
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            // Reset predicate to unfiltered state first
+            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
+        });
+        waitForFxEvents();
+
+        Platform.runLater(() -> {
+            artistsProperty.add(of("Aphex Twin"));
+            artistsProperty.add(of("Bonobo"));
+            artistsProperty.add(of("Caribou"));
+        });
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        assertThat(artistsListView.getItems()).hasSize(3);
+
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Aph", this)));
+        waitForFxEvents();
+
+        assertThat(artistsListView.getItems()).hasSize(1);
+        assertThat(artistsListView.getItems().get(0).getName()).isEqualTo("Aphex Twin");
+    }
+
+    @Test
+    @DisplayName("All three views restore to full state when SearchTextTypedEvent fires with empty query")
+    void restoresAllViewsToFullStateOnEmptyQuery(FxRobot fxRobot) {
+        // --- Seed audio table ---
+        ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
+                mockAudioItem("Apple", "Artist A", "Album A"),
+                mockAudioItem("Banana", "Artist B", "Album B"),
+                mockAudioItem("Cherry", "Artist C", "Album C")
+        );
+        Platform.runLater(() -> {
+            audioItemTableView.setSourceItems(items);
+            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("App", this));
+        });
+        waitForFxEvents();
+        assertThat(audioItemTableView.getItems()).hasSize(1);
+
+        // --- Seed artist list ---
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
+        });
+        waitForFxEvents();
+
+        Platform.runLater(() -> {
+            artistsProperty.add(of("Aphex Twin"));
+            artistsProperty.add(of("Bonobo"));
+            artistsProperty.add(of("Caribou"));
+        });
+        waitForFxEvents();
+
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Aph", this)));
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        assertThat(artistsListView.getItems()).hasSize(1);
+
+        // --- Clear the query — a single SearchTextTypedEvent("") on the bus reaches both subscribers. ---
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this)));
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(3);
+        assertThat(artistsListView.getItems()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("ArtistViewController matches artists by track title, album, and label when the artist catalog is loaded")
+    @SuppressWarnings("unchecked")
+    void matchesArtistsByTrackTitleAlbumAndLabelWhenArtistCatalogIsLoaded(FxRobot fxRobot) {
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
+        });
+        waitForFxEvents();
+
+        var aphexTwin = of("Aphex Twin");
+        var bonobo = of("Bonobo");
+
+        // Add artists FIRST without any catalog stubbed so the auto-select path triggers
+        // selectedArtistListener with an empty catalog and skips ArtistAlbumListRow construction
+        // (which would otherwise fail against the bare AlbumSet/ObservableArtistCatalog mocks below).
+        Platform.runLater(() -> {
+            artistsProperty.add(aphexTwin);
+            artistsProperty.add(bonobo);
+        });
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        assertThat(artistsListView.getItems()).hasSize(2);
+
+        // Now wire a populated catalog for aphexTwin so filterArtistsByQuery's catalog-walk branch
+        // exercises the loaded path. selectedArtistListener won't refire because the selected
+        // artist hasn't changed identity.
+        var labelMock = mock(Label.class);
+        when(labelMock.getName()).thenReturn("Warp Records");
+        var album = mock(Album.class);
+        when(album.getName()).thenReturn("Selected Ambient Works 85-92");
+        when(album.getAlbumArtist()).thenReturn(aphexTwin);
+        when(album.getLabel()).thenReturn(labelMock);
+        var item = mock(ObservableAudioItem.class);
+        when(item.getTitle()).thenReturn("Xtal");
+        when(item.getArtist()).thenReturn(aphexTwin);
+        when(item.getAlbum()).thenReturn(album);
+
+        // AlbumSet extends List; stream() default impl returns null on a Mockito mock, so stub it
+        // with thenAnswer so the predicate can re-iterate across multiple search calls.
+        var albumSet = mock(AlbumSet.class);
+        when(albumSet.stream()).thenAnswer(inv -> java.util.stream.Stream.of(item));
+        var catalog = mock(ObservableArtistCatalog.class);
+        when(catalog.getAlbums()).thenReturn(java.util.Set.of(albumSet));
+        // doReturn instead of when().thenReturn() because the production signature is
+        // Optional<out ObservableArtistCatalog> (Kotlin covariant) which the typed thenReturn rejects.
+        doReturn(java.util.Optional.of(catalog)).when(audioRepository).getArtistCatalog(aphexTwin);
+        doReturn(java.util.Optional.empty()).when(audioRepository).getArtistCatalog(bonobo);
+
+        // Title-only query: matches Aphex Twin via track title; Bonobo has no matching catalog item.
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Xtal", this)));
+        waitForFxEvents();
+        assertThat(artistsListView.getItems()).hasSize(1);
+        assertThat(artistsListView.getItems().get(0).getName()).isEqualTo("Aphex Twin");
+
+        // Label-only query: confirms the new label-match branch in artistMatchesQuery.
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Warp", this)));
+        waitForFxEvents();
+        assertThat(artistsListView.getItems()).hasSize(1);
+        assertThat(artistsListView.getItems().get(0).getName()).isEqualTo("Aphex Twin");
+
+        // Album-only query.
+        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Ambient Works", this)));
+        waitForFxEvents();
+        assertThat(artistsListView.getItems()).hasSize(1);
+        assertThat(artistsListView.getItems().get(0).getName()).isEqualTo("Aphex Twin");
+
+        // Reset stubs back to empty so other tests in the class don't inherit a populated catalog
+        // (Spring context is singleton-per-class — mock state leaks otherwise).
+        doReturn(java.util.Optional.empty()).when(audioRepository).getArtistCatalog(aphexTwin);
+        doReturn(java.util.Optional.empty()).when(audioRepository).getArtistCatalog(bonobo);
+        Platform.runLater(() -> {
+            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
+            artistsProperty.clear();
+        });
+        waitForFxEvents();
+    }
+
+    /**
+     * Creates a mock {@link ObservableAudioItem} suitable for audio table predicate testing.
+     * Stubs only the fields examined by {@code AudioItemTableViewBase.audioItemContainsQuery}.
+     */
+    private ObservableAudioItem mockAudioItem(String title, String artistName, String albumName) {
+        var item = mock(ObservableAudioItem.class);
+        when(item.getTitle()).thenReturn(title);
+
+        var artist = mock(Artist.class);
+        when(artist.getName()).thenReturn(artistName);
+        when(item.getArtist()).thenReturn(artist);
+
+        var albumArtist = mock(Artist.class);
+        when(albumArtist.getName()).thenReturn(artistName);
+
+        var album = mock(Album.class);
+        when(album.getName()).thenReturn(albumName);
+        when(album.getAlbumArtist()).thenReturn(albumArtist);
+        when(item.getAlbum()).thenReturn(album);
+
+        // Stub path and cover for any defensive null checks in other parts of the table internals
+        when(item.getPath()).thenReturn(Path.of("/mock/path/" + title + ".mp3"));
+
+        return item;
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                ArtistViewController.class,
+                SimpleAudioItemTableView.class,
+                FullAudioItemTableView.class,
+                ArtistAlbumListRow.class
+        })
+})
+class SearchFlowITConfiguration {
+
+    @Bean
+    public SetProperty<Artist> artistsProperty() {
+        return new SimpleSetProperty<>(FXCollections.observableSet());
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public ObservableAudioLibrary audioRepository(ReadOnlySetProperty<Artist> artistsProperty) {
+        var repository = mock(ObservableAudioLibrary.class);
+        when(repository.getArtistsProperty()).thenReturn(artistsProperty);
+        when(repository.getArtistCatalogPublisher()).thenReturn(mock(LirpEventPublisher.class));
+        return repository;
+    }
+
+    // No @Bean for ApplicationEventPublisher — the test relies on the real Spring multicaster so
+    // the @EventListener delivery path is fully exercised. ApplicationContext itself implements
+    // ApplicationEventPublisher and is autowirable.
+
+    // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,
+    // which would call Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/PrimaryStageInitializer.java
+++ b/src/main/java/net/transgressoft/musicott/PrimaryStageInitializer.java
@@ -2,6 +2,7 @@ package net.transgressoft.musicott;
 
 import net.transgressoft.musicott.events.StageReadyEvent;
 import net.transgressoft.musicott.events.StopApplicationEvent;
+import net.transgressoft.musicott.view.EditController;
 import net.transgressoft.musicott.view.ErrorDialogController;
 import net.transgressoft.musicott.view.MainController;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
@@ -69,6 +70,7 @@ public class PrimaryStageInitializer implements ApplicationListener<StageReadyEv
      */
     private void prewarmAuxiliaryViews() {
         fxWeaver.loadView(ErrorDialogController.class);
+        fxWeaver.loadView(EditController.class);
     }
 
     /**

--- a/src/main/java/net/transgressoft/musicott/services/PlayerService.java
+++ b/src/main/java/net/transgressoft/musicott/services/PlayerService.java
@@ -180,11 +180,11 @@ public class PlayerService {
         } else {
             currentTrack.ifPresent(track -> {
                 TrackQueueRow row = new TrackQueueRow(track);
-                historyQueueList.add(0, row);
+                historyQueueList.add(row);
                 enforceHistoryCap();
                 publishHistoryUpdatedEvent();
             });
-            TrackQueueRow nextRow = playQueueList.remove(0);
+            TrackQueueRow nextRow = playQueueList.remove(playQueueList.size() - 1);
             publishQueueUpdatedEvent();
             play(nextRow.getTrack());
         }
@@ -198,10 +198,10 @@ public class PlayerService {
                     playQueueList.remove(row);
                     publishQueueUpdatedEvent();
                 });
-                playQueueList.add(0, row);
+                playQueueList.add(row);
                 publishQueueUpdatedEvent();
             });
-            TrackQueueRow previousRow = historyQueueList.remove(0);
+            TrackQueueRow previousRow = historyQueueList.remove(historyQueueList.size() - 1);
             publishHistoryUpdatedEvent();
             setPlayer(previousRow.getTrack());
         } else {
@@ -218,7 +218,7 @@ public class PlayerService {
             playQueueList.clear();
             playingRandom = false;
         }
-        audioItems.stream()
+        var newRows = audioItems.stream()
                 .filter(JavaFxPlayer.Companion::isPlayable)
                 .map(item -> {
                     TrackQueueRow row = new TrackQueueRow(item);
@@ -228,19 +228,31 @@ public class PlayerService {
                     });
                     return row;
                 })
-                .forEach(playQueueList::add);
-        publishQueueUpdatedEvent();
+                .toList();
+        // Inverted storage: index size-1 is next-up, index 0 is farthest-out. The first input is
+        // next-up (bottom of the popover), the last input is farthest (top). Reverse the new rows
+        // and addAll at index 0 in one call, avoiding O(n²) repeated shifts and N change events.
+        if (!newRows.isEmpty()) {
+            var reversed = new java.util.ArrayList<>(newRows);
+            java.util.Collections.reverse(reversed);
+            playQueueList.addAll(0, reversed);
+            publishQueueUpdatedEvent();
+        }
     }
 
     public void playFromQueue(TrackQueueRow trackQueueRow) {
         ObservableAudioItem track = trackQueueRow.getTrack();
-        setPlayer(track);
-        TrackQueueRow historyRow = new TrackQueueRow(track);
-        historyQueueList.add(0, historyRow);
-        enforceHistoryCap();
-        publishHistoryUpdatedEvent();
+        // Append the previous current track to history (the one being LEFT). The selected
+        // track is what's about to start playing; it will be appended to history when it
+        // finishes naturally via next() — appending it here would duplicate it.
+        currentTrack.ifPresent(prev -> {
+            historyQueueList.add(new TrackQueueRow(prev));
+            enforceHistoryCap();
+            publishHistoryUpdatedEvent();
+        });
         playQueueList.remove(trackQueueRow);
         publishQueueUpdatedEvent();
+        setPlayer(track);
         logger.debug("Play from queue selected. Queue size {}, history queue size {}", playQueueList.size(), historyQueueList.size());
     }
 
@@ -281,7 +293,8 @@ public class PlayerService {
 
     private void enforceHistoryCap() {
         if (historyQueueList.size() > HISTORY_CAP) {
-            historyQueueList.remove(HISTORY_CAP, historyQueueList.size());
+            int overflow = historyQueueList.size() - HISTORY_CAP;
+            historyQueueList.remove(0, overflow);
         }
     }
 

--- a/src/main/java/net/transgressoft/musicott/services/PlayerService.java
+++ b/src/main/java/net/transgressoft/musicott/services/PlayerService.java
@@ -175,15 +175,15 @@ public class PlayerService {
     }
 
     public void next() {
+        currentTrack.ifPresent(track -> {
+            TrackQueueRow row = new TrackQueueRow(track);
+            historyQueueList.add(row);
+            enforceHistoryCap();
+            publishHistoryUpdatedEvent();
+        });
         if (playQueueList.isEmpty()) {
             stop();
         } else {
-            currentTrack.ifPresent(track -> {
-                TrackQueueRow row = new TrackQueueRow(track);
-                historyQueueList.add(row);
-                enforceHistoryCap();
-                publishHistoryUpdatedEvent();
-            });
             TrackQueueRow nextRow = playQueueList.remove(playQueueList.size() - 1);
             publishQueueUpdatedEvent();
             play(nextRow.getTrack());

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -55,8 +55,11 @@ public class ArtistViewController {
     private Button artistRandomButton;
 
     private ObservableMap<AlbumSet<ObservableAudioItem>, ArtistAlbumListRow> albumListRowMap;
+    private ObservableList<ArtistAlbumListRow> albumRowsBackingList;
+    private FilteredList<ArtistAlbumListRow> filteredAlbumRows;
     private ObjectProperty<Optional<Artist>> selectedArtistProperty;
     private FilteredList<Artist> filteredArtists;
+    private String currentSearchQuery = "";
 
     @Autowired
     public ArtistViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext) {
@@ -77,6 +80,11 @@ public class ArtistViewController {
 
         albumListRowMap = FXCollections.observableMap(new TreeMap<>());
         albumListRowMap.addListener(this::artistAlbumListRowMapChangeListener);
+        // Backing list mirrors albumListRowMap insertions/removals; albumsListView shows a filtered
+        // view so the active search query can hide non-matching album rows entirely.
+        albumRowsBackingList = FXCollections.observableArrayList();
+        filteredAlbumRows = new FilteredList<>(albumRowsBackingList);
+        albumsListView.setItems(filteredAlbumRows);
 
         // TODO replace listener from artistsListView to selectedArtistProperty ?
         artistsListView.getSelectionModel().selectedItemProperty().addListener(this::selectedArtistListener);
@@ -129,9 +137,13 @@ public class ArtistViewController {
     private void artistAlbumListRowMapChangeListener(MapChangeListener.Change<? extends AlbumSet<ObservableAudioItem>, ? extends ArtistAlbumListRow> change) {
         Platform.runLater(() -> {
             if (change.wasAdded()) {
-                albumsListView.getItems().add(change.getValueAdded());
+                ArtistAlbumListRow added = change.getValueAdded();
+                // Newly-loaded rows must inherit the active query so reselecting an artist while a
+                // search is active doesn't surface unfiltered album content for a moment.
+                added.filterTracksByQuery(currentSearchQuery);
+                albumRowsBackingList.add(added);
             } else if (change.wasRemoved()) {
-                albumsListView.getItems().remove(change.getValueRemoved());
+                albumRowsBackingList.remove(change.getValueRemoved());
             }
             totalTracksLabel.setText(getTotalArtistTracksString());
             totalAlbumsLabel.setText(getAlbumString());
@@ -246,38 +258,67 @@ public class ArtistViewController {
 
     @EventListener
     public void searchTextTypedEvent(SearchTextTypedEvent event) {
-        filteredArtists.setPredicate(filterArtistsByQuery(event.searchText));
+        currentSearchQuery = event.searchText == null ? "" : event.searchText;
+        filteredArtists.setPredicate(filterArtistsByQuery(currentSearchQuery));
+        // Propagate to currently-loaded album rows: hide rows with no matching tracks and let each
+        // visible row narrow its embedded SimpleAudioItemTableView to the matching tracks.
+        albumRowsBackingList.forEach(row -> row.filterTracksByQuery(currentSearchQuery));
+        filteredAlbumRows.setPredicate(albumRowMatchesQuery(currentSearchQuery));
     }
 
     private Predicate<Artist> filterArtistsByQuery(String query) {
         if (query == null || query.isEmpty()) {
             return artist -> true;
         }
-        // When the album map is not yet populated, fall back to matching on artist name alone.
-        // This keeps the predicate correct even before the user selects an artist for the first time.
-        if (albumListRowMap.isEmpty()) {
-            return artist -> artist.getName().toLowerCase().contains(query.toLowerCase());
+        String q = query.toLowerCase();
+        // Walk the artist's own catalog instead of albumListRowMap (which only holds the currently
+        // selected artist's albums). Without this, queries by title/album/comments/label only ever
+        // match against the selected artist, so other artists with track-level matches stay hidden.
+        return artist -> {
+            if (artist.getName().toLowerCase().contains(q)) {
+                return true;
+            }
+            return audioRepository.getArtistCatalog(artist).stream()
+                    .flatMap(catalog -> catalog.getAlbums().stream())
+                    .flatMap(Collection::stream)
+                    .anyMatch(audioItem -> artistMatchesQuery(audioItem, artist, q));
+        };
+    }
+
+    private Predicate<ArtistAlbumListRow> albumRowMatchesQuery(String query) {
+        if (query == null || query.isEmpty()) {
+            return row -> true;
         }
-        return artist ->
-                albumListRowMap.keySet().stream()
-                        .flatMap(Collection::stream)
-                        .anyMatch(audioItem -> artistMatchesQuery(audioItem, artist, query.toLowerCase()));
+        return row -> row.hasTracksMatching(query);
     }
 
     private boolean artistMatchesQuery(ObservableAudioItem audioItem, Artist artist, String query) {
         if (query == null || query.isEmpty())
             return true;
 
-        var matchesName = artist.getName().toLowerCase().contains(query.toLowerCase());
-        var matchesArtist = audioItem.getArtist().equals(artist);
-        var matchesArtistName = audioItem.getArtist().getName().toLowerCase().contains(query);
-        var matchesAlbumArtist = audioItem.getAlbum().getAlbumArtist().getName().toLowerCase().contains(query);
+        // Guard each metadata access — partial catalogs can have null artist/album/album-artist
+        // or null name fields; one malformed track shouldn't NPE the entire artist filter.
+        var matchesName = artist.getName() != null && artist.getName().toLowerCase().contains(query);
+        var itemArtist = audioItem.getArtist();
+        var matchesArtist = itemArtist != null && itemArtist.equals(artist);
+        var matchesTitle = audioItem.getTitle() != null && audioItem.getTitle().toLowerCase().contains(query);
+        var matchesArtistName = itemArtist != null && itemArtist.getName() != null
+                && itemArtist.getName().toLowerCase().contains(query);
+        var album = audioItem.getAlbum();
+        var matchesAlbumArtist = album != null && album.getAlbumArtist() != null
+                && album.getAlbumArtist().getName() != null
+                && album.getAlbumArtist().getName().toLowerCase().contains(query);
         var matchesComments = audioItem.getComments() != null && audioItem.getComments().toLowerCase().contains(query);
-        var matchesAlbumName = audioItem.getAlbum().getName().toLowerCase().contains(query);
+        var matchesAlbumName = album != null && album.getName() != null
+                && album.getName().toLowerCase().contains(query);
+        var matchesLabel = album != null && album.getLabel() != null
+                && album.getLabel().getName() != null
+                && album.getLabel().getName().toLowerCase().contains(query);
 
         var containsMatchedTrack =
                 matchesArtist &&
-                (matchesName || matchesArtistName || matchesAlbumArtist || matchesComments || matchesAlbumName);
+                (matchesName || matchesTitle || matchesArtistName || matchesAlbumArtist
+                        || matchesComments || matchesAlbumName || matchesLabel);
 
         return matchesName || containsMatchedTrack;
     }

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -112,9 +112,16 @@ public class ArtistViewController {
     }
 
     private void artistsListener(ListChangeListener.Change<? extends Artist> change) {
-        if (selectedArtistProperty.get().isEmpty() && !change.getList().isEmpty()) {
-            artistsListView.getSelectionModel().select(0);
-            artistsListView.getFocusModel().focus(0);
+        if (!change.getList().isEmpty()) {
+            // Defer selection until the SortedList (registered after this listener) has processed
+            // the same change. Only auto-select when nothing is selected yet — preserve the user's
+            // current selection across catalog updates that mutate the artist list.
+            Platform.runLater(() -> {
+                if (artistsListView.getSelectionModel().getSelectedItem() == null) {
+                    artistsListView.getSelectionModel().select(0);
+                    artistsListView.getFocusModel().focus(0);
+                }
+            });
         }
     }
 
@@ -243,6 +250,14 @@ public class ArtistViewController {
     }
 
     private Predicate<Artist> filterArtistsByQuery(String query) {
+        if (query == null || query.isEmpty()) {
+            return artist -> true;
+        }
+        // When the album map is not yet populated, fall back to matching on artist name alone.
+        // This keeps the predicate correct even before the user selects an artist for the first time.
+        if (albumListRowMap.isEmpty()) {
+            return artist -> artist.getName().toLowerCase().contains(query.toLowerCase());
+        }
         return artist ->
                 albumListRowMap.keySet().stream()
                         .flatMap(Collection::stream)

--- a/src/main/java/net/transgressoft/musicott/view/EditController.java
+++ b/src/main/java/net/transgressoft/musicott/view/EditController.java
@@ -14,6 +14,7 @@ import com.neovisionaries.i18n.CountryCode;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.CacheHint;
+import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -112,6 +114,7 @@ public class EditController {
         stage.setTitle("Edit");
         stage.setResizable(false);
         stage.initModality(Modality.APPLICATION_MODAL);
+        stage.getIcons().add(ApplicationImage.APP_ICON.get());
         stage.setOnCloseRequest(e -> close());
         stage.setOnShown(e -> {
             if (stage.getScene() != null) {
@@ -285,15 +288,32 @@ public class EditController {
                 multipleEditionConfirmationAlert.showAndWait().ifPresent(result -> {
                     if (result.getButtonData().isDefaultButton()) {
                         updateFields();
-                        stage.showAndWait();
+                        showStage();
                     } else {
                         close();
                     }
                 });
             } else {
                 updateFields();
-                stage.showAndWait();
+                showStage();
             }
+        }
+    }
+
+    /**
+     * Ensures the modal dialog stage owns a Scene wrapping the FXML root before showing it.
+     * Without this attachment {@code showAndWait} opens an empty black window: the controller's
+     * stage is constructed in {@link #initialize()} but the FXML root has no implicit scene
+     * since the editor is loaded standalone (not embedded by another controller).
+     */
+    private void showStage() {
+        attachSceneIfNeeded();
+        stage.showAndWait();
+    }
+
+    void attachSceneIfNeeded() {
+        if (stage.getScene() == null && rootPane.getScene() == null) {
+            stage.setScene(new Scene(rootPane));
         }
     }
 
@@ -330,12 +350,16 @@ public class EditController {
     }
 
     private String commonString(List<String> list) {
-        String commonString;
-        if (list.stream().allMatch(st -> st.equalsIgnoreCase(list.get(0))))
-            commonString = list.get(0);
-        else
-            commonString = "-";
-        return commonString;
+        if (list.isEmpty()) {
+            return "";
+        }
+        String first = list.get(0);
+        for (String value : list) {
+            if (!Objects.equals(first, value) && !(first != null && value != null && first.equalsIgnoreCase(value))) {
+                return "-";
+            }
+        }
+        return first == null ? "" : first;
     }
 
     private String commonTitle() {
@@ -374,19 +398,30 @@ public class EditController {
     }
 
     private String commonTrackNumber() {
-        return commonString(audioItemSelection.stream().map(t -> String.valueOf(t.getTrackNumber())).collect(toList()));
+        return commonString(audioItemSelection.stream().map(t -> formatPositiveShort(t.getTrackNumber())).collect(toList()));
     }
 
     private String commonDiscNumber() {
-        return commonString(audioItemSelection.stream().map(t -> String.valueOf(t.getDiscNumber())).collect(toList()));
+        return commonString(audioItemSelection.stream().map(t -> formatPositiveShort(t.getDiscNumber())).collect(toList()));
     }
 
     private String commonYear() {
-        return commonString(audioItemSelection.stream().map(t -> String.valueOf(t.getAlbum().getYear())).collect(toList()));
+        return commonString(audioItemSelection.stream().map(t -> formatPositiveShort(t.getAlbum().getYear())).collect(toList()));
     }
 
     private String commonBpm() {
-        return commonString(audioItemSelection.stream().map(t -> String.valueOf(t.getBpm())).collect(toList()));
+        return commonString(audioItemSelection.stream()
+                .map(t -> {
+                    Float bpm = t.getBpm();
+                    return bpm == null || bpm <= 0f ? null : bpm.toString();
+                }).collect(toList()));
+    }
+
+    // Track/disc/year are nullable Short on the music-commons API; when unset the getter returns
+    // null. Treat null and any non-positive value as "unset" so the field renders empty instead
+    // of the literal "null" string (which is what String.valueOf(null) would have produced).
+    private String formatPositiveShort(Short value) {
+        return value == null || value <= 0 ? null : value.toString();
     }
 
     private Optional<byte[]> commonCoverImage() {
@@ -424,7 +459,11 @@ public class EditController {
     }
 
     private String getEditionFieldResult(TextInputControl textField) {
-        return textField.getText().equals("-") ? null : textField.getText();
+        // commonString() returns "" when every selected track has the field unset; treat empty
+        // and the multi-value dash sentinel both as null so a no-op save doesn't overwrite
+        // unset metadata with empty strings.
+        String value = textField.getText();
+        return value == null || value.isEmpty() || value.equals("-") ? null : value;
     }
 
     private void close() {

--- a/src/main/java/net/transgressoft/musicott/view/PlayQueueController.java
+++ b/src/main/java/net/transgressoft/musicott/view/PlayQueueController.java
@@ -74,6 +74,7 @@ public class PlayQueueController {
 
         playQueueList.addListener((ListChangeListener<TrackQueueRow>) change -> {
             while (change.next()) {
+                change.getRemoved().forEach(TrackQueueRow::dispose);
                 change.getAddedSubList().forEach(trackQueueRow -> trackQueueRow.setOnDeleteButtonClickedHandler(event -> {
                     playQueueList.remove(trackQueueRow);
                     LOG.debug("Removing track from play queue by clicking the button. Queue size: {}", playQueueList.size());
@@ -83,6 +84,7 @@ public class PlayQueueController {
 
         historyQueueList.addListener((ListChangeListener<TrackQueueRow>) change -> {
             while (change.next()) {
+                change.getRemoved().forEach(TrackQueueRow::dispose);
                 change.getAddedSubList().forEach(trackQueueRow -> trackQueueRow.setOnDeleteButtonClickedHandler(event -> {
                     historyQueueList.remove(trackQueueRow);
                     LOG.debug("Removing track from history queue by clicking the button. History queue size: {}", historyQueueList.size());

--- a/src/main/java/net/transgressoft/musicott/view/PlayQueueController.java
+++ b/src/main/java/net/transgressoft/musicott/view/PlayQueueController.java
@@ -76,11 +76,14 @@ public class PlayQueueController {
             }
         });
 
-        historyQueueList.addListener((ListChangeListener<TrackQueueRow>) change ->
+        historyQueueList.addListener((ListChangeListener<TrackQueueRow>) change -> {
+            while (change.next()) {
                 change.getAddedSubList().forEach(trackQueueRow -> trackQueueRow.setOnDeleteButtonClickedHandler(event -> {
                     historyQueueList.remove(trackQueueRow);
                     LOG.debug("Removing track from history queue by clicking the button. History queue size: {}", historyQueueList.size());
-                })));
+                }));
+            }
+        });
 
         historyQueueButton.setId("historyQueueButton");
         queuesListView.setCellFactory(_ -> new TrackQueueListCell(() -> historyQueueButton.isSelected()));

--- a/src/main/java/net/transgressoft/musicott/view/PlayQueueController.java
+++ b/src/main/java/net/transgressoft/musicott/view/PlayQueueController.java
@@ -7,6 +7,7 @@ import net.transgressoft.musicott.view.custom.table.AudioItemTableViewBase;
 import net.transgressoft.musicott.view.custom.table.TrackQueueListCell;
 import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
 
+import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -36,6 +37,10 @@ import java.util.Objects;
 public class PlayQueueController {
 
     private static final String DRAG_OVER_STYLE = "-fx-border-color: rgb(99, 255, 109); -fx-border-width: 2px;";
+    // TrackQueueRow renders a 42px cover next to two label rows, plus the cell's own padding.
+    // Used as the fixed cell size so the ListView's intrinsic prefHeight = items * cellSize and
+    // the bottom-aligning VBox can shrink it to fit content with empty space at the top.
+    private static final double TRACK_QUEUE_ROW_CELL_HEIGHT = 54.0;
 
     private final Logger LOG = LoggerFactory.getLogger(getClass().getName());
 
@@ -88,6 +93,17 @@ public class PlayQueueController {
         historyQueueButton.setId("historyQueueButton");
         queuesListView.setCellFactory(_ -> new TrackQueueListCell(() -> historyQueueButton.isSelected()));
         queuesListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+        // Fixed cell size + height bound to current items lets the bottom-aligning VBox in the FXML
+        // shrink the list to its content so the rows hug the bottom of the popover.
+        queuesListView.setFixedCellSize(TRACK_QUEUE_ROW_CELL_HEIGHT);
+        queuesListView.prefHeightProperty().bind(Bindings.createDoubleBinding(
+                () -> queuesListView.getItems() == null
+                        ? 0.0
+                        : queuesListView.getItems().size() * TRACK_QUEUE_ROW_CELL_HEIGHT,
+                queuesListView.itemsProperty(),
+                Bindings.size(playQueueList),
+                Bindings.size(historyQueueList)));
+        queuesListView.maxHeightProperty().bind(queuesListView.prefHeightProperty());
         queuesListView.setItems(playQueueList);
         queuesListView.setOnMouseClicked(event -> {
             if (event.getClickCount() == 2)

--- a/src/main/java/net/transgressoft/musicott/view/PlayerController.java
+++ b/src/main/java/net/transgressoft/musicott/view/PlayerController.java
@@ -202,9 +202,17 @@ public class PlayerController {
             StackPane.setMargin(playQueueLayout, new Insets(0, 0, bottomMargin, 0));
         };
 
+        // hidePlayQueue removes playQueueLayout from its parent, so sceneProperty fires every time
+        // the popover toggles. Detach old listeners on each transition to prevent stacking.
+        javafx.beans.value.ChangeListener<Number> resizeListener = (o, ov, nv) -> apply.run();
         playQueueLayout.sceneProperty().addListener((obs, oldScene, newScene) -> {
+            if (oldScene != null) {
+                oldScene.heightProperty().removeListener(resizeListener);
+                oldScene.widthProperty().removeListener(resizeListener);
+            }
             if (newScene != null) {
-                newScene.heightProperty().addListener((o, ov, nv) -> apply.run());
+                newScene.heightProperty().addListener(resizeListener);
+                newScene.widthProperty().addListener(resizeListener);
                 apply.run();
             }
         });

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -1,9 +1,11 @@
 package net.transgressoft.musicott.view.custom.table;
 
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
@@ -35,6 +37,7 @@ public class ArtistAlbumListRow extends HBox {
     private final AlbumSet<ObservableAudioItem> albumSet;
     private final ListProperty<ObservableAudioItem> selectedAudioItemsProperty;
     private final ObservableList<ObservableAudioItem> containedAudioItems;
+    private final FilteredList<ObservableAudioItem> filteredAudioItems;
     private final ListProperty<ObservableAudioItem> containedAudioItemsProperty;
     private final SimpleAudioItemTableView audioItemsTableView;
 
@@ -52,6 +55,7 @@ public class ArtistAlbumListRow extends HBox {
         this.audioItemsTableView = audioItemsTableView;
         containedAudioItems = FXCollections.observableArrayList(albumSet);
         containedAudioItems.sort(this::audioItemComparator);
+        filteredAudioItems = new FilteredList<>(containedAudioItems);
         containedAudioItemsProperty = new SimpleListProperty<>(this, "contained tracks");
         containedAudioItemsProperty.bind(new SimpleObjectProperty<>(containedAudioItems));
 
@@ -61,7 +65,7 @@ public class ArtistAlbumListRow extends HBox {
         setMinWidth(0);
         setPrefHeight(USE_COMPUTED_SIZE);
         getStylesheets().add(getClass().getResource(BASE_STYLE).toExternalForm());
-        audioItemsTableView.setItems(containedAudioItems);
+        audioItemsTableView.setItems(filteredAudioItems);
         audioItemsTableView.sort();
         setRelatedArtistsLabel();
         updateAlbumLabelLabel();
@@ -181,10 +185,64 @@ public class ArtistAlbumListRow extends HBox {
     private void buildSimpleTableView() {
         audioItemsTableView.trackNumberCol.setCellValueFactory(cellData -> listenAudioItemChangesAndSort(cellData.getValue()));
 
-        var rows = map(containedAudioItemsProperty.sizeProperty(), s -> s.intValue() * 1.06);
-        audioItemsTableView.prefHeightProperty().bind(audioItemsTableView.fixedCellSizeProperty().multiply(rows.getValue()));
+        // Bind the table height to the FILTERED row count so the row collapses (or expands)
+        // as the search query narrows the visible tracks instead of leaving empty space behind.
+        var rowCount = Bindings.size(filteredAudioItems);
+        audioItemsTableView.prefHeightProperty().bind(
+                audioItemsTableView.fixedCellSizeProperty().multiply(Bindings.createDoubleBinding(
+                        () -> rowCount.intValue() * 1.06,
+                        rowCount)));
         audioItemsTableView.minHeightProperty().bind(audioItemsTableView.prefHeightProperty());
         audioItemsTableView.maxHeightProperty().bind(audioItemsTableView.prefHeightProperty());
+    }
+
+    /**
+     * Applies the global search query to the embedded track table. An empty or null query clears
+     * the filter; otherwise only tracks whose title, artist, album, album-artist, or comments
+     * contain the query (case-insensitive) remain visible.
+     */
+    public void filterTracksByQuery(String query) {
+        if (query == null || query.isEmpty()) {
+            filteredAudioItems.setPredicate(null);
+        } else {
+            String q = query.toLowerCase();
+            filteredAudioItems.setPredicate(item -> trackMatchesQuery(item, q));
+        }
+    }
+
+    /** True when at least one track in this album row matches the query (or the query is empty). */
+    public boolean hasTracksMatching(String query) {
+        if (query == null || query.isEmpty()) {
+            return true;
+        }
+        String q = query.toLowerCase();
+        return containedAudioItems.stream().anyMatch(item -> trackMatchesQuery(item, q));
+    }
+
+    private static boolean trackMatchesQuery(ObservableAudioItem item, String lowerCaseQuery) {
+        if (item.getTitle() != null && item.getTitle().toLowerCase().contains(lowerCaseQuery)) {
+            return true;
+        }
+        var artist = item.getArtist();
+        if (artist != null && artist.getName() != null
+                && artist.getName().toLowerCase().contains(lowerCaseQuery)) {
+            return true;
+        }
+        var album = item.getAlbum();
+        if (album != null) {
+            if (album.getName() != null && album.getName().toLowerCase().contains(lowerCaseQuery)) {
+                return true;
+            }
+            if (album.getAlbumArtist() != null && album.getAlbumArtist().getName() != null
+                    && album.getAlbumArtist().getName().toLowerCase().contains(lowerCaseQuery)) {
+                return true;
+            }
+            if (album.getLabel() != null && album.getLabel().getName() != null
+                    && album.getLabel().getName().toLowerCase().contains(lowerCaseQuery)) {
+                return true;
+            }
+        }
+        return item.getComments() != null && item.getComments().toLowerCase().contains(lowerCaseQuery);
     }
 
     /**

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableView.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableView.java
@@ -1,11 +1,9 @@
 package net.transgressoft.musicott.view.custom.table;
 
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
-@Scope("prototype")
 public class FullAudioItemTableView extends AudioItemTableViewBase {
 
     @SuppressWarnings ("unchecked")

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/TrackQueueRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/TrackQueueRow.java
@@ -20,6 +20,7 @@
 package net.transgressoft.musicott.view.custom.table;
 
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.musicott.view.custom.ApplicationImage;
 
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -28,12 +29,15 @@ import javafx.geometry.Pos;
 import javafx.scene.CacheHint;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
+import org.fxmisc.easybind.Subscription;
 
 import static org.fxmisc.easybind.EasyBind.combine;
+import static org.fxmisc.easybind.EasyBind.subscribe;
 
 /**
  * Class that represents a single {@link ObservableAudioItem} in the play queue or the history queue.
@@ -52,6 +56,7 @@ public class TrackQueueRow extends GridPane {
     private ImageView coverImage;
     private VBox labelBox;
     private Button deleteTrackQueueRowButton;
+    private Subscription coverSubscription;
 
     public TrackQueueRow(ObservableAudioItem track) {
         super();
@@ -77,12 +82,17 @@ public class TrackQueueRow extends GridPane {
     private void placeCover() {
         coverImage = new ImageView();
         coverImage.setId("coverImage");
-//        subscribe(track.hasCoverProperty(), c -> Utils.updateCoverImage(track, coverImage)); //TODO
         coverImage.setCacheHint(CacheHint.QUALITY);
         coverImage.setCache(false);
         coverImage.setSmooth(true);
         coverImage.setFitWidth(COVER_SIZE);
         coverImage.setFitHeight(COVER_SIZE);
+
+        Image defaultCover = ApplicationImage.DEFAULT_COVER.get();
+        coverImage.setImage(track.getCoverImageProperty().get().orElse(defaultCover));
+        coverSubscription = subscribe(track.getCoverImageProperty(),
+                opt -> coverImage.setImage(opt.orElse(defaultCover)));
+
         add(coverImage, 0, 0);
     }
 
@@ -112,5 +122,17 @@ public class TrackQueueRow extends GridPane {
 
     public void setOnDeleteButtonClickedHandler(EventHandler<ActionEvent> onDeleteListener) {
         deleteTrackQueueRowButton.setOnAction(onDeleteListener);
+    }
+
+    /**
+     * Releases the cover-property subscription. Call when the row leaves both the play queue and
+     * the history queue so the row no longer pins {@code track} as a listener target and can be
+     * garbage-collected.
+     */
+    public void dispose() {
+        if (coverSubscription != null) {
+            coverSubscription.unsubscribe();
+            coverSubscription = null;
+        }
     }
 }

--- a/src/main/kotlin/net/transgressoft/musicott/service/MediaImportService.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/service/MediaImportService.kt
@@ -175,8 +175,7 @@ class MediaImportService(
         val future = coreItunesImportService.importAsync(
             selectedPlaylists,
             library,
-            policy,
-            rootDirectoryName = ROOT_PLAYLIST_NAME
+            policy
         ) { progress ->
             Platform.runLater {
                 // Guard against an empty import surfacing Infinity / NaN to the status bar.

--- a/src/main/resources/fxml/PlayQueueController.fxml
+++ b/src/main/resources/fxml/PlayQueueController.fxml
@@ -14,11 +14,14 @@
         <BorderPane prefHeight="467.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
                     AnchorPane.topAnchor="0.0">
             <center>
-                <ListView id="queuesListView" fx:id="queuesListView" BorderPane.alignment="CENTER">
-                    <BorderPane.margin>
-                        <Insets/>
-                    </BorderPane.margin>
-                </ListView>
+                <!-- Bottom-aligned list: empty space hangs at the top of the popover, items hug the
+                     bottom so the next-up track (storage size-1) sits closest to the play button. -->
+                <VBox alignment="BOTTOM_LEFT" BorderPane.alignment="CENTER">
+                    <children>
+                        <Region VBox.vgrow="ALWAYS"/>
+                        <ListView id="queuesListView" fx:id="queuesListView" maxHeight="-Infinity" VBox.vgrow="NEVER"/>
+                    </children>
+                </VBox>
             </center>
             <bottom>
                 <GridPane prefHeight="35.0" BorderPane.alignment="CENTER">

--- a/src/uiTest/java/net/transgressoft/musicott/view/PlayQueueOrderingUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/PlayQueueOrderingUIT.java
@@ -1,0 +1,207 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.audio.Album;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.waveform.AudioWaveform;
+import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
+import net.transgressoft.musicott.services.PlayerService;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.ApplicationImage;
+import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
+
+import javafx.application.Platform;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.Node;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.GridPane;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * UI test verifying visible row ordering in the play queue popover and cover image
+ * rendering in queue rows.
+ */
+@JavaFxSpringTest(classes = PlayQueueOrderingUITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("Play queue ordering and cover rendering")
+class PlayQueueOrderingUIT extends ApplicationTestBase<GridPane> {
+
+    @Autowired
+    FxControllerAndView<PlayerController, GridPane> playerControllerAndView;
+
+    @Autowired
+    PlayerService playerService;
+
+    @Override
+    protected GridPane javaFxComponent() {
+        return playerControllerAndView.getView().get();
+    }
+
+    @BeforeEach
+    @Override
+    protected void beforeEach() {
+        super.beforeEach();
+        Platform.runLater(() -> playerService.clearQueue());
+        waitForFxEvents();
+    }
+
+    /**
+     * Creates a mock {@link ObservableAudioItem} with all properties required by
+     * {@link TrackQueueRow} and {@code JavaFxPlayer.isPlayable} stubbed to playable MP3 defaults.
+     */
+    ObservableAudioItem mockPlayableAudioItem(String title) {
+        ObservableAudioItem item = mock(ObservableAudioItem.class);
+        when(item.getTitleProperty()).thenReturn(new SimpleStringProperty(title));
+        Artist artist = mock(Artist.class);
+        when(artist.getName()).thenReturn("Test Artist");
+        when(item.getArtistProperty()).thenReturn(new SimpleObjectProperty<>(artist));
+        Album album = mock(Album.class);
+        when(album.getName()).thenReturn("Test Album");
+        when(item.getAlbumProperty()).thenReturn(new SimpleObjectProperty<>(album));
+        when(item.getCoverImageProperty()).thenReturn(new SimpleObjectProperty<>(Optional.empty()));
+        // Required by JavaFxPlayer.isPlayable: extension must be a supported type,
+        // encoding and encoder must be null to avoid the Apple/iTunes exclusion.
+        when(item.getExtension()).thenReturn("mp3");
+        when(item.getEncoding()).thenReturn(null);
+        when(item.getEncoder()).thenReturn(null);
+        return item;
+    }
+
+    @Test
+    @DisplayName("renders next-up track at the bottom of the queue list view")
+    void rendersNextUpTrackAtBottomOfQueueListView(FxRobot robot) {
+        ObservableAudioItem itemA = mockPlayableAudioItem("Song A");
+        ObservableAudioItem itemB = mockPlayableAudioItem("Song B");
+        ObservableAudioItem itemC = mockPlayableAudioItem("Song C");
+
+        Platform.runLater(() -> playerService.addToQueue(List.of(itemA, itemB, itemC)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ToggleButton playQueueButton = robot.lookup("#playQueueButton").queryAs(ToggleButton.class);
+        Platform.runLater(playQueueButton::fire);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ListView<TrackQueueRow> queuesListView = robot.lookup("#queuesListView").queryListView();
+        List<TrackQueueRow> items = new ArrayList<>(queuesListView.getItems());
+        assertThat(items).hasSize(3);
+        // Inverted storage: index 0 is the farthest-out track (plays last), size-1 is next-up.
+        // The first selected item (A) is what the user wants played first, so addToQueue([A,B,C])
+        // produces storage [C, B, A]: A at size-1 (next-up, bottom of the popover) and C at index 0
+        // (farthest-out, top). Display follows storage 1:1.
+        assertThat(items.get(items.size() - 1).getTrack()).isSameAs(itemA);
+        assertThat(items.get(0).getTrack()).isSameAs(itemC);
+    }
+
+    @Test
+    @DisplayName("renders the track cover image in queue rows")
+    void rendersTrackCoverImageInQueueRows(FxRobot robot) {
+        Image testCover = new Image(getClass().getResourceAsStream("/images/default-cover-image-queue.png"));
+        ObservableAudioItem itemWithCover = mockPlayableAudioItem("With Cover");
+        when(itemWithCover.getCoverImageProperty())
+                .thenReturn(new SimpleObjectProperty<>(Optional.of(testCover)));
+
+        ObservableAudioItem itemWithoutCover = mockPlayableAudioItem("No Cover");
+        when(itemWithoutCover.getCoverImageProperty())
+                .thenReturn(new SimpleObjectProperty<>(Optional.empty()));
+
+        Platform.runLater(() -> playerService.addToQueue(List.of(itemWithCover, itemWithoutCover)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ToggleButton playQueueButton = robot.lookup("#playQueueButton").queryAs(ToggleButton.class);
+        Platform.runLater(playQueueButton::fire);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ListView<TrackQueueRow> queuesListView = robot.lookup("#queuesListView").queryListView();
+        Image defaultCover = ApplicationImage.DEFAULT_COVER.get();
+        for (TrackQueueRow row : queuesListView.getItems()) {
+            // Use per-row lookup to avoid ambiguity when multiple coverImage nodes exist
+            ImageView iv = (ImageView) row.lookup("#coverImage");
+            assertThat(iv.getImage()).isNotNull();
+            if (row.getTrack() == itemWithCover) {
+                assertThat(iv.getImage()).isSameAs(testCover);
+            } else {
+                assertThat(iv.getImage()).isSameAs(defaultCover);
+            }
+        }
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                PlayerController.class,
+                PlayQueueController.class
+        })
+})
+class PlayQueueOrderingUITConfiguration {
+
+    final SimpleBooleanProperty emptyLibraryProperty = new SimpleBooleanProperty(false);
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public PlayerService playerService(ApplicationEventPublisher publisher) {
+        return new PlayerService(publisher);   // REAL instance — UIT drives real list mutations
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public AudioWaveformRepository<AudioWaveform, ObservableAudioItem> audioWaveformRepository() {
+        return mock(AudioWaveformRepository.class);
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioLibrary() {
+        ObservableAudioLibrary library = mock(ObservableAudioLibrary.class);
+        when(library.getEmptyLibraryProperty()).thenReturn(emptyLibraryProperty);
+        return library;
+    }
+
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/uiTest/java/net/transgressoft/musicott/view/PlayerPopoverUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/PlayerPopoverUIT.java
@@ -1,0 +1,195 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.waveform.AudioWaveform;
+import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
+import net.transgressoft.musicott.services.PlayerService;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+
+import javafx.application.Platform;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.scene.Node;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.GridPane;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * UI test verifying that the play-queue popover stays aligned to the play-queue button after
+ * the application window is resized horizontally or vertically.
+ */
+@JavaFxSpringTest(classes = PlayerPopoverUITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("Play queue popover")
+class PlayerPopoverUIT extends ApplicationTestBase<GridPane> {
+
+    @Autowired
+    FxControllerAndView<PlayerController, GridPane> playerControllerAndView;
+
+    @Override
+    protected GridPane javaFxComponent() {
+        return playerControllerAndView.getView().get();
+    }
+
+    /**
+     * Returns the {@code playQueueLayout} field from the controller. Since the node is removed
+     * from the scene graph when hidden (see {@code PlayerController.hidePlayQueue}), CSS id lookup
+     * via robot cannot find it; we retrieve the reference directly via reflection.
+     */
+    AnchorPane playQueueLayout() {
+        try {
+            Field field = PlayerController.class.getDeclaredField("playQueueLayout");
+            field.setAccessible(true);
+            return (AnchorPane) field.get(playerControllerAndView.getController());
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Cannot access PlayerController.playQueueLayout", e);
+        }
+    }
+
+    @Test
+    @DisplayName("anchors to play-queue button on initial show")
+    void anchorsToPlayQueueButtonOnInitialShow(FxRobot robot) {
+        // playQueueLayout is removed from the scene by hidePlayQueue() during initialize();
+        // fire the toggle button first so showPlayQueue() re-adds it to the scene graph.
+        ToggleButton playQueueButton = robot.lookup("#playQueueButton").queryAs(ToggleButton.class);
+        AnchorPane playQueueLayout = playQueueLayout();
+        Platform.runLater(playQueueButton::fire);
+        waitForFxEvents();
+
+        assertThat(playQueueLayout.isVisible()).isTrue();
+        double popoverCenterX = playQueueLayout.localToScene(playQueueLayout.getBoundsInLocal()).getCenterX();
+        double buttonCenterX = playQueueButton.localToScene(playQueueButton.getBoundsInLocal()).getCenterX();
+        assertThat(Math.abs(popoverCenterX - buttonCenterX)).isLessThan(2.0);
+    }
+
+    @Test
+    @DisplayName("re-anchors to play-queue button after horizontal window resize")
+    void reAnchorsToPlayQueueButtonAfterHorizontalWindowResize(FxRobot robot) {
+        ToggleButton playQueueButton = robot.lookup("#playQueueButton").queryAs(ToggleButton.class);
+        AnchorPane playQueueLayout = playQueueLayout();
+        Platform.runLater(playQueueButton::fire);
+        waitForFxEvents();
+
+        assertThat(playQueueLayout.isVisible()).isTrue();
+
+        Stage stage = (Stage) robot.window(0);
+        double newWidth = stage.getWidth() + 100.0;
+        Platform.runLater(() -> stage.setWidth(newWidth));
+        waitForFxEvents();
+
+        double popoverCenterX = playQueueLayout.localToScene(playQueueLayout.getBoundsInLocal()).getCenterX();
+        double buttonCenterX = playQueueButton.localToScene(playQueueButton.getBoundsInLocal()).getCenterX();
+        assertThat(Math.abs(popoverCenterX - buttonCenterX)).isLessThan(2.0);
+    }
+
+    @Test
+    @DisplayName("re-anchors to play-queue button after vertical window resize")
+    void reAnchorsToPlayQueueButtonAfterVerticalWindowResize(FxRobot robot) {
+        ToggleButton playQueueButton = robot.lookup("#playQueueButton").queryAs(ToggleButton.class);
+        AnchorPane playQueueLayout = playQueueLayout();
+        Platform.runLater(playQueueButton::fire);
+        waitForFxEvents();
+
+        assertThat(playQueueLayout.isVisible()).isTrue();
+
+        Stage stage = (Stage) robot.window(0);
+        double popoverTopBefore = playQueueLayout.localToScene(playQueueLayout.getBoundsInLocal()).getMinY();
+
+        double newHeight = stage.getHeight() + 100.0;
+        Platform.runLater(() -> stage.setHeight(newHeight));
+        waitForFxEvents();
+
+        var popoverBounds = playQueueLayout.localToScene(playQueueLayout.getBoundsInLocal());
+        var buttonBounds = playQueueButton.localToScene(playQueueButton.getBoundsInLocal());
+        assertThat(Math.abs(popoverBounds.getCenterX() - buttonBounds.getCenterX())).isLessThan(2.0);
+
+        // configurePlayQueuePopupSizing pins popover.minY ≈ topReserved (30px) regardless of scene
+        // height: bottomMargin = max(bottomReserved, sceneH - popupH - topReserved), so growing the
+        // scene grows bottomMargin in lockstep, keeping the popover top fixed near the top edge.
+        // Without the heightProperty listener firing, bottomMargin would stay stale and popover.minY
+        // would drift downward as the scene grows.
+        double popoverTopAfter = popoverBounds.getMinY();
+        assertThat(Math.abs(popoverTopAfter - popoverTopBefore)).isLessThan(5.0);
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                PlayerController.class,
+                PlayQueueController.class
+        })
+})
+class PlayerPopoverUITConfiguration {
+
+    final SimpleBooleanProperty emptyLibraryProperty = new SimpleBooleanProperty(false);
+
+    @Bean
+    public PlayerService playerService() {
+        var service = mock(PlayerService.class);
+        when(service.getPlayQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(service.getHistoryQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(service.currentTrack()).thenReturn(Optional.empty());
+        when(service.getTotalDuration()).thenReturn(javafx.util.Duration.ZERO);
+        return service;
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioLibrary() {
+        var library = mock(ObservableAudioLibrary.class);
+        when(library.getEmptyLibraryProperty()).thenReturn(emptyLibraryProperty);
+        return library;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public AudioWaveformRepository<AudioWaveform, ObservableAudioItem> audioWaveformRepository() {
+        return mock(AudioWaveformRepository.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,
+    // which would call Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes nine bugs across three flows: play queue (5), search (3), and the Ctrl+I metadata editor (1). All four test source sets pass (test, integrationTest, uiTest, e2eTest).

## Issues addressed

- Closes #21 — re-anchor play-queue popover on width changes
- Closes #22 — invert play queue and history storage order
- Closes #23 — bind play-queue and history row cover images to track property
- Closes #24 — wrap `historyQueueList` listener in `while (change.next())`
- Closes #25 — append finished track to history regardless of queue emptiness
- Closes #26 — deliver `SearchTextTypedEvent` end-to-end across All Tracks, Playlists, and Artists
- Closes #27 — keep artist auto-selected on filter change
- Closes #28 — restore artist on search clear
- Closes #29 — render the metadata editor on Ctrl+I

## Test plan

- [x] `gradle test` — green
- [x] `gradle integrationTest` — green
- [x] `gradle uiTest` — green
- [x] `gradle e2eTest` — green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search filtering for artists, albums, and tracks; album rows now respect active queries.
  * Play queue rows show cover images with automatic fallback to the default image.

* **Bug Fixes**
  * Play queue ordering and navigation (next/previous/add) corrected.
  * Play queue popover positioning and sizing improved during window resizes.
  * Modal dialog presentation and common-field handling fixed.

* **Tests**
  * Extensive new integration/UI tests for search, queue behavior, popover anchoring, and controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->