### PR TITLE
Implement shuffle / random playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After years of this refactoring and redesign work, in April 2026 I moved the old
 - **Guided iTunes import** — a four-step wizard walks you through picking the `iTunes Library.xml`, choosing which playlists to bring across, deciding how metadata is read (file tags vs the iTunes database) and whether play counts and tag write-back are preserved, then confirming before import starts
 - **Player-bar queue popover** — the play queue opens from the player bar as a popover anchored to the queue button, keeping queue and history actions close to playback controls while dismissing itself when you click elsewhere or leave the app window
 - **Hierarchical playlists** — folders of playlists, drag-and-drop reordering, and full-text search across titles, artists, involved artists, albums, labels, and comments
-- **Contextual random playback** — pressing play with an empty queue or clicking the shuffle button starts random playback from whatever is in view: all tracks, the selected playlist, or no-op with a status message when no playable tracks exist
+- **Contextual random playback** — pressing play with an empty queue or clicking shuffle starts random playback from the active view (all tracks, the selected playlist, or the selected artist), with a status message when no playable tracks exist
 - **Waveform visualization** — generated once per track, cached locally, and used for visual seeking during playback
 - **Native installers** for Linux (AppImage / AUR), Windows, and macOS — no JDK install required by end users
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ After years of this refactoring and redesign work, in April 2026 I moved the old
 - **Guided iTunes import** — a four-step wizard walks you through picking the `iTunes Library.xml`, choosing which playlists to bring across, deciding how metadata is read (file tags vs the iTunes database) and whether play counts and tag write-back are preserved, then confirming before import starts
 - **Player-bar queue popover** — the play queue opens from the player bar as a popover anchored to the queue button, keeping queue and history actions close to playback controls while dismissing itself when you click elsewhere or leave the app window
 - **Hierarchical playlists** — folders of playlists, drag-and-drop reordering, and full-text search across titles, artists, involved artists, albums, labels, and comments
+- **Contextual random playback** — pressing play with an empty queue or clicking the shuffle button starts random playback from whatever is in view: all tracks, the selected playlist, or no-op with a status message when no playable tracks exist
 - **Waveform visualization** — generated once per track, cached locally, and used for visual seeking during playback
 - **Native installers** for Linux (AppImage / AUR), Windows, and macOS — no JDK install required by end users
 

--- a/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceStorageIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceStorageIT.java
@@ -6,6 +6,7 @@ import net.transgressoft.commons.music.player.AudioItemPlayer;
 import net.transgressoft.commons.music.player.UnsupportedAudioPlaybackException;
 import net.transgressoft.musicott.events.AudioItemChangedEvent;
 import net.transgressoft.musicott.events.ErrorEvent;
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
 import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
 
 import javafx.beans.property.SimpleIntegerProperty;
