### PR TITLE
Artist view live cover refresh and multi-disc album layout

### DIFF
--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.beans.property.*;
 import javafx.beans.value.WritableObjectValue;
 import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
@@ -246,7 +247,11 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
         waitForFxEvents();
 
         ArtistAlbumListRow row = albumsListView.getItems().get(0);
-        assertThat(track.getCoverImageProperty().get().isPresent()).isTrue();
+        Node coverNode = row.lookup("#coverImageView");
+        assertThat(coverNode).isInstanceOf(ImageView.class);
+        ImageView renderedCover = (ImageView) coverNode;
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> renderedCover.getImage() == coverImage);
+        assertThat(renderedCover.getImage()).isSameAs(coverImage);
     }
 
     @Test
@@ -301,6 +306,8 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
 
     private static byte[] loadTestImageBytes() throws IOException {
         try (var stream = ArtistViewControllerIT.class.getResourceAsStream("/images/default-cover-image.png")) {
+            if (stream == null)
+                throw new IOException("Missing test resource: /images/default-cover-image.png");
             return stream.readAllBytes();
         }
     }

--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
@@ -2,6 +2,8 @@ package net.transgressoft.musicott.view;
 
 import javafx.application.Platform;
 import javafx.beans.property.*;
+import javafx.beans.value.WritableObjectValue;
+import javafx.scene.image.Image;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
@@ -36,6 +38,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.testfx.api.FxRobot;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -207,6 +212,99 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
         assertThat(artistsListView.getSelectionModel().getSelectedItem()).isSameAs(artistsListView.getItems().get(0));
     }
 
+    @Test
+    @DisplayName("ArtistViewController refreshes album row cover image after track cover art is updated")
+    void refreshesAlbumRowCoverImageAfterTrackCoverArtIsUpdated(FxRobot fxRobot) throws Exception {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track = audioItem("Kiara", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo));
+
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            audioItemsProperty.clear();
+            audioItemsProperty.add(track);
+            artistsProperty.add(bonobo);
+        });
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        ListView<ArtistAlbumListRow> albumsListView = fxRobot.lookup("#albumsListView").queryAs(ListView.class);
+
+        Platform.runLater(() -> artistsListView.getSelectionModel().select(bonobo));
+        waitForDisplayedTitle(albumsListView, "Kiara");
+
+        byte[] coverBytes = loadTestImageBytes();
+        // coverImageProperty is declared ReadOnlyObjectProperty but backed by a SimpleObjectProperty
+        // in TestObservableAudioItem — cast to WritableObjectValue to inject a cover image directly.
+        @SuppressWarnings("unchecked")
+        WritableObjectValue<Optional<Image>> writableCover =
+                (WritableObjectValue<Optional<Image>>) track.getCoverImageProperty();
+        Image coverImage = new Image(new ByteArrayInputStream(coverBytes));
+        Platform.runLater(() -> writableCover.set(Optional.of(coverImage)));
+
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () ->
+                track.getCoverImageProperty().get().isPresent());
+        waitForFxEvents();
+
+        ArtistAlbumListRow row = albumsListView.getItems().get(0);
+        assertThat(track.getCoverImageProperty().get().isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ArtistViewController creates one album row per disc for multi-disc albums")
+    void createsOneAlbumRowPerDiscForMultiDiscAlbums(FxRobot fxRobot) throws Exception {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem disc1Track = audioItem("Kiara", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo), 1);
+        ObservableAudioItem disc2Track = audioItem("Stay the Same", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo), 2);
+
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            audioItemsProperty.clear();
+            audioItemsProperty.addAll(disc1Track, disc2Track);
+            artistsProperty.add(bonobo);
+        });
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        ListView<ArtistAlbumListRow> albumsListView = fxRobot.lookup("#albumsListView").queryAs(ListView.class);
+
+        Platform.runLater(() -> artistsListView.getSelectionModel().select(bonobo));
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> albumsListView.getItems().size() == 2);
+        waitForFxEvents();
+
+        assertThat(albumsListView.getItems()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("ArtistViewController creates one album row for single-disc albums")
+    void createsOneAlbumRowForSingleDiscAlbums(FxRobot fxRobot) throws Exception {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track1 = audioItem("Kiara", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo), 1);
+        ObservableAudioItem track2 = audioItem("Kong", bonobo, "Black Sands", bonobo, 2, Set.of(bonobo), 1);
+
+        Platform.runLater(() -> {
+            artistsProperty.clear();
+            audioItemsProperty.clear();
+            audioItemsProperty.addAll(track1, track2);
+            artistsProperty.add(bonobo);
+        });
+        waitForFxEvents();
+
+        ListView<Artist> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        ListView<ArtistAlbumListRow> albumsListView = fxRobot.lookup("#albumsListView").queryAs(ListView.class);
+
+        Platform.runLater(() -> artistsListView.getSelectionModel().select(bonobo));
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> albumsListView.getItems().size() == 1);
+        waitForFxEvents();
+
+        assertThat(albumsListView.getItems()).hasSize(1);
+    }
+
+    private static byte[] loadTestImageBytes() throws IOException {
+        try (var stream = ArtistViewControllerIT.class.getResourceAsStream("/images/default-cover-image.png")) {
+            return stream.readAllBytes();
+        }
+    }
+
     private static void waitForDisplayedTitle(ListView<ArtistAlbumListRow> albumsListView, String title) throws Exception {
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> displayedTitles(albumsListView).contains(title));
         waitForFxEvents();
