### PR TITLE
Bug fixes: About dialog stray label and runtime version sourcing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,14 @@ group = 'net.transgressoft'
 version = scmVersion.version
 description = 'musicott'
 
+// Generate META-INF/build-info.properties at build time so Spring's BuildProperties
+// bean is autoconfigured. AboutWindowAlert reads buildProperties.getVersion() to
+// display the runtime version (sourced from scmVersion.version above) instead of
+// a hardcoded literal.
+springBoot {
+    buildInfo()
+}
+
 // Stabilise transitive kotlinx versions — Spring Boot's kotlin BOM and music-commons can
 // otherwise pull conflicting coroutines/serialization releases into the runtime classpath.
 // Also strip transitive org.openjfx:javafx-* JARs: with Liberica Full / 'jdk+fx' the JDK

--- a/src/integrationTest/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlertIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlertIT.java
@@ -1,0 +1,166 @@
+package net.transgressoft.musicott.view.custom.alerts;
+
+import net.transgressoft.musicott.services.SimpleWebRedirectionService;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Alert;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration test verifying the full rendered state of {@link AboutWindowAlert}: the logo
+ * sits on top of a FlowPane carrying the version line, GitHub hyperlink, and license line; no
+ * stray "Message" content-text label leaks from {@link Alert.AlertType#INFORMATION}; the version
+ * string is sourced from Spring's {@link BuildProperties} bean; and the dialog window carries
+ * the application icon.
+ */
+@JavaFxSpringTest(classes = AboutWindowAlertITConfiguration.class)
+@DisplayName("AboutWindowAlert")
+class AboutWindowAlertIT extends ApplicationTestBase<Pane> {
+
+    @Autowired
+    AlertFactory alertFactory;
+
+    Alert aboutAlert;
+
+    @Override
+    protected Pane javaFxComponent() {
+        // The test stage needs some Parent as scene root; the alert renders in its own
+        // owned window once initOwner(testStage) is set in beforeEach().
+        return new Pane();
+    }
+
+    @Override
+    @BeforeEach
+    protected void beforeEach() {
+        super.beforeEach();
+        Platform.runLater(() -> {
+            aboutAlert = (Alert) alertFactory.aboutWindowAlert();
+            aboutAlert.initOwner(testStage);
+            aboutAlert.show();
+        });
+        waitForFxEvents();
+    }
+
+    @AfterEach
+    void closeAlert() {
+        if (aboutAlert != null) {
+            Platform.runLater(aboutAlert::close);
+            waitForFxEvents();
+        }
+    }
+
+    @Test
+    @DisplayName("renders the about dialog with logo on top, runtime version, and application icon")
+    void rendersAboutDialogWithLogoOnTopRuntimeVersionAndApplicationIcon(FxRobot fxRobot) {
+        DialogPane dialogPane = aboutAlert.getDialogPane();
+
+        assertThat(dialogPane.getHeaderText()).isNull();
+        assertThat(aboutAlert.getTitle()).isEqualTo("About Musicott");
+
+        List<Label> labels = collectLabels(dialogPane, new ArrayList<>());
+        assertThat(labels)
+                .filteredOn(label -> "Message".equals(label.getText()))
+                .as("dialog pane should not contain any Label with text == 'Message'")
+                .isEmpty();
+
+        assertThat(dialogPane.getContent()).isInstanceOf(VBox.class);
+        VBox content = (VBox) dialogPane.getContent();
+        assertThat(content.getChildren()).hasSize(2);
+        assertThat(content.getChildren().get(0))
+                .as("logo must be the first child so it renders on top of the text")
+                .isInstanceOf(ImageView.class);
+        assertThat(content.getChildren().get(1)).isInstanceOf(FlowPane.class);
+
+        FlowPane flowPane = (FlowPane) content.getChildren().get(1);
+        assertThat(flowPane.getChildren()).hasSize(3);
+        assertThat(flowPane.getChildren().get(0)).isInstanceOf(Label.class);
+        assertThat(flowPane.getChildren().get(1)).isInstanceOf(Hyperlink.class);
+        assertThat(flowPane.getChildren().get(2)).isInstanceOf(Label.class);
+
+        Label versionLabel = (Label) flowPane.getChildren().get(0);
+        String expectedVersionPrefix = "Version 1.0.0-test.\nCopyright © 2015-" + Year.now().getValue();
+        assertThat(versionLabel.getText()).startsWith(expectedVersionPrefix);
+        assertThat(versionLabel.getText()).endsWith("\nOctavio Calleya.");
+
+        Hyperlink githubLink = (Hyperlink) flowPane.getChildren().get(1);
+        assertThat(githubLink.getText()).isEqualTo(SimpleWebRedirectionService.GITHUB_URL);
+
+        Label licenseLabel = (Label) flowPane.getChildren().get(2);
+        assertThat(licenseLabel.getText()).contains("includes software");
+
+        Stage dialogStage = (Stage) dialogPane.getScene().getWindow();
+        assertThat(dialogStage.getIcons())
+                .as("about dialog window should carry the application icon")
+                .isNotEmpty();
+    }
+
+    static List<Label> collectLabels(Parent root, List<Label> acc) {
+        for (Node child : root.getChildrenUnmodifiable()) {
+            if (child instanceof Label label) {
+                acc.add(label);
+            } else if (child instanceof Parent parent) {
+                collectLabels(parent, acc);
+            }
+        }
+        return acc;
+    }
+}
+
+@JavaFxSpringTestConfiguration
+class AboutWindowAlertITConfiguration {
+
+    @Bean
+    SimpleWebRedirectionService webRedirectionService() {
+        // Mock — the real constructor takes javafx.application.HostServices which is unavailable
+        // under headless TestFX. The IT never clicks the hyperlink, so a Mockito mock is sufficient.
+        // Pattern precedent: ErrorDialogControllerTest.java.
+        return mock(SimpleWebRedirectionService.class);
+    }
+
+    @Bean
+    BuildProperties buildProperties() {
+        Properties props = new Properties();
+        props.setProperty("group", "net.transgressoft");
+        props.setProperty("artifact", "musicott");
+        props.setProperty("name", "musicott");
+        props.setProperty("version", "1.0.0-test");
+        return new BuildProperties(props);
+    }
+
+    @Bean
+    AlertFactory alertFactory(SimpleWebRedirectionService webRedirectionService,
+                              ObjectProvider<BuildProperties> buildPropertiesProvider) {
+        return new AlertFactory(webRedirectionService, buildPropertiesProvider);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlert.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlert.java
@@ -3,10 +3,16 @@ package net.transgressoft.musicott.view.custom.alerts;
 import net.transgressoft.musicott.services.SimpleWebRedirectionService;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 
+import javafx.geometry.Pos;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.springframework.boot.info.BuildProperties;
+
+import java.time.Year;
 
 import static net.transgressoft.musicott.services.SimpleWebRedirectionService.GITHUB_URL;
 
@@ -15,24 +21,41 @@ import static net.transgressoft.musicott.services.SimpleWebRedirectionService.GI
  */
 public class AboutWindowAlert extends ApplicationAlertBase {
 
-    private static final String ABOUT_MUSICOTT_FIRST_LINE = "Version 0.11.\nCopyright © 2015-2020\nOctavio Calleya.";
-
-    private static final String ABOUT_MUSICOTT_SECOND_LINE = "\nLicensed under GNU GPLv3. This product includes\0"
+    private static final String ABOUT_MUSICOTT_SECOND_LINE = "\nLicensed under GNU GPLv3. This product includes "
         + "software developed by other open source projects.";
 
-    public AboutWindowAlert(SimpleWebRedirectionService webRedirectionService) {
+    /**
+     * @param webRedirectionService service used by the GitHub hyperlink action
+     * @param buildProperties Spring's BuildProperties bean — may be null when the
+     *                        bootBuildInfo task did not run (e.g. an IDE invocation
+     *                        that bypassed Gradle resource processing). Falls back
+     *                        to "dev" as the displayed version string.
+     */
+    public AboutWindowAlert(SimpleWebRedirectionService webRedirectionService, BuildProperties buildProperties) {
         super(AlertType.INFORMATION);
+        setHeaderText(null);
 
-        Label aboutLabel1 = new Label(ABOUT_MUSICOTT_FIRST_LINE);
+        String version = (buildProperties != null) ? buildProperties.getVersion() : "dev";
+        String firstLine = "Version " + version + ".\nCopyright © 2015-"
+            + Year.now().getValue() + "\nOctavio Calleya.";
+
+        Label aboutLabel1 = new Label(firstLine);
         Label aboutLabel2 = new Label(ABOUT_MUSICOTT_SECOND_LINE);
         Hyperlink githubLink = new Hyperlink(GITHUB_URL);
         githubLink.setOnAction(event -> webRedirectionService.navigateToGithub());
         FlowPane flowPane = new FlowPane();
         flowPane.getChildren().addAll(aboutLabel1, githubLink, aboutLabel2);
-        getDialogPane().contentProperty().set(flowPane);
-        setGraphic(new ImageView(ApplicationImage.ABOUT_IMAGE.get()));
+        ImageView logo = new ImageView(ApplicationImage.ABOUT_IMAGE.get());
+        VBox content = new VBox(logo, flowPane);
+        content.setAlignment(Pos.TOP_CENTER);
+        getDialogPane().contentProperty().set(content);
+        setGraphic(null);
 
-        setContentText("");
         setTitle("About Musicott");
+        setOnShown(event -> {
+            if (getDialogPane().getScene().getWindow() instanceof Stage stage) {
+                stage.getIcons().add(ApplicationImage.APP_ICON.get());
+            }
+        });
     }
 }

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/AlertFactory.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/AlertFactory.java
@@ -5,7 +5,9 @@ import javafx.scene.control.Dialog;
 import javafx.scene.control.MenuBar;
 import net.transgressoft.commons.music.itunes.ImportResult;
 import net.transgressoft.musicott.services.SimpleWebRedirectionService;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Component;
 
 /**
@@ -17,14 +19,17 @@ import org.springframework.stereotype.Component;
 public class AlertFactory {
 
     private final SimpleWebRedirectionService webRedirectionService;
+    private final ObjectProvider<BuildProperties> buildPropertiesProvider;
 
     @Autowired
-    public AlertFactory(SimpleWebRedirectionService webRedirectionService) {
+    public AlertFactory(SimpleWebRedirectionService webRedirectionService,
+                        ObjectProvider<BuildProperties> buildPropertiesProvider) {
         this.webRedirectionService = webRedirectionService;
+        this.buildPropertiesProvider = buildPropertiesProvider;
     }
 
     public Alert aboutWindowAlert() {
-        return new AboutWindowAlert(webRedirectionService);
+        return new AboutWindowAlert(webRedirectionService, buildPropertiesProvider.getIfAvailable());
     }
 
     /**


### PR DESCRIPTION
## Summary

Two bug fixes against the About dialog plus UAT-driven layout polish, packaged as one commit.

- **#37 BUG-ABOUT-01** — the dialog rendered a stray "Message" label inherited from `Alert.INFORMATION` and a `\0` (null character) collapsed the second-line text.
- **#38 BUG-ABOUT-02** — the dialog showed a hardcoded `Version 0.11` / `2020` literal instead of the project's actual version sourced from the `axion-release` plugin output.
- **UAT polish** — repositions the Musicott logo on top of the text and sets the application icon on the dialog window.

## Changes

### Stray "Message" label and line-break typo

- `setHeaderText(null)` collapses the inherited `Alert.INFORMATION` content-text affordance.
- The seam of the second info string (`includes\0software`) is replaced with a single space, so the rendered second line reads naturally.

### Runtime version from `BuildProperties`

- `build.gradle` adds a top-level `springBoot { buildInfo() }` block. The Spring Boot Gradle plugin generates `META-INF/build-info.properties` from `project.version` (already wired to `scmVersion.version` from the `axion-release` plugin), so Spring auto-configures a `BuildProperties` bean at startup.
- `AlertFactory` now takes `ObjectProvider<BuildProperties>` and threads `getIfAvailable()` through to `AboutWindowAlert`.
- `AboutWindowAlert`'s constructor accepts a nullable `BuildProperties` and computes the first information line at dialog construction:

  ```
  Version <buildProperties.getVersion()>.
  Copyright © 2015-<currentYear>
  Octavio Calleya.
  ```

  When `BuildProperties` is unavailable (e.g. an IDE invocation that bypasses Gradle resource processing) it falls back to `"dev"` instead of throwing. The hardcoded `Version 0.11` / `2020` literal is removed; `Year.now()` is evaluated at dialog-open time so the copyright bound rolls over without a build.

### UAT polish — layout and icon

- The Musicott logo now sits on top of the text inside a `VBox` content node (logo + FlowPane), replacing the side-rendered `Alert` graphic.
- `setOnShown(...)` adds `ApplicationImage.APP_ICON` to the dialog Stage's icons so the About window matches the rest of the application (mirrors the pattern in `EditController`).

## Verification

- New `AboutWindowAlertIT` integration test boots a Spring context with a stub `BuildProperties("1.0.0-test")` bean and asserts the whole rendered state in one pass: header suppressed, no descendant `"Message"` label, `VBox` content with `ImageView` on top, `FlowPane` composition (version label, GitHub hyperlink, license label), version text starts with `"Version 1.0.0-test.\nCopyright © 2015-{currentYear}"`, hyperlink wired to `SimpleWebRedirectionService.GITHUB_URL`, license label contains `"includes software"` (proves the `\0` fix), and the application icon is present on the dialog stage.
- `gradle test integrationTest` GREEN — no cross-suite regressions.
- Manual UAT performed against `gradle run` confirms the dialog renders correctly with logo on top and the application icon in the title bar.

Closes #37, #38