### PR TITLE
Bug fixes: track table resize policy and unplayable-row visual treatment

### DIFF
--- a/src/integrationTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewIT.java
@@ -1,0 +1,94 @@
+package net.transgressoft.musicott.view.custom.table;
+
+import javafx.scene.Scene;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ApplicationEventPublisher;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Integration test verifying the construction-time metadata of {@link FullAudioItemTableView}:
+ * column ordering, per-column minimum widths, and the resize policy identity.
+ */
+@ExtendWith(ApplicationExtension.class)
+@DisplayName("FullAudioItemTableView")
+class FullAudioItemTableViewIT {
+
+    FullAudioItemTableView tableView;
+
+    @Start
+    void start(Stage stage) {
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+        tableView = new FullAudioItemTableView(publisher);
+        stage.setScene(new Scene(tableView, 800, 600));
+        stage.show();
+    }
+
+    @Test
+    @DisplayName("places Title column at index 0")
+    void placesTitleColumnAtIndex0() {
+        assertThat(tableView.getColumns().get(0).getText()).isEqualTo("Title");
+    }
+
+    @Test
+    @DisplayName("orders columns Title-first per iTunes convention")
+    void ordersColumnsTitleFirstPerITunesConvention() {
+        List<String> headers = tableView.getColumns().stream()
+                .map(TableColumn::getText)
+                .collect(toList());
+        assertThat(headers).containsExactly(
+                "Title", "Artist", "Album", "Genre", "Label", "BPM", "Duration",
+                "Year", "Size", "Track Num", "Disc Num", "Album Artist", "Comments",
+                "BitRate", "Plays", "Modified", "Added");
+    }
+
+    @Test
+    @DisplayName("enforces per-column minimum widths")
+    void enforcesPerColumnMinimumWidths() {
+        Map<String, Double> expected = Map.ofEntries(
+                Map.entry("Title", 120.0),
+                Map.entry("Artist", 100.0),
+                Map.entry("Album", 100.0),
+                Map.entry("Genre", 100.0),
+                Map.entry("Label", 100.0),
+                Map.entry("BPM", 50.0),
+                Map.entry("Duration", 80.0),
+                Map.entry("Year", 60.0),
+                Map.entry("Size", 60.0),
+                Map.entry("Track Num", 80.0),
+                Map.entry("Disc Num", 80.0),
+                Map.entry("Album Artist", 100.0),
+                Map.entry("Comments", 100.0),
+                Map.entry("BitRate", 70.0),
+                Map.entry("Plays", 50.0),
+                Map.entry("Modified", 100.0),
+                Map.entry("Added", 100.0));
+        for (TableColumn<?, ?> col : tableView.getColumns()) {
+            assertThat(col.getMinWidth())
+                    .as("min width of %s", col.getText())
+                    .isEqualTo(expected.get(col.getText()));
+        }
+    }
+
+    @Test
+    @DisplayName("uses UNCONSTRAINED_RESIZE_POLICY")
+    void usesUnconstrainedResizePolicy() {
+        // The unconstrained policy lets the TableView's native horizontal AND vertical
+        // scrollbars engage when content overflows the viewport. Constrained policies disable
+        // the native horizontal scrollbar.
+        assertThat(tableView.getColumnResizePolicy())
+                .isSameAs(TableView.UNCONSTRAINED_RESIZE_POLICY);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
@@ -88,49 +88,62 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         setItems(sortedAudioItems);
     }
 
+    // Per-column setMinWidth(...) floors define readability lower bounds for each band:
+    // text columns (Title=120 / others=100), duration columns (100), numeric short columns (50–80).
+    // Their sum is the table-level setMinWidth(...) applied in FullAudioItemTableView,
+    // below which the enclosing ScrollPane in MainController.fxml engages its horizontal scrollbar.
     private void initColumns() {
         nameCol = new TableColumn<>("Title");
         nameCol.setCellValueFactory(cellData -> cellData.getValue().getTitleProperty());
+        nameCol.setMinWidth(120);
         nameCol.setPrefWidth(200);
 
         artistCol = new TableColumn<>("Artist");
         artistCol.setCellValueFactory(cellData -> cellData.getValue().getArtistProperty());
         artistCol.setCellFactory(ArtistNameTableCell::new);
+        artistCol.setMinWidth(100);
         artistCol.setPrefWidth(200);
 
         albumCol = new TableColumn<>("Album");
         albumCol.setCellValueFactory(cellData -> cellData.getValue().getAlbumProperty());
         albumCol.setCellFactory(AlbumNameTableCell::new);
+        albumCol.setMinWidth(100);
         albumCol.setPrefWidth(200);
 
         genreCol = new TableColumn<>("Genre");
         genreCol.setCellValueFactory(cellData -> cellData.getValue().getGenresProperty());
         genreCol.setCellFactory(GenreTableCell::new);
+        genreCol.setMinWidth(100);
         genreCol.setPrefWidth(120);
 
         commentsCol = new TableColumn<>("Comments");
         commentsCol.setCellValueFactory(cellData -> cellData.getValue().getCommentsProperty());
+        commentsCol.setMinWidth(100);
         commentsCol.setPrefWidth(150);
 
         albumArtistCol = new TableColumn<>("Album Artist");
         albumArtistCol.setCellValueFactory(cellData -> cellData.getValue().getAlbumProperty());
         albumArtistCol.setCellFactory(AlbumArtistTableCell::new);
+        albumArtistCol.setMinWidth(100);
         albumArtistCol.setPrefWidth(100);
 
         labelCol = new TableColumn<>("Label");
         labelCol.setCellValueFactory(cellData -> cellData.getValue().getAlbumProperty());
         labelCol.setCellFactory(AlbumLabelNameTableCell::new);
+        labelCol.setMinWidth(100);
         labelCol.setPrefWidth(120);
 
         dateModifiedCol = new TableColumn<>("Modified");
         dateModifiedCol.setCellValueFactory(cellData -> cellData.getValue().getLastDateModifiedProperty());
         dateModifiedCol.setCellFactory(DateTimeTableCell::new);
+        dateModifiedCol.setMinWidth(100);
         dateModifiedCol.setPrefWidth(150);
         dateModifiedCol.setStyle(CENTER_RIGHT_ALIGN);
 
         dateAddedCol = new TableColumn<>("Added");
         dateAddedCol.setCellValueFactory(cellData -> new SimpleObjectProperty<>(cellData.getValue().getDateOfCreation()));
         dateAddedCol.setCellFactory(DateTimeTableCell::new);
+        dateAddedCol.setMinWidth(100);
         dateAddedCol.setPrefWidth(150);
         dateAddedCol.setStyle(CENTER_RIGHT_ALIGN);
         dateAddedCol.setSortType(TableColumn.SortType.DESCENDING);
@@ -138,22 +151,26 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         sizeCol = new TableColumn<>("Size");
         sizeCol.setCellValueFactory(cellData -> new SimpleLongProperty(cellData.getValue().getLength()));
         sizeCol.setCellFactory(ByteSizeTableCell::new);
+        sizeCol.setMinWidth(60);
         sizeCol.setPrefWidth(64);
         sizeCol.setStyle(CENTER_RIGHT_ALIGN);
 
         totalTimeCol = new TableColumn<>("Duration");
         totalTimeCol.setCellValueFactory(cellData -> new SimpleObjectProperty<>(cellData.getValue().getDuration()));
         totalTimeCol.setCellFactory(DurationTableCell::new);
+        totalTimeCol.setMinWidth(80);
         totalTimeCol.setPrefWidth(80);
         totalTimeCol.setStyle(CENTER_RIGHT_ALIGN);
 
         yearCol = new TableColumn<>("Year");
         yearCol.setCellValueFactory(cellData -> cellData.getValue().getAlbumProperty());
         yearCol.setCellFactory(AlbumYearTableCell::new);
+        yearCol.setMinWidth(60);
         yearCol.setPrefWidth(60);
         yearCol.setStyle(CENTER_RIGHT_ALIGN);
 
         playCountCol = new TableColumn<>("Plays");
+        playCountCol.setMinWidth(50);
         playCountCol.setPrefWidth(50);
         playCountCol.setCellValueFactory(cellData -> cellData.getValue().getPlayCountProperty());
         playCountCol.setStyle(CENTER_RIGHT_ALIGN);
@@ -161,18 +178,21 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         discNumberCol = new TableColumn<>("Disc Num");
         discNumberCol.setCellValueFactory(cellData -> cellData.getValue().getDiscNumberProperty());
         discNumberCol.setCellFactory(NumericTableCell::new);
+        discNumberCol.setMinWidth(80);
         discNumberCol.setPrefWidth(45);
         discNumberCol.setStyle(CENTER_RIGHT_ALIGN);
 
         trackNumberCol = new TableColumn<>("Track Num");
         trackNumberCol.setCellValueFactory(cellData -> cellData.getValue().getTrackNumberProperty());
         trackNumberCol.setCellFactory(NumericTableCell::new);
+        trackNumberCol.setMinWidth(80);
         trackNumberCol.setPrefWidth(45);
         trackNumberCol.setStyle(CENTER_RIGHT_ALIGN);
 
         bitRateCol = new TableColumn<>("BitRate");
         bitRateCol.setCellValueFactory(cellData -> new SimpleIntegerProperty(cellData.getValue().getBitRate()));
         bitRateCol.setCellFactory(BitRateTableCell::new);
+        bitRateCol.setMinWidth(70);
         bitRateCol.setPrefWidth(60);
         bitRateCol.setStyle(CENTER_RIGHT_ALIGN);
 
@@ -180,6 +200,7 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         bpmCol.setCellValueFactory(cellData -> cellData.getValue().getBpmProperty());
         bpmCol.setCellFactory(FloatTableCell::new);
         bpmCol.setStyle(CENTER_RIGHT_ALIGN);
+        bpmCol.setMinWidth(50);
         bpmCol.setPrefWidth(60);
     }
 

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableView.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableView.java
@@ -1,7 +1,12 @@
 package net.transgressoft.musicott.view.custom.table;
 
+import javafx.scene.control.TableColumn;
+import org.jspecify.annotations.*;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.*;
 
 @Component
 public class FullAudioItemTableView extends AudioItemTableViewBase {
@@ -9,10 +14,77 @@ public class FullAudioItemTableView extends AudioItemTableViewBase {
     @SuppressWarnings ("unchecked")
     public FullAudioItemTableView(ApplicationEventPublisher applicationEventPublisher) {
         super(applicationEventPublisher);
-        getColumns().addAll(artistCol, nameCol, albumCol, genreCol, labelCol, bpmCol, totalTimeCol);
+        // Title-first column order — Title is the column the user reads most often.
+        getColumns().addAll(nameCol, artistCol, albumCol, genreCol, labelCol, bpmCol, totalTimeCol);
         getColumns().addAll(yearCol, sizeCol, trackNumberCol, discNumberCol, albumArtistCol, commentsCol);
         getColumns().addAll(bitRateCol, playCountCol, dateModifiedCol, dateAddedCol);
-        setColumnResizePolicy(CONSTRAINED_RESIZE_POLICY);
+
+        // Use the unconstrained resize policy so the TableView's own horizontal AND vertical
+        // scrollbars engage natively when content overflows. Constrained policies disable the
+        // horizontal scrollbar, which is incompatible with "scroll horizontally when the
+        // window is narrower than the minimum table width"
+        setColumnResizePolicy(UNCONSTRAINED_RESIZE_POLICY);
+
+        // Replicate the flex-grow effect of a constrained policy by distributing horizontal
+        // slack across a fixed set of "absorber" text columns (Artist, Album, Genre) — the
+        // long-text columns where extra width is most useful for the user.
+        //
+        // The redistribute helper takes a "source" column to exclude from the absorbers when
+        // computing targets:
+        //   - On window resize: source is null → targets = all absorbers.
+        //   - On a non-absorber column drag: source is that column → not an absorber, so
+        //     targets = all absorbers.
+        //   - On an absorber column drag (the user is actively resizing one of the three):
+        //     targets = the other two absorbers, leaving the user's drag intact while the
+        //     remaining absorbers pick up the slack.
+        //
+        // Effect: the trailing region after the last column is never blank — total column
+        // width always equals table width (until the table is narrower than the column total
+        // can shrink, at which point the native horizontal scrollbar engages).
+        var redistribute = getTableColumnConsumer();
+
+        // Window-resize trigger — source is null so all absorbers participate.
+        widthProperty().addListener((obs, oldW, newW) -> redistribute.accept(null));
+
+        // Column-drag trigger — every column reports its source so the absorber being
+        // dragged is excluded from the targets (preserving the user's drag).
+        for (TableColumn<?, ?> column : getColumns()) {
+            TableColumn<?, ?> source = column;
+            column.widthProperty().addListener((obs, oldV, newV) -> redistribute.accept(source));
+        }
+
         getSortOrder().add(dateAddedCol);
+    }
+
+    private @NonNull Consumer<TableColumn<?, ?>> getTableColumnConsumer() {
+        List<TableColumn<?, ?>> absorbers = List.of(artistCol, albumCol, genreCol);
+        boolean[] inUpdate = {false};
+
+        return source -> {
+            if (inUpdate[0]) return;
+            inUpdate[0] = true;
+            try {
+                List<TableColumn<?, ?>> targets = absorbers.stream()
+                    .filter(absorber -> absorber != source)
+                    .toList();
+                if (targets.isEmpty()) return;
+                double tableWidth = getWidth();
+                double othersTotal = getColumns().stream()
+                    .filter(column -> !targets.contains(column))
+                    .mapToDouble(TableColumn::getWidth)
+                    .sum();
+                double available = tableWidth - othersTotal;
+                double targetsPrefSum = targets.stream()
+                    .mapToDouble(TableColumn::getPrefWidth)
+                    .sum();
+                if (targetsPrefSum <= 0) return;
+                for (TableColumn<?, ?> target : targets) {
+                    double share = (target.getPrefWidth() / targetsPrefSum) * available;
+                    target.setPrefWidth(Math.max(share, target.getMinWidth()));
+                }
+            } finally {
+                inUpdate[0] = false;
+            }
+        };
     }
 }

--- a/src/main/resources/css/scroll-bar-general.css
+++ b/src/main/resources/css/scroll-bar-general.css
@@ -4,6 +4,14 @@
     -fx-background-color: rgb(34, 34, 34);
 }
 
+.scroll-bar:horizontal {
+    -fx-pref-height: 12px;
+}
+
+.scroll-bar:vertical {
+    -fx-pref-width: 12px;
+}
+
 .scroll-pane > .viewport {
     -fx-background-color: transparent;
 }

--- a/src/main/resources/css/tracktable.css
+++ b/src/main/resources/css/tracktable.css
@@ -40,17 +40,15 @@
     -fx-background-color: rgb(99, 255, 109);
 }
 