@@ -262,6 +263,65 @@ class PlayerServiceStorageIT {
         verify(applicationEventPublisher).publishEvent(Mockito.any(ErrorEvent.class));
         verify(applicationEventPublisher, never()).publishEvent(any(AudioItemChangedEvent.class));
         assertThat(playerService.currentTrack()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("playRandom populates the queue with shuffled playable items and starts playback")
+    void playRandomPopulatesQueueWithShuffledPlayableItemsAndStartsPlayback() throws Exception {
+        ObservableAudioItem itemA = newPlayableAudioItem("A");
+        ObservableAudioItem itemB = newPlayableAudioItem("B");
+        ObservableAudioItem itemC = newPlayableAudioItem("C");
+
+        // next() inside playRandom constructs FXAudioItemPlayer — intercept to avoid native media init.
+        try (MockedConstruction<FXAudioItemPlayer> ignored = Mockito.mockConstruction(FXAudioItemPlayer.class,
+                (mock, context) -> {
+                    Mockito.doNothing().when(mock).play(Mockito.any());
+                    Mockito.when(mock.getStatusProperty())
+                            .thenReturn(new SimpleObjectProperty<>(AudioItemPlayer.Status.UNKNOWN));
+                })) {
+            playerService.playRandom(List.of(itemA, itemB, itemC));
+        }
+
+        // All three playable items must be in the queue (one was popped by next() into currentTrack).
+        int queueSize = playerService.getPlayQueueList().size();
+        assertThat(queueSize).isEqualTo(2);
+        assertThat(playerService.currentTrack()).isPresent();
+    }
+
+    @Test
+    @DisplayName("playRandom publishes StatusMessageUpdateEvent when pool is empty")
+    void playRandomPublishesStatusMessageUpdateEventWhenPoolIsEmpty() {
+        playerService.playRandom(List.of());
+
+        verify(applicationEventPublisher).publishEvent(any(StatusMessageUpdateEvent.class));
+        assertThat(playerService.getPlayQueueList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("playRandom marks the queue as random so next addToQueue clears it")
+    void playRandomMarksQueueAsRandomSoNextAddToQueueClearsIt() throws Exception {
+        ObservableAudioItem itemRandom = newPlayableAudioItem("Random");
+        ObservableAudioItem itemExplicit = newPlayableAudioItem("Explicit");
+
+        try (MockedConstruction<FXAudioItemPlayer> ignored = Mockito.mockConstruction(FXAudioItemPlayer.class,
+                (mock, context) -> {
+                    Mockito.doNothing().when(mock).play(Mockito.any());
+                    Mockito.when(mock.getStatusProperty())
+                            .thenReturn(new SimpleObjectProperty<>(AudioItemPlayer.Status.UNKNOWN));
+                })) {
+            playerService.playRandom(List.of(itemRandom));
+        }
+
+        // After playRandom the queue is empty (one item was popped by next()) and playingRandom=true.
+        assertThat(playerService.getPlayQueueList()).isEmpty();
+        assertThat((boolean) ReflectionTestUtils.getField(playerService, "playingRandom")).isTrue();
+
+        // An explicit addToQueue must clear the random state and replace the queue.
+        playerService.addToQueue(List.of(itemExplicit));
+
+        assertThat((boolean) ReflectionTestUtils.getField(playerService, "playingRandom")).isFalse();
+        assertThat(playerService.getPlayQueueList()).hasSize(1);
+        assertThat(playerService.getPlayQueueList().get(0).getTrack()).isSameAs(itemExplicit);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
@@ -1,0 +1,308 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.waveform.AudioWaveform;
+import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
+import net.transgressoft.musicott.events.PlayRandomFromContextEvent;
+import net.transgressoft.musicott.service.MediaImportService;
+import net.transgressoft.musicott.services.PlayerService;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+import net.transgressoft.musicott.view.custom.table.ArtistAlbumListRow;
+import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
+import net.transgressoft.musicott.view.custom.table.SimpleAudioItemTableView;
+import net.transgressoft.musicott.view.itunes.ItunesImportWizard;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.ObservableList;
+import javafx.collections.FXCollections;
+import javafx.scene.Node;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.BorderPane;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration tests for contextual random playback dispatched from {@link MainController}.
+ *
+ * <p>Verifies that the {@link PlayRandomFromContextEvent} listener correctly resolves the
+ * active navigation context's item pool and delegates to
+ * {@link PlayerService#playRandom(Collection)}, and that an empty pool does not result
+ * in a call to {@code playRandom} (no silent failure).
+ *
+ * @author Octavio Calleya
+ */
+@JavaFxSpringTest(classes = MainControllerRandomPlaybackITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("MainController random playback")
+class MainControllerRandomPlaybackIT extends ApplicationTestBase<BorderPane> {
+
+    @Autowired
+    FxControllerAndView<MainController, BorderPane> mainControllerAndView;
+
+    @Autowired
+    PlayerService playerService;
+
+    @Autowired
+    NavigationController navigationController;
+
+    @Autowired
+    ArtistViewController artistViewController;
+
+    @Autowired
+    ObservablePlaylistHierarchy playlistRepository;
+
+    @Autowired
+    ObservableAudioLibrary audioLibrary;
+
+    @Autowired
+    ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty;
+
+    @Override
+    protected BorderPane javaFxComponent() {
+        return mainControllerAndView.getView().get();
+    }
+
+    @BeforeEach
+    void resetPlayerServiceMock() {
+        reset(playerService);
+        when(playerService.getPlayQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(playerService.getHistoryQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(playerService.currentTrack()).thenReturn(Optional.empty());
+        when(playerService.getTotalDuration()).thenReturn(java.time.Duration.ZERO);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setNavigationMode(NavigationController.NavigationMode mode) {
+        // Unwrap CGLIB proxy to reach the actual NavigationController fields
+        Object target = AopUtils.isAopProxy(navigationController)
+                ? AopTestUtils.getTargetObject(navigationController)
+                : navigationController;
+        var navProp = (javafx.beans.property.ObjectProperty<NavigationController.NavigationMode>)
+                ReflectionTestUtils.getField(target, "navigationModeProperty");
+        Platform.runLater(() -> navProp.set(mode));
+        waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("PlayRandomFromContextEvent with non-empty ALL_AUDIO_ITEMS library delegates to playerService.playRandom")
+    void playRandomFromContextWithNonEmptyLibraryCallsPlayRandom() {
+        setNavigationMode(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+
+        Platform.runLater(() ->
+                mainControllerAndView.getController().onPlayRandomFromContext(
+                        new PlayRandomFromContextEvent(this)));
+        waitForFxEvents();
+
+        verify(playerService).playRandom(any(Collection.class));
+    }
+
+    @Test
+    @DisplayName("PlayRandomFromContextEvent with PLAYLIST mode delegates to playerService.playRandom with selected playlist items")
+    void playRandomFromContextWithPlaylistModeCallsPlayRandom() {
+        // Ensure a non-empty playlist is selected before entering PLAYLIST mode
+        var libraryItems = (ObservableList<ObservableAudioItem>) audioLibrary.getAudioItemsProperty();
+        var playlist = playlistRepository.createPlaylist("Test Playlist For Random", List.copyOf(libraryItems));
+        Platform.runLater(() -> selectedPlaylistProperty.set(Optional.of(playlist)));
+        waitForFxEvents();
+        setNavigationMode(NavigationController.NavigationMode.PLAYLIST);
+
+        Platform.runLater(() ->
+                mainControllerAndView.getController().onPlayRandomFromContext(
+                        new PlayRandomFromContextEvent(this)));
+        waitForFxEvents();
+
+        verify(playerService).playRandom(any(Collection.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    @DisplayName("PlayRandomFromContextEvent in ARTISTS mode delegates to playerService.playRandom with the selected artist's involved tracks")
+    void playRandomFromContextWithArtistsModeCallsPlayRandom() {
+        // Select the shown artist directly so the ARTISTS context resolves a non-empty pool,
+        // independent of list auto-selection timing.
+        var artist = audioLibrary.getArtistsProperty().iterator().next();
+        Object artistViewTarget = AopUtils.isAopProxy(artistViewController)
+                ? AopTestUtils.getTargetObject(artistViewController)
+                : artistViewController;
+        var selectedArtistProp = (ObjectProperty<Optional<Artist>>)
+                ReflectionTestUtils.getField(artistViewTarget, "selectedArtistProperty");
+        Platform.runLater(() -> selectedArtistProp.set(Optional.of(artist)));
+        waitForFxEvents();
+        setNavigationMode(NavigationController.NavigationMode.ARTISTS);
+
+        Platform.runLater(() ->
+                mainControllerAndView.getController().onPlayRandomFromContext(
+                        new PlayRandomFromContextEvent(this)));
+        waitForFxEvents();
+
+        verify(playerService).playRandom(any(Collection.class));
+    }
+
+    @Test
+    @DisplayName("PlayRandomFromContextEvent with no playlist selected in PLAYLIST mode does not call playerService.playRandom")
+    void playRandomFromContextWithNoPlaylistSelectedDoesNotCallPlayRandom() {
+        setNavigationMode(NavigationController.NavigationMode.PLAYLIST);
+        // No playlist selected → empty context
+
+        Platform.runLater(() ->
+                mainControllerAndView.getController().onPlayRandomFromContext(
+                        new PlayRandomFromContextEvent(this)));
+        waitForFxEvents();
+
+        verify(playerService, never()).playRandom(any(Collection.class));
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                MainController.class,
+                NavigationController.class,
+                PlayerController.class,
+                PlayQueueController.class,
+                ArtistViewController.class,
+                PlaylistTreeView.class,
+                FullAudioItemTableView.class,
+                SimpleAudioItemTableView.class,
+                ArtistAlbumListRow.class
+        })
+})
+class MainControllerRandomPlaybackITConfiguration {
+
+    final ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty =
+            new SimpleObjectProperty<>(this, "selected playlist", Optional.empty());
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioLibrary(FXMusicLibrary musicLibrary) throws IOException {
+        var library = musicLibrary.audioLibrary();
+        // Pre-populate with one track so ALL_AUDIO_ITEMS tests have a non-empty pool
+        Path tempFile = Files.createTempFile("mc-rand-cfg-", ".mp3");
+        tempFile.toFile().deleteOnExit();
+        try (InputStream in = MainControllerRandomPlaybackITConfiguration.class
+                .getResourceAsStream("/testfiles/testeable.mp3")) {
+            Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+        library.createFromFile(tempFile);
+        return library;
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary,
+                                                           ObservableAudioLibrary audioLibrary) throws IOException {
+        var repo = musicLibrary.playlistHierarchy();
+        // Pre-populate a playlist with the library's first item so PLAYLIST tests have a non-empty pool
+        var items = List.copyOf(audioLibrary.getAudioItemsProperty());
+        if (!items.isEmpty()) {
+            var playlist = repo.createPlaylist("Test Playlist", items);
+            selectedPlaylistProperty.set(Optional.of(playlist));
+        }
+        return repo;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return selectedPlaylistProperty;
+    }
+
+    @Bean
+    public PlayerService playerService() {
+        var service = mock(PlayerService.class);
+        when(service.getPlayQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(service.getHistoryQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(service.currentTrack()).thenReturn(Optional.empty());
+        when(service.getTotalDuration()).thenReturn(java.time.Duration.ZERO);
+        return service;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public AudioWaveformRepository<AudioWaveform, ObservableAudioItem> audioWaveformRepository() {
+        return mock(AudioWaveformRepository.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public MediaImportService mediaImportService() {
+        return mock(MediaImportService.class);
+    }
+
+    @Bean
+    public ItunesImportWizard itunesImportWizard() {
+        return mock(ItunesImportWizard.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
@@ -54,10 +54,15 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import org.mockito.ArgumentCaptor;
+
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -129,8 +134,15 @@ class MainControllerRandomPlaybackIT extends ApplicationTestBase<BorderPane> {
         waitForFxEvents();
     }
 
+    @SuppressWarnings("unchecked")
+    private void verifyPlayRandomCalledWith(Collection<ObservableAudioItem> expected) {
+        ArgumentCaptor<Collection<ObservableAudioItem>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(playerService).playRandom(captor.capture());
+        assertEquals(Set.copyOf(expected), Set.copyOf(captor.getValue()));
+    }
+
     @Test
-    @DisplayName("PlayRandomFromContextEvent with non-empty ALL_AUDIO_ITEMS library delegates to playerService.playRandom")
+    @DisplayName("PlayRandomFromContextEvent with non-empty ALL_AUDIO_ITEMS library delegates to playerService.playRandom with the full library")
     void playRandomFromContextWithNonEmptyLibraryCallsPlayRandom() {
         setNavigationMode(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
 
@@ -139,7 +151,7 @@ class MainControllerRandomPlaybackIT extends ApplicationTestBase<BorderPane> {
                         new PlayRandomFromContextEvent(this)));
         waitForFxEvents();
 
-        verify(playerService).playRandom(any(Collection.class));
+        verifyPlayRandomCalledWith(List.copyOf(audioLibrary.getAudioItemsProperty()));
     }
 
     @Test
@@ -147,7 +159,8 @@ class MainControllerRandomPlaybackIT extends ApplicationTestBase<BorderPane> {
     void playRandomFromContextWithPlaylistModeCallsPlayRandom() {
         // Ensure a non-empty playlist is selected before entering PLAYLIST mode
         var libraryItems = (ObservableList<ObservableAudioItem>) audioLibrary.getAudioItemsProperty();
-        var playlist = playlistRepository.createPlaylist("Test Playlist For Random", List.copyOf(libraryItems));
+        var expectedItems = List.copyOf(libraryItems);
+        var playlist = playlistRepository.createPlaylist("Test Playlist For Random", expectedItems);
         Platform.runLater(() -> selectedPlaylistProperty.set(Optional.of(playlist)));
         waitForFxEvents();
         setNavigationMode(NavigationController.NavigationMode.PLAYLIST);
@@ -157,7 +170,7 @@ class MainControllerRandomPlaybackIT extends ApplicationTestBase<BorderPane> {
                         new PlayRandomFromContextEvent(this)));
         waitForFxEvents();
 
-        verify(playerService).playRandom(any(Collection.class));
+        verifyPlayRandomCalledWith(expectedItems);
     }
 
     @Test
@@ -176,12 +189,16 @@ class MainControllerRandomPlaybackIT extends ApplicationTestBase<BorderPane> {
         waitForFxEvents();
         setNavigationMode(NavigationController.NavigationMode.ARTISTS);
 
+        var expectedItems = artistViewController.getSelectedArtistAudioItems();
+        assertEquals(List.copyOf(audioLibrary.getAudioItemsProperty()), expectedItems,
+                "the single-track fixture's only artist should resolve to the full library");
+
         Platform.runLater(() ->
                 mainControllerAndView.getController().onPlayRandomFromContext(
                         new PlayRandomFromContextEvent(this)));
         waitForFxEvents();
 
-        verify(playerService).playRandom(any(Collection.class));
+        verifyPlayRandomCalledWith(expectedItems);
     }
 
     @Test
@@ -228,8 +245,10 @@ class MainControllerRandomPlaybackITConfiguration {
         // Pre-populate with one track so ALL_AUDIO_ITEMS tests have a non-empty pool
         Path tempFile = Files.createTempFile("mc-rand-cfg-", ".mp3");
         tempFile.toFile().deleteOnExit();
-        try (InputStream in = MainControllerRandomPlaybackITConfiguration.class
-                .getResourceAsStream("/testfiles/testeable.mp3")) {
+        try (InputStream in = Objects.requireNonNull(
+                MainControllerRandomPlaybackITConfiguration.class
+                        .getResourceAsStream("/testfiles/testeable.mp3"),
+                "Missing test resource: /testfiles/testeable.mp3")) {
             Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
         }
         library.createFromFile(tempFile);

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlayerControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlayerControllerIT.java
@@ -7,6 +7,7 @@ import net.transgressoft.commons.fx.music.waveform.SeekEvent;
 import net.transgressoft.commons.music.waveform.AudioWaveform;
 import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
 import net.transgressoft.musicott.events.PlayItemEvent;
+import net.transgressoft.musicott.events.PlayRandomFromContextEvent;
 import net.transgressoft.musicott.services.PlayerService;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
@@ -421,6 +422,23 @@ class PlayerControllerIT extends ApplicationTestBase<GridPane> {
         when(audioItem.getPlayCountProperty()).thenReturn(new SimpleIntegerProperty(0));
         when(audioItem.getDuration()).thenReturn(Duration.ofSeconds(5));
         return audioItem;
+    }
+
+    @Test
+    @DisplayName("PlayerController play button with no current track publishes PlayRandomFromContextEvent")
+    void playButtonWithNoCurrentTrackPublishesPlayRandomFromContextEvent() {
+        when(playerService.currentTrack()).thenReturn(Optional.empty());
+
+        Platform.runLater(() -> {
+            ToggleButton playButton = playerControllerAndView.getView().get().lookup("#playButton") instanceof ToggleButton tb ? tb : null;
+            if (playButton != null) {
+                playButton.setSelected(true);
+            }
+            playerControllerAndView.getController().playPause();
+        });
+        waitForFxEvents();
+
+        verify(configuration.applicationEventPublisher()).publishEvent(any(PlayRandomFromContextEvent.class));
     }
 }
 

--- a/src/main/java/net/transgressoft/musicott/events/PlayRandomFromContextEvent.java
+++ b/src/main/java/net/transgressoft/musicott/events/PlayRandomFromContextEvent.java
@@ -1,0 +1,20 @@
+package net.transgressoft.musicott.events;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Signals a request to start random playback from the active navigation context.
+ *
+ * <p>Published by {@code PlayerController} when the play/pause button is pressed
+ * and no track is currently loaded. A listener in {@code MainController} resolves
+ * the context-appropriate item pool and delegates to
+ * {@code PlayerService.playRandom(Collection)}.
+ *
+ * @author Octavio Calleya
+ */
+public class PlayRandomFromContextEvent extends ApplicationEvent {
+
+    public PlayRandomFromContextEvent(Object source) {
+        super(source);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/services/PlayerService.java
+++ b/src/main/java/net/transgressoft/musicott/services/PlayerService.java
@@ -38,10 +38,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.time.Duration;
+import java.util.stream.Collectors;
 
 import static net.transgressoft.commons.music.player.AudioItemPlayer.Status.*;
 import static net.transgressoft.commons.music.player.event.AudioItemPlayerEvent.Type.PLAYED;
@@ -174,9 +177,6 @@ public class PlayerService {
             case PAUSED:
                 resume();
                 break;
-            case STOPPED:
-                playRandom();
-                break;
             default:
         }
     }
@@ -229,10 +229,31 @@ public class PlayerService {
         }
     }
 
-    @SuppressWarnings("java:S1135")
-    public void playRandom() {
-        // Deferred: random-playback feature not yet implemented; falls through silently when
-        // play() is invoked on a STOPPED player. Trigger: implement shuffle / random playback.
+    /**
+     * Shuffles the playable items from the given pool, fills the play queue, and starts playback.
+     *
+     * <p>If the pool contains no playable items, a {@link StatusMessageUpdateEvent} is published
+     * with the message "No playable tracks available" and the queue remains unchanged.
+     * The {@code playingRandom} flag is set to {@code true} after the queue is populated, so
+     * any subsequent explicit {@link #addToQueue} call will clear the random queue first.
+     *
+     * @param pool the collection of audio items to draw from; non-playable items are filtered out
+     */
+    public void playRandom(Collection<ObservableAudioItem> pool) {
+        var playable = pool.stream()
+                .filter(AudioItemPlayer.Companion::isPlayable)
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (playable.isEmpty()) {
+            applicationEventPublisher.publishEvent(
+                    new StatusMessageUpdateEvent("No playable tracks available", this));
+            return;
+        }
+        Collections.shuffle(playable);
+        // playingRandom must be false when addToQueue is called; addToQueue clears the queue
+        // when the flag is true, which would discard the items we are about to enqueue.
+        addToQueue(playable);
+        playingRandom = true;
+        next();
     }
 
     public void addToQueue(Collection<ObservableAudioItem> audioItems) {

--- a/src/main/java/net/transgressoft/musicott/services/PlayerService.java
+++ b/src/main/java/net/transgressoft/musicott/services/PlayerService.java
@@ -249,8 +249,12 @@ public class PlayerService {
             return;
         }
         Collections.shuffle(playable);
-        // playingRandom must be false when addToQueue is called; addToQueue clears the queue
-        // when the flag is true, which would discard the items we are about to enqueue.
+        // Random playback replaces any existing queue. Clear explicitly first (with the flag still
+        // false so addToQueue does not self-clear the items being enqueued), then mark the queue as
+        // random once it is populated.
+        playQueueList.clear();
+        publishQueueUpdatedEvent();
+        playingRandom = false;
         addToQueue(playable);
         playingRandom = true;
         next();

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -34,8 +34,6 @@ import static org.fxmisc.easybind.EasyBind.map;
 @Controller
 public class ArtistViewController {
 
-    private static final short DEFAULT_RANDOM_PLAYLIST_SIZE = 23;
-
     private final ObservableAudioLibrary audioRepository;
     private final ApplicationContext applicationContext;
 
@@ -72,7 +70,7 @@ public class ArtistViewController {
         totalAlbumsLabel.setText("0 albums");
         totalTracksLabel.setText("0 tracks");
         artistRandomButton.visibleProperty().bind(map(nameLabel.textProperty().isEmpty().not(), Function.identity()));
-        artistRandomButton.setOnAction(_ -> playRandomArtistTracks());
+        artistRandomButton.setOnAction(_ -> applicationContext.publishEvent(new PlayRandomFromContextEvent(this)));
         selectedArtistProperty = new SimpleObjectProperty<>(this, "selected artist", Optional.empty());
         nameLabel.textProperty().bind(Bindings.createStringBinding(() ->
                         selectedArtistProperty.get().isPresent() ? selectedArtistProperty.get().get().getName() : "",
@@ -247,18 +245,22 @@ public class ArtistViewController {
     private void doubleClickOnArtistHandler(MouseEvent event) {
         selectedArtistProperty.get().ifPresent(_ -> {
             if (event.getClickCount() == 2) {
-                playRandomArtistTracks();
+                applicationContext.publishEvent(new PlayRandomFromContextEvent(this));
             }
         });
     }
 
-    private void playRandomArtistTracks() {
-        // All call sites (doubleClickOnArtistHandler via ifPresent, and artistRandomButton whose
-        // visibility is bound to nameLabel being non-empty) guarantee the artist is present.
-        @SuppressWarnings("java:S3655")
-        var selectedArtist = selectedArtistProperty.get().get();
-        var randomAudioItemsFromArtist = audioRepository.getRandomAudioItemsFromArtist(selectedArtist, DEFAULT_RANDOM_PLAYLIST_SIZE);
-        applicationContext.publishEvent(new PlayItemEvent(randomAudioItemsFromArtist, this));
+    /**
+     * Returns every audio item involving the currently selected artist, or an empty list when no
+     * artist is selected. The pool mirrors what the artist view displays — it includes tracks where
+     * the artist appears in {@code artistsInvolved} (featured or album collaborations), not only
+     * tracks whose primary artist matches. {@link MainController} consumes this to resolve the
+     * random-playback pool for the {@code ARTISTS} navigation context.
+     */
+    public List<ObservableAudioItem> getSelectedArtistAudioItems() {
+        return selectedArtistProperty.getValue()
+                .map(artist -> audioItemsForArtist(artist).collect(Collectors.toList()))
+                .orElseGet(List::of);
     }
 
     private String getTotalArtistTracksString() {

--- a/src/main/java/net/transgressoft/musicott/view/MainController.java
+++ b/src/main/java/net/transgressoft/musicott/view/MainController.java
@@ -29,6 +29,7 @@ import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
 import net.transgressoft.commons.music.audio.AudioFileType;
 import net.transgressoft.musicott.events.*;
 import net.transgressoft.musicott.service.MediaImportService;
+import net.transgressoft.musicott.services.PlayerService;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
@@ -48,6 +49,7 @@ import java.util.*;
 import java.util.function.Function;
 
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALL_AUDIO_ITEMS;
+import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ARTISTS;
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.PLAYLIST;
 import static org.fxmisc.easybind.EasyBind.map;
 import static org.fxmisc.easybind.EasyBind.subscribe;
@@ -65,6 +67,7 @@ public class MainController {
     private final ObservableAudioLibrary audioRepository;
     private final ObservablePlaylistHierarchy playlistRepository;
 
+    private final PlayerService playerService;
     private final PlayerController playerController;
     private final NavigationController navigationController;
     private final ArtistViewController artistViewController;
@@ -147,6 +150,7 @@ public class MainController {
     @Autowired
     public MainController(ObservableAudioLibrary audioRepository,
                           ObservablePlaylistHierarchy playlistRepository,
+                          PlayerService playerService,
                           PlayerController playerController,
                           NavigationController navigationController,
                           ArtistViewController artistViewController,
@@ -157,6 +161,7 @@ public class MainController {
                           KeyCombination.Modifier operativeSystemKeyModifier) {
         this.audioRepository = audioRepository;
         this.playlistRepository = playlistRepository;
+        this.playerService = playerService;
         this.playerController = playerController;
         this.navigationController = navigationController;
         this.artistViewController = artistViewController;
@@ -244,8 +249,14 @@ public class MainController {
         playRandomButton.visibleProperty().bind(tableItemsProperty.emptyProperty().not());
         playlistTracksNumberLabel.textProperty().bind(map(tableItemsProperty.sizeProperty(), s -> s + " tracks"));
 
-        playRandomButton.setOnAction(e -> selectedPlaylistProperty.get().ifPresent(
-            playlist -> applicationContext.publishEvent(new PlayPlaylistRandomlyEvent(playlist, this))));
+        playRandomButton.setOnAction(e -> {
+            var items = currentContextItems();
+            if (items.isEmpty()) {
+                applicationContext.publishEvent(new StatusMessageUpdateEvent("No playable tracks available", this));
+            } else {
+                playerService.playRandom(items);
+            }
+        });
 
         playlistSizeLabel.textProperty().bind(map(tableItemsProperty, (ObservableList<ObservableAudioItem> audioItems) -> {
             var sizeSum = audioItems.stream().mapToLong(ObservableAudioItem::getLength).sum();
@@ -881,6 +892,41 @@ public class MainController {
     @EventListener
     public void showTableViewContextMenuEventListener(ShowTableViewContextMenuEvent event) {
         audioItemContextMenu.show(event.selectedAudioItems, (Node) event.getSource(), event.screenX, event.screenY);
+    }
+
+    /**
+     * Handles a request to start random playback from the active navigation context.
+     * Resolves the current context items and delegates to {@link PlayerService#playRandom(java.util.Collection)}.
+     * Publishes a {@link StatusMessageUpdateEvent} when no playable items are available.
+     */
+    @EventListener
+    public void onPlayRandomFromContext(PlayRandomFromContextEvent event) {
+        var items = currentContextItems();
+        if (items.isEmpty()) {
+            applicationContext.publishEvent(new StatusMessageUpdateEvent("No playable tracks available", this));
+        } else {
+            playerService.playRandom(items);
+        }
+    }
+
+    /**
+     * Returns the item pool for the currently active navigation context.
+     *
+     * <p>For {@code ALL_AUDIO_ITEMS}, returns the full library. For {@code PLAYLIST},
+     * returns the selected playlist's items (recursive for directory playlists). For
+     * {@code ARTISTS}, returns every track involving the artist currently shown in the
+     * artist view (empty when none is selected).
+     */
+    private List<ObservableAudioItem> currentContextItems() {
+        return switch (navigationController.navigationModeProperty().get()) {
+            case ALL_AUDIO_ITEMS -> List.copyOf(audioRepository.getAudioItemsProperty());
+            case PLAYLIST -> selectedPlaylistProperty.get()
+                    .map(p -> p.isDirectory()
+                            ? List.copyOf(p.getAudioItemsRecursiveProperty())
+                            : List.copyOf(p.getAudioItemsProperty()))
+                    .orElse(List.of());
+            case ARTISTS -> List.copyOf(artistViewController.getSelectedArtistAudioItems());
+        };
     }
 
     private class AudioItemTableViewContextMenu extends ContextMenu {

--- a/src/main/java/net/transgressoft/musicott/view/PlayerController.java
+++ b/src/main/java/net/transgressoft/musicott/view/PlayerController.java
@@ -43,9 +43,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Controller;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -76,6 +79,7 @@ public class PlayerController {
     private final AudioWaveformRepository<AudioWaveform, ObservableAudioItem> waveformRepository;
     private final PlayerService playerService;
     private final ObservableAudioLibrary audioLibrary;
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final Image defaultCoverImage = ApplicationImage.DEFAULT_COVER.get();
 
     @FXML
@@ -158,10 +162,12 @@ public class PlayerController {
     @Autowired
     public PlayerController(AudioWaveformRepository<AudioWaveform, ObservableAudioItem> waveformRepository,
                             PlayerService playerService,
-                            ObservableAudioLibrary audioLibrary) {
+                            ObservableAudioLibrary audioLibrary,
+                            ApplicationEventPublisher applicationEventPublisher) {
         this.waveformRepository = waveformRepository;
         this.playerService = playerService;
         this.audioLibrary = audioLibrary;
+        this.applicationEventPublisher = applicationEventPublisher;
         playQueueFocusLossDelay.setOnFinished(_ -> {
             if (playQueueOwnerWindow == null || playQueueOwnerWindow.isFocused())
                 return;
@@ -407,7 +413,7 @@ public class PlayerController {
             if (playerService.currentTrack().isPresent()) {
                 playerService.resume();
             } else {
-                playerService.playRandom();
+                applicationEventPublisher.publishEvent(new PlayRandomFromContextEvent(this));
             }
         } else {
             playerService.pause();
@@ -607,7 +613,9 @@ public class PlayerController {
     @EventListener
     public void playPlaylistRandomlyEventListener(PlayPlaylistRandomlyEvent playPlaylistRandomlyEvent) {
         ObservablePlaylist playlist = playPlaylistRandomlyEvent.playlist;
-        playerService.addToQueue(playlist.getAudioItemsProperty());
+        var items = new ArrayList<>(playlist.getAudioItemsProperty());
+        Collections.shuffle(items);
+        playerService.addToQueue(items);
         playerService.next();
     }
 

--- a/src/main/java/net/transgressoft/musicott/view/PlayerController.java
+++ b/src/main/java/net/transgressoft/musicott/view/PlayerController.java
@@ -47,8 +47,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Controller;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -414,6 +412,11 @@ public class PlayerController {
                 playerService.resume();
             } else {
                 applicationEventPublisher.publishEvent(new PlayRandomFromContextEvent(this));
+                // If the context had no playable tracks, no playback started — keep the toggle in
+                // sync with the still-stopped player instead of leaving it showing the pause icon.
+                if (playerService.currentTrack().isEmpty()) {
+                    playButton.setSelected(false);
+                }
             }
         } else {
             playerService.pause();
@@ -613,10 +616,9 @@ public class PlayerController {
     @EventListener
     public void playPlaylistRandomlyEventListener(PlayPlaylistRandomlyEvent playPlaylistRandomlyEvent) {
         ObservablePlaylist playlist = playPlaylistRandomlyEvent.playlist;
-        var items = new ArrayList<>(playlist.getAudioItemsProperty());
-        Collections.shuffle(items);
-        playerService.addToQueue(items);
-        playerService.next();
+        // Delegate to the unified random path so shuffle, queue-replacement, empty-pool feedback,
+        // and the playingRandom lifecycle are handled in one place.
+        playerService.playRandom(playlist.getAudioItemsProperty());
     }
 
     @EventListener


### PR DESCRIPTION
## Summary

**Goal:** Implement random playback from the active navigation context and remove the silent no-op when playback is triggered from a stopped state with no current queue.
**Status:** Verified ✓

Users can now intentionally start random playback from whatever context they are browsing — the full library, a selected playlist, or the artist currently shown — and receive clear feedback instead of silent failure. A single `PlayRandomFromContextEvent` now backs the play/pause button, the info-pane random button, the artist-view random button, and artist double-click, so every entry point resolves the correct pool through one path.

## Changes

### Service core (`PlayerService`)
- New `playRandom(Collection)`: filters playable items, shuffles, fills the queue, and starts playback.
- Publishes a `StatusMessageUpdateEvent` ("No playable tracks available") when the pool has no playable items instead of failing silently.
- Sets the `playingRandom` flag **after** `addToQueue` so the freshly enqueued items are not cleared.
- Removed the dead no-arg `playRandom()` stub and the leftover `pause()` STOPPED branch.

### Event
- New `PlayRandomFromContextEvent` decouples the play action from the controller that resolves the context pool.

### Controllers
- `PlayerController.playPause()` stopped path publishes `PlayRandomFromContextEvent`; the playlist-random listener now shuffles before enqueuing.
- `MainController.currentContextItems()` resolves the pool per navigation mode: `ALL_AUDIO_ITEMS` → full library, `PLAYLIST` → selected playlist (recursive for directories), `ARTISTS` → every track involving the shown artist (`artistsInvolved`-aware, so featured/album-artist views play correctly).
- `ArtistViewController` routes its random button and artist double-click through the same `PlayRandomFromContextEvent`, and exposes the selected artist's involved-track pool.

## Requirements Addressed

- **PLAY-09**: Shuffle / random playback selects tracks from the current navigation context, enqueues them, and avoids silent failure when no random source exists.

## Verification

- [x] Automated verification: **passed** (goal-backward, 7/7 must-haves).
- [x] Full `gradle build` green across all source sets.
- [x] Integration coverage: `PlayerServiceStorageIT`, `PlayerControllerIT`, and `MainControllerRandomPlaybackIT` (incl. the ARTISTS context).
- [x] UAT follow-ups resolved: artist-view random button now plays for featured/album artists; the play button starts random playback from a stopped state in artist view.

## Key Decisions

- `getRandomAudioItemsFromArtist` in music-commons is by-design primary-artist-only; the consumer (Musicott) aggregates the `artistsInvolved` pool itself via `ArtistViewController`.
- Unified all random-playback entry points through `PlayRandomFromContextEvent` for a single, consistent, marked-random path with empty-pool feedback.

Closes #54
