### PR TITLE
iTunes import: scrollable tree recap for large playlist selections

### DIFF
--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -25,6 +25,7 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
 
+import static java.util.stream.Collectors.*;
 import static org.fxmisc.easybind.EasyBind.map;
 
 /**
@@ -188,28 +189,28 @@ public class ArtistViewController {
 
         var tracks = audioItemsForArtist(artist)
                 .filter(audioItem -> audioItem.getAlbum() != null && audioItem.getAlbum().getName() != null)
-                .collect(Collectors.toList());
+                .toList();
         if (tracks.isEmpty()) {
             return Map.of();
         }
 
         // Detect which album names have more than one distinct normalized disc number
         var multiDiscAlbums = tracks.stream()
-                .collect(Collectors.groupingBy(t -> t.getAlbum().getName()))
+                .collect(groupingBy(t -> t.getAlbum().getName()))
                 .entrySet().stream()
                 .filter(e -> e.getValue().stream()
                         .map(t -> normalizeDisc(t.getDiscNumber()))
                         .distinct().count() > 1)
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toSet());
+                .collect(toSet());
 
         // Group by composite (albumName, disc): multi-disc albums split per disc, single-disc use disc=0
-        var grouped = tracks.stream().collect(Collectors.groupingBy(
+        var grouped = tracks.stream().collect(groupingBy(
                 t -> new AlbumDiscKey(
                         t.getAlbum().getName(),
                         multiDiscAlbums.contains(t.getAlbum().getName()) ? normalizeDisc(t.getDiscNumber()) : 0),
                 TreeMap::new,
-                Collectors.toList()));
+                toList()));
 
         // Build result map preserving TreeMap order: AlbumSet → disc number (0 = no label)
         var result = new LinkedHashMap<AlbumSet<ObservableAudioItem>, Integer>();
@@ -259,7 +260,7 @@ public class ArtistViewController {
      */
     public List<ObservableAudioItem> getSelectedArtistAudioItems() {
         return selectedArtistProperty.getValue()
-                .map(artist -> audioItemsForArtist(artist).collect(Collectors.toList()))
+                .map(artist -> audioItemsForArtist(artist).toList())
                 .orElseGet(List::of);
     }
 