@@ -226,6 +324,17 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
             Artist albumArtist,
             int trackNumber,
             Set<Artist> artistsInvolved) {
+        return audioItem(title, artist, albumName, albumArtist, trackNumber, artistsInvolved, 1);
+    }
+
+    private static ObservableAudioItem audioItem(
+            String title,
+            Artist artist,
+            String albumName,
+            Artist albumArtist,
+            int trackNumber,
+            Set<Artist> artistsInvolved,
+            int discNumber) {
         return FxAudioItemTestFactory.createFxAudioItem(attributes -> {
             attributes.setTitle(title);
             attributes.setArtist(artist);
@@ -236,7 +345,7 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
                     null,
                     Label.of("Test Label")));
             attributes.setTrackNumber((short) trackNumber);
-            attributes.setDiscNumber((short) 1);
+            attributes.setDiscNumber((short) discNumber);
         }, artistsInvolved);
     }
 }

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -151,8 +151,8 @@ public class ArtistViewController {
     }
 
     private void refreshAlbumRowsForArtist(Artist artist) {
-        var albumSets = albumSetsForArtist(artist);
-        Runnable refresh = () -> replaceAlbumRowsForArtist(artist, albumSets);
+        var albumSetsWithDisc = albumSetsForArtist(artist);
+        Runnable refresh = () -> replaceAlbumRowsForArtist(artist, albumSetsWithDisc);
         if (Platform.isFxApplicationThread()) {
             refresh.run();
         } else {
@@ -160,12 +160,12 @@ public class ArtistViewController {
         }
     }
 
-    private void replaceAlbumRowsForArtist(Artist artist, Set<AlbumSet<ObservableAudioItem>> albumSets) {
+    private void replaceAlbumRowsForArtist(Artist artist, Map<AlbumSet<ObservableAudioItem>, Integer> albumSetsWithDisc) {
         albumListRowMap.clear();
         albumRowsBackingList.clear();
-        albumSets.forEach(albumSet -> {
+        albumSetsWithDisc.forEach((albumSet, discNum) -> {
             var audioItemsTableView = applicationContext.getBean(SimpleAudioItemTableView.class);
-            var artistListRow = applicationContext.getBean(ArtistAlbumListRow.class, artist, albumSet, audioItemsTableView);
+            var artistListRow = applicationContext.getBean(ArtistAlbumListRow.class, artist, albumSet, audioItemsTableView, discNum);
             artistListRow.filterTracksByQuery(currentSearchQuery);
             albumListRowMap.put(albumSet, artistListRow);
             albumRowsBackingList.add(artistListRow);
@@ -174,19 +174,56 @@ public class ArtistViewController {
         totalAlbumsLabel.setText(getAlbumString());
     }
 
-    Set<AlbumSet<ObservableAudioItem>> albumSetsForArtist(Artist artist) {
-        var albumAudioItems = audioItemsForArtist(artist)
-                .filter(audioItem -> audioItem.getAlbum() != null && audioItem.getAlbum().getName() != null)
-                .collect(Collectors.groupingBy(
-                        audioItem -> audioItem.getAlbum().getName(),
-                        TreeMap::new,
-                        Collectors.toList()));
-        if (!albumAudioItems.isEmpty()) {
-            return albumAudioItems.entrySet().stream()
-                    .map(entry -> new AlbumView<ObservableAudioItem>(entry.getKey(), entry.getValue()))
-                    .collect(Collectors.toCollection(TreeSet::new));
+    /**
+     * Builds an ordered map of album sets to disc numbers for the given artist. Multi-disc albums
+     * produce one entry per distinct disc number; single-disc albums produce one entry with disc
+     * number {@code 0} (no disc label rendered).
+     */
+    Map<AlbumSet<ObservableAudioItem>, Integer> albumSetsForArtist(Artist artist) {
+        record AlbumDiscKey(String albumName, int disc) implements Comparable<AlbumDiscKey> {
+            @Override
+            public int compareTo(AlbumDiscKey other) {
+                int cmp = albumName.compareTo(other.albumName);
+                return cmp != 0 ? cmp : Integer.compare(disc, other.disc);
+            }
         }
-        return Set.of();
+
+        var tracks = audioItemsForArtist(artist)
+                .filter(audioItem -> audioItem.getAlbum() != null && audioItem.getAlbum().getName() != null)
+                .collect(Collectors.toList());
+        if (tracks.isEmpty()) {
+            return Map.of();
+        }
+
+        // Detect which album names have more than one distinct normalized disc number
+        var multiDiscAlbums = tracks.stream()
+                .collect(Collectors.groupingBy(t -> t.getAlbum().getName()))
+                .entrySet().stream()
+                .filter(e -> e.getValue().stream()
+                        .map(t -> normalizeDisc(t.getDiscNumber()))
+                        .distinct().count() > 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
+        // Group by composite (albumName, disc): multi-disc albums split per disc, single-disc use disc=0
+        var grouped = tracks.stream().collect(Collectors.groupingBy(
+                t -> new AlbumDiscKey(
+                        t.getAlbum().getName(),
+                        multiDiscAlbums.contains(t.getAlbum().getName()) ? normalizeDisc(t.getDiscNumber()) : 0),
+                TreeMap::new,
+                Collectors.toList()));
+
+        // Build result map preserving TreeMap order: AlbumSet → disc number (0 = no label)
+        var result = new LinkedHashMap<AlbumSet<ObservableAudioItem>, Integer>();
+        grouped.forEach((key, items) ->
+                result.put(new AlbumView<>(key.albumName(), items), key.disc()));
+        return result;
+    }
+
+    private static int normalizeDisc(Number discNumber) {
+        if (discNumber == null) return 1;
+        int v = discNumber.intValue();
+        return v <= 0 ? 1 : v;
     }
 
     // getAudioItemsProperty() is nominally non-null, but partial or mock-backed repositories can
@@ -233,9 +270,12 @@ public class ArtistViewController {
     }
 
     private String getAlbumString() {
-        int numberOfTrackSets = albumRowsBackingList.size();
-        var appendix = numberOfTrackSets == 1 ? " album" : " albums";
-        return numberOfTrackSets + appendix;
+        long numberOfAlbums = albumRowsBackingList.stream()
+                .map(row -> row.getAlbumSet().getAlbumName())
+                .distinct()
+                .count();
+        var appendix = numberOfAlbums == 1 ? " album" : " albums";
+        return numberOfAlbums + appendix;
     }
 
     /**
@@ -275,7 +315,9 @@ public class ArtistViewController {
             artistsListView.scrollTo(newArtist);
         } else {
             albumRowsBackingList.forEach(trackSet -> {
-                if (trackSet.getAlbumSet().getAlbumName().equals(audioItem.getAlbum().getName())) {
+                boolean sameAlbum = trackSet.getAlbumSet().getAlbumName().equals(audioItem.getAlbum().getName());
+                boolean containsItem = trackSet.getAlbumSet().stream().anyMatch(item -> item.equals(audioItem));
+                if (sameAlbum && containsItem) {
                     trackSet.selectAudioItem(audioItem);
                     albumsListView.scrollTo(trackSet);
                 } else {
@@ -400,9 +442,9 @@ public class ArtistViewController {
         protected void updateItem(Artist item, boolean empty) {
             super.updateItem(item, empty);
             if (empty || item == null)
-                Platform.runLater(() -> setGraphic(null));
+                setGraphic(null);
             else
-                Platform.runLater(() -> setGraphic(new Label(item.getName())));
+                setGraphic(new Label(item.getName()));
         }
     }
 }

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -315,7 +315,9 @@ public class ArtistViewController {
             artistsListView.scrollTo(newArtist);
         } else {
             albumRowsBackingList.forEach(trackSet -> {
-                boolean sameAlbum = trackSet.getAlbumSet().getAlbumName().equals(audioItem.getAlbum().getName());
+                var album = audioItem.getAlbum();
+                boolean sameAlbum = album != null
+                        && trackSet.getAlbumSet().getAlbumName().equals(album.getName());
                 boolean containsItem = trackSet.getAlbumSet().stream().anyMatch(item -> item.equals(audioItem));
                 if (sameAlbum && containsItem) {
                     trackSet.selectAudioItem(audioItem);

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -102,6 +102,7 @@ public class ArtistAlbumListRow extends HBox {
 
     private void placeLeftVBox() {
         coverImageView = new ImageView();
+        coverImageView.setId("coverImageView");
         coverImageView.setFitWidth(COVER_SIZE);
         coverImageView.setFitHeight(COVER_SIZE);
         updateAudioItemsImage();
@@ -193,7 +194,8 @@ public class ArtistAlbumListRow extends HBox {
     @SuppressWarnings("java:S2589")
     private void updateAlbumLabelLabel() {
         var labelString = containedAudioItems.stream()
-                .filter(entry -> entry.getAlbum().getLabel() != null
+                .filter(entry -> entry.getAlbum() != null
+                        && entry.getAlbum().getLabel() != null
                         && entry.getAlbum().getLabel().getName() != null
                         && !entry.getAlbum().getLabel().getName().isEmpty())
                 .map(entry -> entry.getAlbum().getLabel().getName())

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -18,13 +18,22 @@ import net.transgressoft.musicott.view.custom.ApplicationImage;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import org.fxmisc.easybind.Subscription;
 
 import static org.fxmisc.easybind.EasyBind.map;
 import static org.fxmisc.easybind.EasyBind.subscribe;
 
 /**
+ * A row in the artist albums list view that displays a single album (or a single disc of a
+ * multi-disc album) together with its embedded track table. When {@code discNumber > 0} the row
+ * renders a "Disc N" header label above the album title to distinguish disc sections within the
+ * same album.
+ *
  * @author Octavio Calleya
  */
 @Component
@@ -36,11 +45,14 @@ public class ArtistAlbumListRow extends HBox {
 
     private final Artist artist;
     private final AlbumSet<ObservableAudioItem> albumSet;
+    private final int discNumber;
     private final ListProperty<ObservableAudioItem> selectedAudioItemsProperty;
     private final ObservableList<ObservableAudioItem> containedAudioItems;
     private final FilteredList<ObservableAudioItem> filteredAudioItems;
     private final ListProperty<ObservableAudioItem> containedAudioItemsProperty;
     private final SimpleAudioItemTableView audioItemsTableView;
+
+    private final List<Subscription> subscriptions = new ArrayList<>();
 
     private ImageView coverImageView;
     private VBox albumInfoVBox;
@@ -49,11 +61,21 @@ public class ArtistAlbumListRow extends HBox {
     private Label yearLabel;
     private Label relatedArtistsLabel;
 
-    public ArtistAlbumListRow(Artist artist, AlbumSet<ObservableAudioItem> albumSet, SimpleAudioItemTableView audioItemsTableView) {
+    /**
+     * Creates a new album list row.
+     *
+     * @param artist             the artist owning this album row
+     * @param albumSet           the set of audio items belonging to this album (or disc)
+     * @param audioItemsTableView the embedded track table view
+     * @param discNumber         the 1-based disc number for multi-disc albums; {@code 0} means
+     *                           single-disc (no disc label rendered)
+     */
+    public ArtistAlbumListRow(Artist artist, AlbumSet<ObservableAudioItem> albumSet, SimpleAudioItemTableView audioItemsTableView, int discNumber) {
         super();
         this.artist = artist;
         this.albumSet = albumSet;
         this.audioItemsTableView = audioItemsTableView;
+        this.discNumber = discNumber;
         containedAudioItems = FXCollections.observableArrayList(albumSet);
         containedAudioItems.sort(this::audioItemComparator);
         filteredAudioItems = new FilteredList<>(containedAudioItems);
@@ -73,6 +95,9 @@ public class ArtistAlbumListRow extends HBox {
         setArtistColumn();
         selectedAudioItemsProperty = new SimpleListProperty<>(this, "selected artist tracks");
         selectedAudioItemsProperty.bind(new SimpleObjectProperty<>(audioItemsTableView.getSelectionModel().getSelectedItems()));
+        sceneProperty().addListener((obs, oldScene, newScene) -> {
+            if (newScene == null) subscriptions.forEach(Subscription::unsubscribe);
+        });
     }
 
     private void placeLeftVBox() {
@@ -122,6 +147,11 @@ public class ArtistAlbumListRow extends HBox {
         buildSimpleTableView();
 
         albumInfoVBox = new VBox(albumTitleLabel, genresLabel, audioItemsTableView);
+        if (discNumber > 0) {
+            var discLabel = new Label("Disc " + discNumber);
+            discLabel.setId("discLabel");
+            albumInfoVBox.getChildren().add(1, discLabel);
+        }
         VBox.setVgrow(audioItemsTableView, Priority.ALWAYS);
         HBox.setHgrow(albumInfoVBox, Priority.SOMETIMES);
         HBox.setMargin(albumInfoVBox, new Insets(20, 20, 5, 0));
@@ -134,9 +164,10 @@ public class ArtistAlbumListRow extends HBox {
                 .collect(Collectors.toSet()));
     }
 
+    @SuppressWarnings("java:S2589")
     private String buildYearsString() {
         return containedAudioItems.stream()
-                .filter(track -> track.getAlbum().getYear() != null)
+                .filter(track -> track.getAlbum() != null && track.getAlbum().getYear() != null)
                 .map(track -> String.valueOf(track.getAlbum().getYear()))
                 .sorted()
                 .collect(Collectors.joining(", "));
@@ -157,9 +188,14 @@ public class ArtistAlbumListRow extends HBox {
                 });
     }
 
+    // Defensive null guards — tracks imported without a label tag carry null Album.getLabel()
+    // or null Label.getName(); one untagged track must not NPE the entire row render.
+    @SuppressWarnings("java:S2589")
     private void updateAlbumLabelLabel() {
         var labelString = containedAudioItems.stream()
-                .filter(entry -> ! entry.getAlbum().getLabel().getName().isEmpty())
+                .filter(entry -> entry.getAlbum().getLabel() != null
+                        && entry.getAlbum().getLabel().getName() != null
+                        && !entry.getAlbum().getLabel().getName().isEmpty())
                 .map(entry -> entry.getAlbum().getLabel().getName())
                 .collect(Collectors.joining(", "));
 
@@ -270,18 +306,19 @@ public class ArtistAlbumListRow extends HBox {
      * @return The {@link IntegerProperty} of the audioItem number
      */
     private ReadOnlyIntegerProperty listenAudioItemChangesAndSort(ObservableAudioItem audioItem) {
-        subscribe(audioItem.getTrackNumberProperty(), tn -> containedAudioItems.sort(this::audioItemComparator));
-        subscribe(audioItem.getDiscNumberProperty(), dn -> containedAudioItems.sort(this::audioItemComparator));
-        subscribe(audioItem.getGenresProperty(), g -> genresLabel.setText(buildGenresString()));
-        subscribe(audioItem.getAlbumProperty(), y -> {
+        subscriptions.add(subscribe(audioItem.getTrackNumberProperty(), tn -> containedAudioItems.sort(this::audioItemComparator)));
+        subscriptions.add(subscribe(audioItem.getDiscNumberProperty(), dn -> containedAudioItems.sort(this::audioItemComparator)));
+        subscriptions.add(subscribe(audioItem.getGenresProperty(), g -> genresLabel.setText(buildGenresString())));
+        subscriptions.add(subscribe(audioItem.getAlbumProperty(), y -> {
             yearLabel.setText(buildYearsString());
             updateAlbumLabelLabel();
-        });
-        subscribe(audioItem.getArtistsInvolvedProperty(), ai ->
+        }));
+        subscriptions.add(subscribe(audioItem.getArtistsInvolvedProperty(), ai ->
                 Platform.runLater(() -> {
                     setRelatedArtistsLabel();
                     setArtistColumn();
-                }));
+                })));
+        subscriptions.add(subscribe(audioItem.getCoverImageProperty(), _ -> Platform.runLater(this::updateAudioItemsImage)));
         return audioItem.getTrackNumberProperty();
     }
 

--- a/src/test/java/net/transgressoft/musicott/view/ArtistViewControllerTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/ArtistViewControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,11 +54,11 @@ class ArtistViewControllerTest {
 
         var controller = new ArtistViewController(audioLibrary, mock(ApplicationContext.class));
 
-        assertThat(controller.albumSetsForArtist(akkya))
+        assertThat(controller.albumSetsForArtist(akkya).keySet())
                 .singleElement()
                 .satisfies(albumSet -> {
                     assertThat(albumSet.getAlbumName()).isEqualTo("Diffusion 7.0");
-                    assertThat((java.util.List<ObservableAudioItem>) albumSet).containsExactly(akkyaTrack);
+                    assertThat((List<ObservableAudioItem>) albumSet).containsExactly(akkyaTrack);
                 });
     }
 

--- a/src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java
@@ -113,6 +113,8 @@ class ArtistViewControllerUIT extends ApplicationTestBase<SplitPane> {
         ObservableAudioItem disc2Track = audioItem("Stay the Same", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo), 2);
 
         Platform.runLater(() -> {
+            audioItemsProperty.clear();
+            artistsProperty.clear();
             audioItemsProperty.addAll(disc1Track, disc2Track);
             artistsProperty.add(bonobo);
         });

--- a/src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java
@@ -105,6 +105,31 @@ class ArtistViewControllerUIT extends ApplicationTestBase<SplitPane> {
         assertThat(fxRobot.lookup("Kiara").tryQuery()).isEmpty();
     }
 
+    @Test
+    @DisplayName("multi-disc album rows show a Disc N label for each disc section")
+    void multiDiscAlbumRowsShowDiscLabelForEachDiscSection(FxRobot fxRobot) throws Exception {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem disc1Track = audioItem("Kiara", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo), 1);
+        ObservableAudioItem disc2Track = audioItem("Stay the Same", bonobo, "Black Sands", bonobo, 1, Set.of(bonobo), 2);
+
+        Platform.runLater(() -> {
+            audioItemsProperty.addAll(disc1Track, disc2Track);
+            artistsProperty.add(bonobo);
+        });
+        waitForFxEvents();
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS,
+                () -> fxRobot.lookup("Bonobo").tryQuery().isPresent());
+
+        fxRobot.clickOn("Bonobo");
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS,
+                () -> fxRobot.lookup("Disc 1").tryQuery().isPresent()
+                        && fxRobot.lookup("Disc 2").tryQuery().isPresent());
+        waitForFxEvents();
+
+        assertThat(fxRobot.lookup("Disc 1").tryQuery()).isPresent();
+        assertThat(fxRobot.lookup("Disc 2").tryQuery()).isPresent();
+    }
+
     private static void waitForTrackText(FxRobot fxRobot, String title) throws Exception {
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> fxRobot.lookup(title).tryQuery().isPresent());
         waitForFxEvents();
@@ -117,6 +142,17 @@ class ArtistViewControllerUIT extends ApplicationTestBase<SplitPane> {
             Artist albumArtist,
             int trackNumber,
             Set<Artist> artistsInvolved) {
+        return audioItem(title, artist, albumName, albumArtist, trackNumber, artistsInvolved, 1);
+    }
+
+    private static ObservableAudioItem audioItem(
+            String title,
+            Artist artist,
+            String albumName,
+            Artist albumArtist,
+            int trackNumber,
+            Set<Artist> artistsInvolved,
+            int discNumber) {
         return FxAudioItemTestFactory.createFxAudioItem(attributes -> {
             attributes.setTitle(title);
             attributes.setArtist(artist);
@@ -127,7 +163,7 @@ class ArtistViewControllerUIT extends ApplicationTestBase<SplitPane> {
                     null,
                     Label.of("Test Label")));
             attributes.setTrackNumber((short) trackNumber);
-            attributes.setDiscNumber((short) 1);
+            attributes.setDiscNumber((short) discNumber);
         }, artistsInvolved);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two remaining artist-view correctness and clarity gaps: album rows now refresh their displayed artwork live when track cover art changes (no manual refresh), and multi-disc albums render as distinct per-disc sections while single-disc albums keep their simpler presentation.

Closes #52 and #53.

## Changes

### Live album-row cover refresh
`ArtistAlbumListRow` subscribes to `coverImageProperty` via EasyBind inside `listenAudioItemChangesAndSort`; the handler re-renders the row artwork on the FX thread through `Platform.runLater`. No manual refresh action is required.

- `src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java`
- `src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java`

### Multi-disc album split
`ArtistViewController.albumSetsForArtist` groups by a composite `(albumName, normalizedDisc)` key (returning `Map<AlbumSet, Integer>` to thread the disc number to row construction). `ArtistAlbumListRow` takes a `discNumber` constructor parameter and renders a `Disc N` header label only when `discNumber > 0`. Single-disc albums are unchanged (`disc=0`, no label). Disc normalization (null/0 → 1) matches the existing comparator.

- `src/main/java/net/transgressoft/musicott/view/ArtistViewController.java`
- `src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java`
- `src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java`
- `src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java`

### Hardening
- Null guards in `updateAlbumLabelLabel` and `buildYearsString` (FX-thread NPE risk)
- EasyBind subscriptions now stored and cancelled on scene detach (subscription-leak fix)
- `getAlbumString()` counts distinct album names, not disc rows
- Removed stale-graphic `Platform.runLater` deferral in `ArtistCell.updateItem`
- `findAudioItemInArtistViewAndSelect` matches by item membership so multi-disc rows resolve to the correct disc

## Testing

- New: 3 integration tests + 1 UI test covering live cover refresh and multi-disc grouping
- Full `integrationTest` and `uiTest` suites pass (no regressions)
- Manual check suggested: confirm disc-section label legibility in a multi-disc album in the Artist view

🤖 Generated with [Claude Code](https://claude.com/claude-code)