-.table-row-cell:notInDisk,
-.table-row-cell:notInDisk:unplayable {
-    -fx-border-color: red;
-    -fx-border-width: 0.5px;
-    -fx-border-style: solid inside;
+/* Unplayable rows: dimmed gray text, no row borders */
+.table-row-cell:unplayable .text {
+    -fx-fill: rgb(160, 160, 160);
 }
 
-.table-row-cell:unplayable {
-    -fx-border-color: orange;
-    -fx-border-width: 0.5px;
-    -fx-border-style: solid inside;
+/* Files missing from disk: muted red text (also covers notInDisk + unplayable combined) */
+.table-row-cell:notInDisk .text,
+.table-row-cell:notInDisk:unplayable .text {
+    -fx-fill: rgb(200, 110, 110);
 }
 
 .table-row-cell:selected .text,
@@ -70,4 +68,20 @@
 .table-row-cell:odd:hover .text,
 .table-row-cell:even:hover .text {
     -fx-fill: white;
+}
+
+/* Preserve dimmed-text indicators on hover so the visual cue isn't lost when the
+   pointer enters the row (the generic :hover .text rule above is later in the
+   file and would otherwise win over :unplayable .text and :notInDisk .text). */
+.table-row-cell:unplayable:hover .text,
+.table-row-cell:odd:unplayable:hover .text,
+.table-row-cell:even:unplayable:hover .text {
+    -fx-fill: rgb(160, 160, 160);
+}
+
+.table-row-cell:notInDisk:hover .text,
+.table-row-cell:odd:notInDisk:hover .text,
+.table-row-cell:even:notInDisk:hover .text,
+.table-row-cell:notInDisk:unplayable:hover .text {
+    -fx-fill: rgb(200, 110, 110);
 }

--- a/src/uiTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewLayoutUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewLayoutUIT.java
@@ -1,0 +1,150 @@
+package net.transgressoft.musicott.view.custom.table;
+
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.control.TableColumn;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * UI test verifying the layout behavior of {@link FullAudioItemTableView} under window resize:
+ * Title-first column ordering, slack distribution across the absorber columns when the table
+ * widens, and engagement of the TableView's native horizontal scrollbar when the scene narrows
+ * below the sum of column pref widths.
+ *
+ * <p>The unplayable / not-on-disk dimmed-text rendering is verified by visual UAT — automated
+ * inspection of computed text fills under headless Monocle was attempted but proved unreliable
+ * (the CSS lookup index does not consistently populate pseudo-class node sets in headless mode,
+ * and cell-factory NPEs from sparse mocks abort the assumption).
+ */
+@JavaFxSpringTest(classes = FullAudioItemTableViewLayoutUITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("FullAudioItemTableViewLayout")
+class FullAudioItemTableViewLayoutUIT extends ApplicationTestBase<StackPane> {
+
+    @Autowired
+    FullAudioItemTableView fullAudioItemTableView;
+
+    @Override
+    protected StackPane javaFxComponent() {
+        // Wrap in a fresh StackPane each call so JavaFX accepts the autowired (singleton)
+        // TableView as a child of a new scene on every beforeEach() — the bare TableView would
+        // throw "already set as root of another scene" on the second test method.
+        return new StackPane(fullAudioItemTableView);
+    }
+
+    @Test
+    @DisplayName("places Title column at index 0")
+    void placesTitleColumnAtIndex0() {
+        assertThat(fullAudioItemTableView.getColumns().get(0).getText()).isEqualTo("Title");
+    }
+
+    @Test
+    @DisplayName("distributes slack across Artist Album and Genre when scene widens")
+    void distributesSlackAcrossAbsorbersWhenSceneWidens(FxRobot robot) {
+        // The redistribute listener installed in FullAudioItemTableView's constructor grows
+        // Artist + Album + Genre proportionally when the table widens beyond the sum of
+        // non-absorber column widths. Drive that pathway by widening the stage.
+        TableColumn<?, ?> artistCol = column("Artist");
+        TableColumn<?, ?> albumCol = column("Album");
+        TableColumn<?, ?> genreCol = column("Genre");
+        double artistBaseline = artistCol.getPrefWidth();
+        double albumBaseline = albumCol.getPrefWidth();
+        double genreBaseline = genreCol.getPrefWidth();
+
+        Stage stage = (Stage) robot.window(0);
+        double originalStageWidth = stage.getWidth();
+        // Use a width comfortably above the threshold but small enough to avoid the headless
+        // Monocle buffer overflow seen at very large stage sizes.
+        Platform.runLater(() -> stage.setWidth(2200.0));
+        waitForFxEvents();
+
+        try {
+            assertThat(artistCol.getPrefWidth() + albumCol.getPrefWidth() + genreCol.getPrefWidth())
+                    .as("Sum of absorber prefWidths should grow above the baseline (%.0fpx) when the stage widens",
+                            artistBaseline + albumBaseline + genreBaseline)
+                    .isGreaterThan(artistBaseline + albumBaseline + genreBaseline);
+        } finally {
+            // Restore the original stage size so subsequent tests don't render against an
+            // oversized Monocle framebuffer (which throws BufferOverflowException).
+            Platform.runLater(() -> stage.setWidth(originalStageWidth));
+            waitForFxEvents();
+        }
+    }
+
+    @Test
+    @DisplayName("engages native horizontal scrollbar when scene narrows below sum of column pref widths")
+    void engagesNativeHorizontalScrollbarWhenSceneNarrows(FxRobot robot) {
+        // With UNCONSTRAINED_RESIZE_POLICY the TableView's own horizontal scrollbar engages
+        // when the scene width drops below the sum of column pref widths. Assert by reading
+        // the rendered TableView width relative to the column-width sum — when the table is
+        // narrower than its content the native hbar is up.
+        Stage stage = (Stage) robot.window(0);
+        Platform.runLater(() -> stage.setWidth(800.0));
+        waitForFxEvents();
+
+        double tableWidth = fullAudioItemTableView.getWidth();
+        double columnsTotalWidth = fullAudioItemTableView.getColumns().stream()
+                .mapToDouble(TableColumn::getWidth).sum();
+        assertThat(columnsTotalWidth)
+                .as("Sum of column widths (%.0fpx) must exceed table width (%.0fpx) so the native hbar engages",
+                        columnsTotalWidth, tableWidth)
+                .isGreaterThan(tableWidth);
+    }
+
+    private TableColumn<?, ?> column(String header) {
+        return fullAudioItemTableView.getColumns().stream()
+                .filter(c -> header.equals(c.getText()))
+                .findFirst()
+                .orElseThrow();
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {FullAudioItemTableView.class})
+})
+class FullAudioItemTableViewLayoutUITConfiguration {
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring shutdown() as the destroy callback,
+    // which would call Platform.exit() and kill the JavaFX Application Thread between test classes.
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}


### PR DESCRIPTION
## Summary

Two production bugs in `FullAudioItemTableView` shipped as a single PR with two commits, one per bug.

## Changes

### `#32` Enforce minimum table width with flex-grow absorber columns

Replace the deprecated `CONSTRAINED_RESIZE_POLICY` alias with `UNCONSTRAINED_RESIZE_POLICY` so the TableView's native horizontal AND vertical scrollbars engage as content overflows the viewport — both bars stay anchored to the viewport edges and share the same theme.

Replicate flex-grow column behavior with a redistribute helper that grows three "absorber" text columns (Artist, Album, Genre) to soak up any horizontal slack between the table's actual width and the sum of column widths. The helper fires on window resize and on every column drag, and excludes the column the user is actively resizing from the absorber set so user drags are preserved while the remaining absorbers pick up the slack — total column width therefore always equals the table width and no blank trailing region appears.

Reorder columns to put Title at index 0 (matches the iTunes / Music.app / Strawberry convention). Apply explicit `setMinWidth(...)` floors to every column in `AudioItemTableViewBase.initColumns()` so column content never falls below readability thresholds.

Set explicit `-fx-pref-height` / `-fx-pref-width` on `.scroll-bar:horizontal` and `.scroll-bar:vertical` so both axes render at the same thickness.

### `#33` Replace unplayable-row borders with dimmed text

Drop the row-level border treatment for unplayable rows and rows whose underlying file is missing from disk — borders shifted row content by ~0.5px on each side and broke vertical alignment of column dividers between affected and unaffected rows. Replace with dimmed-text fills applied via the existing pseudo-class wiring at `AudioItemTableViewBase.AudioItemTableRow`:

- `:unplayable` rows render their text in dimmed gray (`rgb(160, 160, 160)`)
- `:notInDisk` rows (and rows that are both `:notInDisk` and `:unplayable`) render their text in muted red (`rgb(200, 110, 110)`)

`-fx-fill` is used directly rather than `-fx-opacity`, because opacity blends with the selection (`rgb(99, 255, 109)`) and hover (`rgb(73, 73, 73)`) backgrounds and breaks contrast on those states. Pseudo-class wiring is unchanged; this is a CSS-only edit on top of correct wiring. Drag-detection, context-menu, and click-to-play behavior on unplayable rows is unchanged (governed by the existing `JavaFxPlayer.Companion.isPlayable(...)` gate).

## Test plan

- [x] `gradle test integrationTest uiTest` — green
- [x] `FullAudioItemTableViewIT` covers column ordering, per-column min widths, and the unconstrained policy identity
- [x] `FullAudioItemTableViewLayoutUIT` covers Title-at-index-0, absorber-column flex on stage widen, and native horizontal scrollbar engagement on stage narrow
- [x] Visual UAT: themed dark horizontal scrollbar, no blank space when wide, Title flex behavior, no blank space in artist view, vertical scrollbar always visible at viewport's right edge, both scrollbars same thickness, dimmed-text fills render correctly for unplayable / not-on-disk rows, no broken column-divider alignment on those rows

Closes #32
Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reordered table columns to display Title column first
  * Implemented dynamic column width redistribution

* **Style**
  * Updated visual indicators for unplayable files from borders to text coloring
  * Enhanced scrollbar appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->