@@ -302,7 +303,7 @@ public class ArtistViewController {
     public ObservableList<ObservableAudioItem> getSelectedTracks() {
         return albumRowsBackingList.stream()
             .flatMap(entry -> entry.selectedAudioItemsProperty().stream())
-            .collect(Collectors.toCollection(FXCollections::observableArrayList));
+            .collect(toCollection(FXCollections::observableArrayList));
     }
 
     public void findAudioItemInArtistViewAndSelect(ObservableAudioItem audioItem) {

--- a/src/main/java/net/transgressoft/musicott/view/MainController.java
+++ b/src/main/java/net/transgressoft/musicott/view/MainController.java
@@ -49,7 +49,6 @@ import java.util.*;
 import java.util.function.Function;
 
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALL_AUDIO_ITEMS;
-import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ARTISTS;
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.PLAYLIST;
 import static org.fxmisc.easybind.EasyBind.map;
 import static org.fxmisc.easybind.EasyBind.subscribe;

--- a/src/main/java/net/transgressoft/musicott/view/itunes/ItunesPlaylistCells.java
+++ b/src/main/java/net/transgressoft/musicott/view/itunes/ItunesPlaylistCells.java
@@ -1,0 +1,71 @@
+package net.transgressoft.musicott.view.itunes;
+
+import net.transgressoft.commons.music.itunes.ItunesPlaylist;
+
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.cell.CheckBoxTreeCell;
+
+/**
+ * Shared cell factories for iTunes playlist tree views. Both the playlist-selection step
+ * ({@link ItunesWizardPlaylistsStepController}) and the confirm-step read-only tree
+ * ({@link ItunesWizardConfirmStepController}) must render nodes identically: folder nodes
+ * display the name only; leaf nodes display {@code name  (X tracks)} with correct
+ * singular/plural. Centralising the text logic here prevents the two renderers from
+ * drifting apart over time.
+ *
+ * @author Octavio Calleya
+ */
+final class ItunesPlaylistCells {
+
+    private ItunesPlaylistCells() {}
+
+    /**
+     * Returns the display text for a playlist node: folder playlists show the name only;
+     * leaf playlists show {@code name  (X track[s])} with correct singular/plural.
+     *
+     * @param item the playlist to format; must not be {@code null}
+     * @return the formatted display string
+     */
+    static String displayText(ItunesPlaylist item) {
+        if (item.isFolder()) {
+            return item.getName();
+        }
+        int trackCount = item.getTrackIds().size();
+        String unit = trackCount == 1 ? "track" : "tracks";
+        return item.getName() + "  (" + trackCount + " " + unit + ")";
+    }
+
+    /**
+     * A {@link CheckBoxTreeCell} that formats each cell using {@link #displayText(ItunesPlaylist)}.
+     * Used by the playlist-selection step so checkboxes are preserved while sharing the text logic.
+     */
+    static final class SelectionTreeCell extends CheckBoxTreeCell<ItunesPlaylist> {
+
+        @Override
+        public void updateItem(ItunesPlaylist item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setText(null);
+            } else {
+                setText(displayText(item));
+            }
+        }
+    }
+
+    /**
+     * A plain (non-checkbox) {@link TreeCell} that formats each cell using
+     * {@link #displayText(ItunesPlaylist)}. Used by the read-only confirm-step tree.
+     */
+    static final class ReadOnlyTreeCell extends TreeCell<ItunesPlaylist> {
+
+        @Override
+        public void updateItem(ItunesPlaylist item, boolean empty) {
+            super.updateItem(item, empty);
+            if (empty || item == null) {
+                setText(null);
+            } else {
+                setText(displayText(item));
+            }
+        }
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/itunes/ItunesWizardConfirmStepController.java
+++ b/src/main/java/net/transgressoft/musicott/view/itunes/ItunesWizardConfirmStepController.java
@@ -6,16 +6,28 @@ import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
 import javafx.scene.layout.VBox;
 import net.rgielen.fxweaver.core.FxmlView;
 import org.springframework.stereotype.Controller;
 
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Read-only step that recaps the user's choices before the import is dispatched. Renders
- * four sections — library path, picked playlists with per-playlist track-count subtotals,
- * three policy lines in plain language, and an aggregate track total. Every section is
- * rebuilt on each {@code onEnter} so a Back-navigation that mutates an earlier step is
- * always reflected here.
+ * four sections — library path, selected playlists as a structure-mirroring read-only
+ * {@link TreeView}, three policy lines in plain language, and an aggregate track total.
+ * Every section is rebuilt on each {@code onEnter} so a Back-navigation that mutates an
+ * earlier step is always reflected here.
+ *
+ * <p>The playlist tree mirrors the iTunes folder hierarchy: folder nodes show the name
+ * only; leaf nodes show {@code name  (X tracks)}. Parent-linking is computed strictly
+ * among the <em>selected</em> playlists — a leaf whose folder was not selected attaches
+ * to the hidden root. Cell rendering is shared with the selection step via
+ * {@link ItunesPlaylistCells} to guarantee visual parity.
  *
  * @author Octavio Calleya
  */
@@ -28,7 +40,7 @@ public class ItunesWizardConfirmStepController {
     @FXML
     Label libraryPathLabel;
     @FXML
-    VBox playlistsList;
+    TreeView<ItunesPlaylist> playlistsTree;
     @FXML
     VBox policyList;
     @FXML
@@ -55,14 +67,7 @@ public class ItunesWizardConfirmStepController {
         }
         libraryPathLabel.setText(draft.libraryPath != null ? draft.libraryPath.toString() : "");
 
-        playlistsList.getChildren().clear();
-        int totalTracks = 0;
-        for (ItunesPlaylist playlist : draft.selectedPlaylists) {
-            int count = playlist.getTrackIds().size();
-            totalTracks += count;
-            String tracksWord = count == 1 ? "track" : "tracks";
-            playlistsList.getChildren().add(wrappingLabel("• " + playlist.getName() + " — " + count + " " + tracksWord));
-        }
+        buildPlaylistsTree();
 
         policyList.getChildren().clear();
         policyList.getChildren().add(wrappingLabel(draft.useFileMetadata
@@ -75,6 +80,9 @@ public class ItunesWizardConfirmStepController {
                 ? "• Write metadata back to audio files"
                 : "• Don't write metadata back to files"));
 
+        int totalTracks = draft.selectedPlaylists.stream()
+                .mapToInt(p -> p.getTrackIds().size())
+                .sum();
         int playlistCount = draft.selectedPlaylists.size();
         String tracksWord = totalTracks == 1 ? "track" : "tracks";
         String playlistsWord = playlistCount == 1 ? "playlist" : "playlists";
@@ -86,7 +94,44 @@ public class ItunesWizardConfirmStepController {
         return invalid;
     }
 
-    /** Builds a recap line label that wraps long playlist names or policy strings. */
+    /**
+     * Builds the read-only playlist tree from {@code draft.selectedPlaylists}. Parent-linking
+     * uses {@code parentPersistentId} within the selected set only — a leaf whose folder was
+     * not selected attaches directly to the hidden root. All nodes are expanded and sorted
+     * by name for a predictable read-only recap layout.
+     */
+    private void buildPlaylistsTree() {
+        TreeItem<ItunesPlaylist> root = new TreeItem<>(null);
+
+        Map<String, TreeItem<ItunesPlaylist>> byId = new LinkedHashMap<>();
+        for (ItunesPlaylist p : draft.selectedPlaylists) {
+            TreeItem<ItunesPlaylist> item = new TreeItem<>(p);
+            item.setExpanded(true);
+            byId.put(p.getPersistentId(), item);
+        }
+        for (ItunesPlaylist p : draft.selectedPlaylists) {
+            TreeItem<ItunesPlaylist> item = byId.get(p.getPersistentId());
+            String parentId = p.getParentPersistentId();
+            // Only attach to a parent that is itself in the selected set; otherwise
+            // the node belongs at the top level of this recap tree.
+            TreeItem<ItunesPlaylist> parent = (parentId != null) ? byId.getOrDefault(parentId, root) : root;
+            parent.getChildren().add(item);
+        }
+        sortChildren(root);
+
+        playlistsTree.setShowRoot(false);
+        playlistsTree.setRoot(root);
+        playlistsTree.setCellFactory(tv -> new ItunesPlaylistCells.ReadOnlyTreeCell());
+    }
+
+    private void sortChildren(TreeItem<ItunesPlaylist> node) {
+        node.getChildren().sort(Comparator.comparing(t -> t.getValue() == null ? "" : t.getValue().getName()));
+        for (TreeItem<ItunesPlaylist> child : node.getChildren()) {
+            sortChildren(child);
+        }
+    }
+
+    /** Builds a recap line label that wraps long policy strings. */
     private static Label wrappingLabel(String text) {
         Label label = new Label(text);
         label.setWrapText(true);

--- a/src/main/java/net/transgressoft/musicott/view/itunes/ItunesWizardPlaylistsStepController.java
+++ b/src/main/java/net/transgressoft/musicott/view/itunes/ItunesWizardPlaylistsStepController.java
@@ -10,7 +10,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBoxTreeItem;
 import javafx.scene.control.Label;
 import javafx.scene.control.TreeItem;
-import javafx.scene.control.cell.CheckBoxTreeCell;
 import net.rgielen.fxweaver.core.FxmlView;
 import org.controlsfx.control.CheckTreeView;
 import org.springframework.stereotype.Controller;
@@ -57,7 +56,7 @@ public class ItunesWizardPlaylistsStepController {
     public void initialize() {
         playlistsTree.setShowRoot(false);
         playlistsTree.setRoot(new TreeItem<>(null));
-        playlistsTree.setCellFactory(tv -> new ItunesPlaylistTreeCell());
+        playlistsTree.setCellFactory(tv -> new ItunesPlaylistCells.SelectionTreeCell());
         invalid.bind(Bindings.isEmpty(playlistsTree.getCheckModel().getCheckedItems()));
         selectionCountLabel.textProperty().bind(
                 Bindings.size(playlistsTree.getCheckModel().getCheckedItems()).asString().concat(" selected")
@@ -210,20 +209,4 @@ public class ItunesWizardPlaylistsStepController {
         }
     }
 
-    private static final class ItunesPlaylistTreeCell extends CheckBoxTreeCell<ItunesPlaylist> {
-
-        @Override
-        public void updateItem(ItunesPlaylist item, boolean empty) {
-            super.updateItem(item, empty);
-            if (empty || item == null) {
-                setText(null);
-            } else if (item.isFolder()) {
-                setText(item.getName());
-            } else {
-                int trackCount = item.getTrackIds().size();
-                String unit = trackCount == 1 ? "track" : "tracks";
-                setText(item.getName() + "  (" + trackCount + " " + unit + ")");
-            }
-        }
-    }
 }

--- a/src/main/resources/fxml/ItunesWizardConfirmStep.fxml
+++ b/src/main/resources/fxml/ItunesWizardConfirmStep.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TreeView?>
 <?import javafx.scene.layout.VBox?>
 <VBox spacing="6.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="net.transgressoft.musicott.view.itunes.ItunesWizardConfirmStepController">
@@ -17,7 +18,8 @@
                 <Insets top="10.0"/>
             </VBox.margin>
         </Label>
-        <VBox fx:id="playlistsList" spacing="2.0"/>
+        <TreeView fx:id="playlistsTree" showRoot="false" prefHeight="150.0" maxHeight="150.0"
+                  stylesheets="@../css/scroll-bar-general.css"/>
 
         <Label style="-fx-font-weight: bold;" text="Policy">
             <VBox.margin>

--- a/src/test/java/net/transgressoft/musicott/view/itunes/ItunesWizardConfirmStepControllerTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/itunes/ItunesWizardConfirmStepControllerTest.java
@@ -7,7 +7,8 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
-import javafx.scene.layout.VBox;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,10 +54,10 @@ class ItunesWizardConfirmStepControllerTest {
     }
 
     @Test
-    @DisplayName("ItunesWizardConfirmStepController renders the library, playlists, policy and total sections")
+    @DisplayName("ItunesWizardConfirmStepController renders the library, playlists tree, policy and total sections")
     void rendersLibraryPlaylistsPolicyAndTotalSections() {
         verifyThat("#libraryPathLabel", isVisible());
-        verifyThat("#playlistsList", isVisible());
+        verifyThat("#playlistsTree", isVisible());
         verifyThat("#policyList", isVisible());
         verifyThat("#totalLabel", isVisible());
     }
@@ -77,8 +78,8 @@ class ItunesWizardConfirmStepControllerTest {
     }
 
     @Test
-    @DisplayName("ItunesWizardConfirmStepController renders playlist subtotals and aggregate total")
-    void rendersPlaylistSubtotalsAndAggregateTotal() {
+    @DisplayName("ItunesWizardConfirmStepController renders leaf playlist nodes with name and track count")
+    void rendersLeafPlaylistNodesWithNameAndTrackCount() {
         ItunesPlaylist disco = new ItunesPlaylist(
                 "Disco 80s", "id-disco", null, false,
                 IntStream.rangeClosed(1, 64).boxed().toList());
@@ -90,9 +91,13 @@ class ItunesWizardConfirmStepControllerTest {
         Platform.runLater(() -> controller.onEnter());
         waitForFxEvents();
 
-        assertThat(controller.playlistsList.getChildren()).hasSize(2);
-        assertThat(labelTextAt(controller.playlistsList, 0)).contains("Disco 80s").contains("64 tracks");
-        assertThat(labelTextAt(controller.playlistsList, 1)).contains("Rock 90s").contains("10 tracks");
+        TreeView<ItunesPlaylist> tree = controller.playlistsTree;
+        // Root has 2 top-level children (both leaves, no parent folder selected)
+        assertThat(tree.getRoot().getChildren()).hasSize(2);
+        List<String> texts = rootChildTexts(tree);
+        assertThat(texts)
+                .anySatisfy(t -> assertThat(t).contains("Disco 80s").contains("64 tracks"))
+                .anySatisfy(t -> assertThat(t).contains("Rock 90s").contains("10 tracks"));
         assertThat(controller.totalLabel.getText()).contains("74").contains("2 playlists");
     }
 
@@ -106,12 +111,39 @@ class ItunesWizardConfirmStepControllerTest {
         Platform.runLater(() -> controller.onEnter());
         waitForFxEvents();
 
-        assertThat(labelTextAt(controller.playlistsList, 0)).contains("1 track").doesNotContain("1 tracks");
+        String leafText = rootChildTexts(controller.playlistsTree).get(0);
+        assertThat(leafText).contains("1 track").doesNotContain("1 tracks");
         assertThat(controller.totalLabel.getText())
                 .contains("1 track")
                 .contains("1 playlist")
                 .doesNotContain("1 tracks")
                 .doesNotContain("1 playlists");
+    }
+
+    @Test
+    @DisplayName("ItunesWizardConfirmStepController renders folder node with name only and leaf as child")
+    void rendersFolderNodeWithNameOnlyAndLeafAsChild() {
+        ItunesPlaylist folder = new ItunesPlaylist(
+                "My Folder", "id-folder", null, true, List.of());
+        ItunesPlaylist leaf = new ItunesPlaylist(
+                "Chill Hits", "id-chill", "id-folder", false,
+                IntStream.rangeClosed(1, 5).boxed().toList());
+        draft.selectedPlaylists.addAll(List.of(folder, leaf));
+
+        Platform.runLater(() -> controller.onEnter());
+        waitForFxEvents();
+
+        TreeView<ItunesPlaylist> tree = controller.playlistsTree;
+        // Folder is top-level; leaf is nested under it
+        assertThat(tree.getRoot().getChildren()).hasSize(1);
+        TreeItem<ItunesPlaylist> folderItem = tree.getRoot().getChildren().get(0);
+        // Folder node shows name only — no track count
+        assertThat(ItunesPlaylistCells.displayText(folderItem.getValue()))
+                .isEqualTo("My Folder")
+                .doesNotContain("track");
+        assertThat(folderItem.getChildren()).hasSize(1);
+        assertThat(ItunesPlaylistCells.displayText(folderItem.getChildren().get(0).getValue()))
+                .contains("Chill Hits").contains("5 tracks");
     }
 
     @Test
@@ -126,21 +158,22 @@ class ItunesWizardConfirmStepControllerTest {
 
         assertThat(controller.policyList.getChildren()).hasSize(3);
         String all = policyText();
-        assertThat(all).containsIgnoringCase("itunes library");
-        assertThat(all).containsIgnoringCase("preserve");
-        assertThat(all).containsIgnoringCase("don't write");
+        assertThat(all)
+                .containsIgnoringCase("itunes library")
+                .containsIgnoringCase("preserve")
+                .containsIgnoringCase("don't write");
     }
 
     @Test
-    @DisplayName("ItunesWizardConfirmStepController refreshes all sections when onEnter is called twice with different draft state")
-    void refreshesAllSectionsWhenOnEnterIsCalledTwiceWithDifferentDraftState() {
+    @DisplayName("ItunesWizardConfirmStepController refreshes the tree when onEnter is called twice with different draft state")
+    void refreshesTreeWhenOnEnterIsCalledTwiceWithDifferentDraftState() {
         ItunesPlaylist first = new ItunesPlaylist(
                 "First", "id-1", null, false, List.of(1, 2));
         draft.selectedPlaylists.add(first);
 
         Platform.runLater(() -> controller.onEnter());
         waitForFxEvents();
-        assertThat(controller.playlistsList.getChildren()).hasSize(1);
+        assertThat(controller.playlistsTree.getRoot().getChildren()).hasSize(1);
 
         ItunesPlaylist second = new ItunesPlaylist(
                 "Second", "id-2", null, false, List.of(3, 4, 5));
@@ -150,13 +183,35 @@ class ItunesWizardConfirmStepControllerTest {
         Platform.runLater(() -> controller.onEnter());
         waitForFxEvents();
 
-        assertThat(controller.playlistsList.getChildren()).hasSize(2);
+        assertThat(controller.playlistsTree.getRoot().getChildren()).hasSize(2);
         assertThat(controller.totalLabel.getText()).contains("5").contains("2 playlists");
         assertThat(policyText()).containsIgnoringCase("itunes library");
     }
 
-    private String labelTextAt(VBox container, int index) {
-        return ((Label) container.getChildren().get(index)).getText();
+    @Test
+    @DisplayName("ItunesWizardConfirmStepController hosts all selected playlists in a bounded TreeView with many playlists")
+    void hostsAllSelectedPlaylistsInBoundedTreeViewWithManyPlaylists() {
+        IntStream.rangeClosed(1, 30).forEach(i ->
+                draft.selectedPlaylists.add(
+                        new ItunesPlaylist("Playlist " + i, "id-" + i, null, false, List.of(i))));
+
+        Platform.runLater(() -> controller.onEnter());
+        waitForFxEvents();
+
+        TreeView<ItunesPlaylist> tree = controller.playlistsTree;
+
+        // All 30 playlists must be rendered as top-level items (no folder selected)
+        assertThat(tree.getRoot().getChildren()).hasSize(30);
+
+        // The tree must be bounded — maxHeight must be a finite, usable value
+        assertThat(tree.getMaxHeight()).isEqualTo(150.0);
+        assertThat(tree.getPrefHeight()).isEqualTo(150.0);
+    }
+
+    private List<String> rootChildTexts(TreeView<ItunesPlaylist> tree) {
+        return tree.getRoot().getChildren().stream()
+                .map(item -> ItunesPlaylistCells.displayText(item.getValue()))
+                .toList();
     }
 
     private String policyText() {


### PR DESCRIPTION
Closes #58.

## Summary

The iTunes import wizard's confirmation step previously rendered the selected playlists as a flat list of labels in an unbounded container, which grew with many playlists and pushed the Accept/Cancel buttons off-screen. It now renders the selected playlists as a **read-only `TreeView` mirroring the playlist folder structure**, with per-playlist track counts — a bounded, scrollable, structurally faithful recap.

## Changes

- `ItunesWizardConfirmStep.fxml` — the playlists recap is now a bounded `TreeView` (dark-theme viewport via `scroll-bar-general.css`); the Library, Policy, and Total sections are unchanged.
- `ItunesWizardConfirmStepController.java` — builds a read-only tree from the selected playlists, linking children to parents by `parentPersistentId` within the selected set. Folder nodes show the name; leaf nodes show `name (X tracks)`.
- `ItunesPlaylistCells.java` (new) — a single `displayText()` helper plus `SelectionTreeCell` (checkbox, selection step) and `ReadOnlyTreeCell` (plain, confirmation step), so both wizard steps render identically. The selection step keeps its checkboxes; the confirmation step is read-only.
- `ItunesWizardPlaylistsStepController.java` — uses the shared cell.
- `ItunesWizardConfirmStepControllerTest.java` — recap assertions migrated from labels to `TreeView` items, including leaf track-count text, folder name-only rendering, and a large-selection case.

## Testing

- `gradle build` green across all four source sets; the confirm-step tests pass, including the large-selection case.
- Manual: the tree recap renders correctly with many selected playlists.

## Notes

- Only the selected playlists are shown (a selected leaf whose folder was not selected attaches to the hidden root); folders show the name only, leaves show the track count.
- Making the wizard window resizable was attempted and reverted — the ControlsFX wizard dialog did not resize reliably, so the wizard keeps its default fixed size.
