### PR TITLE
#65 Fix playback advance, playlist selection/DnD, artist-view actions, and UI polish

### DIFF
--- a/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceAutoAdvanceIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/services/PlayerServiceAutoAdvanceIT.java
@@ -1,0 +1,193 @@
+package net.transgressoft.musicott.services;
+
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.player.FXAudioItemPlayer;
+import net.transgressoft.commons.music.player.AudioItemPlayer;
+import net.transgressoft.musicott.events.AudioItemChangedEvent;
+import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
+
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.ObservableList;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration test asserting that {@link PlayerService#next()} correctly advances
+ * to the next queued track and publishes an {@link AudioItemChangedEvent} — covering
+ * the regression where a READY (post-natural-end) player status caused {@code play()}
+ * to no-op and the queue advance to stall silently.
+ */
+@ExtendWith(ApplicationExtension.class)
+@DisplayName("PlayerService auto-advance")
+class PlayerServiceAutoAdvanceIT {
+
+    ApplicationEventPublisher applicationEventPublisher;
+    PlayerService playerService;
+
+    @Start
+    void start(Stage stage) {
+        applicationEventPublisher = mock(ApplicationEventPublisher.class);
+        playerService = new PlayerService(applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("next on a non-empty queue advances currentTrack to the next item and shrinks the queue by one")
+    void nextOnNonEmptyQueueAdvancesCurrentTrackAndShrinksQueue() throws Exception {
+        ObservableAudioItem currentItem = newPlayableAudioItem("Current");
+        ObservableAudioItem nextItem = newPlayableAudioItem("Next");
+
+        ReflectionTestUtils.setField(playerService, "currentTrack", Optional.of(currentItem));
+        playerService.addToQueue(List.of(nextItem));
+
+        ObservableList<TrackQueueRow> queue = playerService.getPlayQueueList();
+        assertThat(queue).hasSize(1);
+
+        // Intercept FXAudioItemPlayer construction so the test stays headless on all platforms.
+        // The status property is set to READY to simulate the post-natural-end state that
+        // previously caused play() to no-op — the regression scenario for this fix.
+        try (MockedConstruction<FXAudioItemPlayer> ignored = Mockito.mockConstruction(FXAudioItemPlayer.class,
+                (mockPlayer, context) -> {
+                    Mockito.doNothing().when(mockPlayer).play(Mockito.any());
+                    Mockito.when(mockPlayer.getStatusProperty())
+                            .thenReturn(new SimpleObjectProperty<>(AudioItemPlayer.Status.READY));
+                })) {
+            playerService.next();
+        }
+
+        // Pump the JavaFX thread — statusProperty is posted via Platform.runLater.
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertThat(playerService.currentTrack()).contains(nextItem);
+        assertThat(queue).isEmpty();
+    }
+
+    @Test
+    @DisplayName("next on a non-empty queue publishes AudioItemChangedEvent carrying the next track")
+    void nextOnNonEmptyQueuePublishesAudioItemChangedEventWithNextTrack() throws Exception {
+        ObservableAudioItem currentItem = newPlayableAudioItem("Current");
+        ObservableAudioItem nextItem = newPlayableAudioItem("Next");
+
+        // Reset the shared mock so only events from this test are captured.
+        Mockito.reset(applicationEventPublisher);
+
+        ReflectionTestUtils.setField(playerService, "currentTrack", Optional.of(currentItem));
+        playerService.addToQueue(List.of(nextItem));
+
+        try (MockedConstruction<FXAudioItemPlayer> ignored = Mockito.mockConstruction(FXAudioItemPlayer.class,
+                (mockPlayer, context) -> {
+                    Mockito.doNothing().when(mockPlayer).play(Mockito.any());
+                    Mockito.when(mockPlayer.getStatusProperty())
+                            .thenReturn(new SimpleObjectProperty<>(AudioItemPlayer.Status.READY));
+                })) {
+            playerService.next();
+        }
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ArgumentCaptor<org.springframework.context.ApplicationEvent> eventCaptor =
+                ArgumentCaptor.forClass(org.springframework.context.ApplicationEvent.class);
+        verify(applicationEventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
+
+        boolean audioItemChangedFired = eventCaptor.getAllValues().stream()
+                .filter(e -> e instanceof AudioItemChangedEvent)
+                .map(e -> (AudioItemChangedEvent) e)
+                .anyMatch(e -> e.currentTrack == nextItem);
+        assertThat(audioItemChangedFired)
+                .as("AudioItemChangedEvent carrying the next track must be published on auto-advance")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("swapping players detaches the previous player's status listener so a late STOPPED never clears the new track")
+    void previousPlayerStatusListenerDetachedOnSwap() throws Exception {
+        ObservableAudioItem first = newPlayableAudioItem("First");
+        ObservableAudioItem second = newPlayableAudioItem("Second");
+
+        Mockito.reset(applicationEventPublisher);
+
+        // Capture each constructed player's status property in construction order so the test can
+        // later mutate the *previous* player's status and assert its listener was removed.
+        List<SimpleObjectProperty<AudioItemPlayer.Status>> statusProps = new java.util.ArrayList<>();
+
+        ReflectionTestUtils.setField(playerService, "currentTrack", Optional.of(first));
+        playerService.addToQueue(List.of(second));
+
+        try (MockedConstruction<FXAudioItemPlayer> ignored = Mockito.mockConstruction(FXAudioItemPlayer.class,
+                (mockPlayer, context) -> {
+                    Mockito.doNothing().when(mockPlayer).play(Mockito.any());
+                    var statusProperty = new SimpleObjectProperty<>(AudioItemPlayer.Status.READY);
+                    statusProps.add(statusProperty);
+                    Mockito.when(mockPlayer.getStatusProperty()).thenReturn(statusProperty);
+                })) {
+            // Build the first player and attach its status listener.
+            playerService.next();
+            WaitForAsyncUtils.waitForFxEvents();
+            // Swap to a fresh player; this must detach the first player's status listener.
+            playerService.play(first);
+            WaitForAsyncUtils.waitForFxEvents();
+        }
+
+        // Simulate the swapped-out player's delayed STOPPED transition.
+        Mockito.clearInvocations(applicationEventPublisher);
+        statusProps.get(0).set(AudioItemPlayer.Status.STOPPED);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        ArgumentCaptor<org.springframework.context.ApplicationEvent> eventCaptor =
+                ArgumentCaptor.forClass(org.springframework.context.ApplicationEvent.class);
+        verify(applicationEventPublisher, Mockito.atLeast(0)).publishEvent(eventCaptor.capture());
+
+        boolean stoppedPublishedAfterSwap = eventCaptor.getAllValues().stream()
+                .anyMatch(e -> e instanceof net.transgressoft.musicott.events.PlaybackStatusChangedEvent p
+                        && p.status == AudioItemPlayer.Status.STOPPED);
+        assertThat(stoppedPublishedAfterSwap)
+                .as("the detached previous player must not emit STOPPED after being swapped out")
+                .isFalse();
+    }
+
+    @SuppressWarnings("unchecked")
+    ObservableAudioItem newPlayableAudioItem(String title) throws Exception {
+        ObservableAudioItem item = mock(ObservableAudioItem.class);
+        Path tempFile = Files.createTempFile("musicott-advance-it-", ".mp3");
+        tempFile.toFile().deleteOnExit();
+        when(item.getPath()).thenReturn(tempFile);
+        when(item.getExtension()).thenReturn("mp3");
+        when(item.getTitleProperty()).thenReturn(new SimpleStringProperty(title));
+
+        var artist = mock(net.transgressoft.commons.music.audio.Artist.class);
+        when(artist.getName()).thenReturn("Test Artist");
+        when(item.getArtistProperty()).thenReturn(new SimpleObjectProperty<>(artist));
+
+        var album = mock(net.transgressoft.commons.music.audio.Album.class);
+        when(album.getName()).thenReturn("Test Album");
+        when(item.getAlbumProperty()).thenReturn(new SimpleObjectProperty<>(album));
+
+        when(item.getCoverImageProperty()).thenReturn(new SimpleObjectProperty<>(Optional.empty()));
+        when(item.getPlayCountProperty()).thenReturn(new SimpleIntegerProperty(0));
+        when(item.getDuration()).thenReturn(Duration.ofSeconds(5));
+        return item;
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewAddTracksIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewAddTracksIT.java
@@ -1,0 +1,262 @@
+package net.transgressoft.musicott.view;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.ListView;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.BorderPane;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.FxAudioItemTestFactory;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.audio.AudioItemTestFactory;
+import net.transgressoft.commons.music.waveform.AudioWaveform;
+import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
+import net.transgressoft.musicott.service.MediaImportService;
+import net.transgressoft.musicott.services.PlayerService;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+import net.transgressoft.musicott.view.custom.table.ArtistAlbumListRow;
+import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
+import net.transgressoft.musicott.view.custom.table.SimpleAudioItemTableView;
+import net.transgressoft.musicott.view.itunes.ItunesImportWizard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static net.transgressoft.commons.music.audio.Artist.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitFor;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration tests verifying that the "Add to play queue" context action in ARTISTS navigation
+ * mode correctly routes through {@link ArtistViewController#getSelectedTracks()} rather than
+ * the empty main-table selection.
+ */
+@JavaFxSpringTest(classes = ArtistViewAddTracksITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("Artist view add-tracks routing")
+class ArtistViewAddTracksIT extends ApplicationTestBase<BorderPane> {
+
+    @Autowired
+    FxControllerAndView<MainController, BorderPane> mainControllerAndView;
+
+    @Autowired
+    NavigationController navigationController;
+
+    @Autowired
+    ArtistViewController artistViewController;
+
+    @Autowired
+    ObservableAudioLibrary audioLibrary;
+
+    @Override
+    protected BorderPane javaFxComponent() {
+        return mainControllerAndView.getView().get();
+    }
+
+    @BeforeEach
+    @Override
+    protected void beforeEach() {
+        super.beforeEach();
+    }
+
+    @Test
+    @DisplayName("add-to-play-queue context action in ARTISTS mode uses the artist-view selection, not the empty main-table selection")
+    void addToPlayQueueInArtistsModeUsesArtistViewSelection() throws Exception {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track = FxAudioItemTestFactory.createFxAudioItem(attributes -> {
+            attributes.setTitle("Kiara");
+            attributes.setArtist(bonobo);
+            attributes.setAlbum(AudioItemTestFactory.createAlbum("Black Sands", bonobo));
+            attributes.setTrackNumber((short) 1);
+            attributes.setDiscNumber((short) 1);
+        }, Set.of(bonobo));
+
+        @SuppressWarnings("unchecked")
+        ObservableList<ObservableAudioItem> libraryItems =
+                (ObservableList<ObservableAudioItem>) audioLibrary.getAudioItemsProperty();
+        Platform.runLater(() -> libraryItems.add(track));
+        waitForFxEvents();
+
+        // Switch to ARTISTS mode
+        setNavigationMode(NavigationController.NavigationMode.ARTISTS);
+
+        // Select the artist so album rows are rendered
+        @SuppressWarnings("unchecked")
+        ListView<Artist> artistsListView = lookup("#artistsListView").queryAs(ListView.class);
+        @SuppressWarnings("unchecked")
+        ListView<ArtistAlbumListRow> albumsListView = lookup("#albumsListView").queryAs(ListView.class);
+
+        Platform.runLater(() -> artistsListView.getSelectionModel().select(bonobo));
+        waitFor(5, TimeUnit.SECONDS, () -> !albumsListView.getItems().isEmpty());
+        waitForFxEvents();
+
+        // Select all tracks in the first album row's embedded table
+        ArtistAlbumListRow albumRow = albumsListView.getItems().get(0);
+        Platform.runLater(albumRow::selectAllAudioItems);
+        waitForFxEvents();
+
+        ObservableList<ObservableAudioItem> artistSelection = artistViewController.getSelectedTracks();
+        assertThat(artistSelection).isNotEmpty();
+
+        // Retrieve the private audioItemContextMenu from MainController via reflection
+        MainController controller = mainControllerAndView.getController();
+        Object audioItemContextMenu = ReflectionTestUtils.getField(controller, "audioItemContextMenu");
+        assertThat(audioItemContextMenu).isNotNull();
+
+        // Invoke show() with an empty main-table selection. In ARTISTS mode the context menu must
+        // substitute the artist-view selection internally before any menu item action fires.
+        ObservableList<ObservableAudioItem> emptyMainTableSelection = FXCollections.emptyObservableList();
+        Platform.runLater(() -> ReflectionTestUtils.invokeMethod(
+                audioItemContextMenu, "show",
+                emptyMainTableSelection, javaFxComponent(), 0.0, 0.0));
+        waitForFxEvents();
+
+        // Read the resolved 'selection' field — it must equal the artist-view selection, not the
+        // empty main-table selection that was passed to show().
+        @SuppressWarnings("unchecked")
+        ObservableList<ObservableAudioItem> resolvedSelection =
+                (ObservableList<ObservableAudioItem>) ReflectionTestUtils.getField(audioItemContextMenu, "selection");
+
+        assertThat(resolvedSelection)
+                .as("context menu selection in ARTISTS mode must equal the artist-view selection")
+                .containsExactlyInAnyOrderElementsOf(artistSelection);
+    }
+
+    @SuppressWarnings("unchecked")
+    void setNavigationMode(NavigationController.NavigationMode mode) {
+        Object target = AopUtils.isAopProxy(navigationController)
+                ? AopTestUtils.getTargetObject(navigationController)
+                : navigationController;
+        var navProp = (javafx.beans.property.ObjectProperty<NavigationController.NavigationMode>)
+                ReflectionTestUtils.getField(target, "navigationModeProperty");
+        Platform.runLater(() -> navProp.set(mode));
+        waitForFxEvents();
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                MainController.class,
+                NavigationController.class,
+                PlayerController.class,
+                PlayQueueController.class,
+                ArtistViewController.class,
+                PlaylistTreeView.class,
+                FullAudioItemTableView.class,
+                SimpleAudioItemTableView.class,
+                ArtistAlbumListRow.class
+        })
+})
+class ArtistViewAddTracksITConfiguration {
+
+    final ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty =
+            new SimpleObjectProperty<>(this, "selected playlist", Optional.empty());
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioLibrary(FXMusicLibrary musicLibrary) throws IOException {
+        return musicLibrary.audioLibrary();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary,
+                                                          ObservableAudioLibrary audioLibrary) throws IOException {
+        return musicLibrary.playlistHierarchy();
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return selectedPlaylistProperty;
+    }
+
+    @Bean
+    public PlayerService playerService() {
+        var service = mock(PlayerService.class);
+        when(service.getPlayQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(service.getHistoryQueueList()).thenReturn(FXCollections.observableArrayList());
+        when(service.currentTrack()).thenReturn(Optional.empty());
+        when(service.getTotalDuration()).thenReturn(java.time.Duration.ZERO);
+        return service;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public AudioWaveformRepository<AudioWaveform, ObservableAudioItem> audioWaveformRepository() {
+        return mock(AudioWaveformRepository.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public MediaImportService mediaImportService() {
+        return mock(MediaImportService.class);
+    }
+
+    @Bean
+    public ItunesImportWizard itunesImportWizard() {
+        return mock(ItunesImportWizard.class);
+    }
+
+    @Bean
+    public javafx.application.Application.Parameters applicationParameters() {
+        return mock(javafx.application.Application.Parameters.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistDragAndDropIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistDragAndDropIT.java
@@ -1,0 +1,315 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Node;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration tests verifying that the dragboard payload for a playlist is a serializable
+ * {@link Integer} id, and that it resolves back to the correct playlist via the hierarchy.
+ */
+@JavaFxSpringTest(classes = PlaylistDragAndDropITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class PlaylistDragAndDropIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    ObservablePlaylistHierarchy playlistRepository;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @Test
+    @DisplayName("PlaylistTreeView playlist id is an Integer and is serializable")
+    void playlistIdIsIntegerAndSerializable(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        var hierarchy = playlistRepository;
+        var playlist = hierarchy.findByName("Drag Playlist").orElseThrow();
+
+        // The id returned by getId() must be an Integer (the dragboard payload type)
+        Object id = playlist.getId();
+        assertThat(id).isInstanceOf(Integer.class);
+
+        // The Integer must be serializable (required for JavaFX dragboard)
+        assertThatCode(() -> {
+            try (var baos = new ByteArrayOutputStream();
+                 var oos = new ObjectOutputStream(baos)) {
+                oos.writeObject(id);
+            }
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PlaylistTreeView drag payload integer id resolves back to the same playlist via hierarchy")
+    void dragPayloadIdResolvesBackToPlaylist(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        var hierarchy = playlistRepository;
+        var playlist = hierarchy.findByName("Drag Playlist").orElseThrow();
+        var id = (Integer) playlist.getId();
+
+        var resolved = hierarchy.findById(id);
+
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get()).isEqualTo(playlist);
+    }
+
+    @Test
+    @DisplayName("PlaylistTreeView resolves drag payload id and moves playlist into a sub-folder without exception")
+    void movePlaylistIntoFolderWithoutException(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        // "Inner Playlist" lives inside "Drag Folder", so findParentPlaylist returns "Drag Folder"
+        // (not ROOT_PLAYLIST), making movePlaylist resolvable via findPlaylistTreeItemGivenPlaylist.
+        var hierarchy = playlistRepository;
+        var playlist = hierarchy.findByName("Inner Playlist").orElseThrow();
+        var targetFolder = hierarchy.findByName("Target Folder").orElseThrow();
+
+        var treeView = playlistTreeView(fxRobot);
+
+        Platform.runLater(() -> treeView.getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        // Simulate what the drop handler does: resolve by id and call movePlaylist
+        var id = (Integer) playlist.getId();
+        var resolvedOpt = hierarchy.findById(id);
+        assertThat(resolvedOpt).isPresent();
+
+        var resolved = resolvedOpt.get();
+        var exception = new AtomicReference<Throwable>();
+        Platform.runLater(() -> {
+            try {
+                treeView.movePlaylist(resolved, targetFolder);
+            } catch (Throwable t) {
+                exception.set(t);
+            }
+        });
+        waitForFxEvents();
+
+        assertThat(exception.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("PlaylistTreeView moves a top-level playlist into a folder without a null-parent exception")
+    void moveTopLevelPlaylistIntoFolderWithoutException(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        // "Drag Playlist" sits directly under ROOT_PLAYLIST, so findParentPlaylist returns the root,
+        // whose tree node is never one of its own children — the case that previously NPE'd at the
+        // null old-parent tree item.
+        var hierarchy = playlistRepository;
+        var playlist = hierarchy.findByName("Drag Playlist").orElseThrow();
+        var targetFolder = hierarchy.findByName("Target Folder").orElseThrow();
+
+        var treeView = playlistTreeView(fxRobot);
+        Platform.runLater(() -> treeView.getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        var resolved = hierarchy.findById((Integer) playlist.getId()).orElseThrow();
+        var exception = new AtomicReference<Throwable>();
+        Platform.runLater(() -> {
+            try {
+                treeView.movePlaylist(resolved, targetFolder);
+            } catch (Throwable t) {
+                exception.set(t);
+            }
+        });
+        waitForFxEvents();
+
+        assertThat(exception.get()).isNull();
+        assertThat(hierarchy.findParentPlaylist(resolved))
+                .isPresent()
+                .get()
+                .extracting(p -> ((ObservablePlaylist) p).getName())
+                .isEqualTo(targetFolder.getName());
+    }
+
+    @Test
+    @DisplayName("PlaylistTreeView moves a top-level folder into another folder, preserving it and its children under the new parent")
+    void moveTopLevelFolderIntoFolderKeepsItAndChildren(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        // "Drag Folder" is a root-level directory containing "Inner Playlist". Moving a directory
+        // previously corrupted the hierarchy (double repository insert) so it vanished from the model.
+        var hierarchy = playlistRepository;
+        var dragFolder = hierarchy.findByName("Drag Folder").orElseThrow();
+        var innerPlaylist = hierarchy.findByName("Inner Playlist").orElseThrow();
+        var targetFolder = hierarchy.findByName("Target Folder").orElseThrow();
+
+        var treeView = playlistTreeView(fxRobot);
+        Platform.runLater(() -> treeView.getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        var resolved = hierarchy.findById((Integer) dragFolder.getId()).orElseThrow();
+        var exception = new AtomicReference<Throwable>();
+        Platform.runLater(() -> {
+            try {
+                treeView.movePlaylist(resolved, targetFolder);
+            } catch (Throwable t) {
+                exception.set(t);
+            }
+        });
+        waitForFxEvents();
+
+        assertThat(exception.get()).isNull();
+        // The folder is now under the target, and is no longer a child of the root.
+        assertThat(hierarchy.findParentPlaylist(resolved))
+                .isPresent()
+                .get()
+                .extracting(p -> ((ObservablePlaylist) p).getName())
+                .isEqualTo(targetFolder.getName());
+        // Its child playlist still belongs to it — the subtree was preserved, not dropped.
+        assertThat(hierarchy.findParentPlaylist(innerPlaylist))
+                .isPresent()
+                .get()
+                .extracting(p -> ((ObservablePlaylist) p).getName())
+                .isEqualTo(dragFolder.getName());
+    }
+
+    @Test
+    @DisplayName("PlaylistTreeView moves a nested playlist back to the first level without exception")
+    void moveNestedPlaylistToFirstLevel(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        // Destination is ROOT_PLAYLIST, whose tree node is the root itself — previously unresolvable,
+        // so first-level moves threw IllegalStateException.
+        var hierarchy = playlistRepository;
+        var innerPlaylist = hierarchy.findByName("Inner Playlist").orElseThrow();
+        var rootPlaylist = hierarchy.findByName("ROOT_PLAYLIST").orElseThrow();
+
+        var treeView = playlistTreeView(fxRobot);
+        Platform.runLater(() -> treeView.getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        var resolved = hierarchy.findById((Integer) innerPlaylist.getId()).orElseThrow();
+        var exception = new AtomicReference<Throwable>();
+        Platform.runLater(() -> {
+            try {
+                treeView.movePlaylist(resolved, rootPlaylist);
+            } catch (Throwable t) {
+                exception.set(t);
+            }
+        });
+        waitForFxEvents();
+
+        assertThat(exception.get()).isNull();
+        assertThat(hierarchy.findParentPlaylist(resolved))
+                .isPresent()
+                .get()
+                .extracting(p -> ((ObservablePlaylist) p).getName())
+                .isEqualTo("ROOT_PLAYLIST");
+    }
+
+    @SuppressWarnings("unchecked")
+    private PlaylistTreeView playlistTreeView(FxRobot fxRobot) {
+        return (PlaylistTreeView) fxRobot.lookup("#playlistTreeView").query();
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class
+        })
+})
+class PlaylistDragAndDropITConfiguration {
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        var folder = repository.createPlaylistDirectory("Drag Folder");
+        var targetFolder = repository.createPlaylistDirectory("Target Folder");
+        var dragPlaylist = repository.createPlaylist("Drag Playlist");
+        repository.addPlaylistsToDirectory(Set.of(folder, targetFolder, dragPlaylist), "ROOT_PLAYLIST");
+        // "Inner Playlist" is nested inside "Drag Folder" so its parent is resolvable in the tree
+        var innerPlaylist = repository.createPlaylist("Inner Playlist");
+        repository.addPlaylistsToDirectory(Set.of(innerPlaylist), "Drag Folder");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,
+    // which would call Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistSelectionIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistSelectionIT.java
@@ -1,0 +1,221 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Node;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALL_AUDIO_ITEMS;
+import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ARTISTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration tests for playlist/navigation selection wiring: sole selection on creation,
+ * mutual exclusivity between playlist tree and nav-mode list, and re-selectability of nav modes.
+ */
+@JavaFxSpringTest(classes = PlaylistSelectionITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class PlaylistSelectionIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    ObservablePlaylistHierarchy playlistRepository;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @Test
+    @DisplayName("NavigationController selects only the newly added playlist after creation")
+    void selectsOnlyNewPlaylistAfterCreation(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        Platform.runLater(() -> treeView(fxRobot).getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        // Click "Test Playlist" first so there is an existing selection
+        fxRobot.clickOn("Test Playlist");
+        waitForFxEvents();
+
+        // Create a new playlist via the controller on the FX thread
+        var newPlaylist = new AtomicReference<ObservablePlaylist>();
+        Platform.runLater(() -> {
+            var p = playlistRepository.createPlaylist("New Playlist");
+            playlistRepository.addPlaylistsToDirectory(Set.of(p), "ROOT_PLAYLIST");
+            newPlaylist.set(p);
+            navigationControllerAndView.getController().addNewPlaylist(p);
+        });
+        waitForFxEvents();
+
+        var selectedItems = treeView(fxRobot).getSelectionModel().getSelectedItems();
+        assertThat(selectedItems).hasSize(1);
+        assertThat(selectedItems.get(0).getValue()).isEqualTo(newPlaylist.get());
+    }
+
+    @Test
+    @DisplayName("NavigationController clears playlist tree when a nav mode is selected")
+    void clearsPlaylistTreeOnNavModeSelection(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        Platform.runLater(() -> treeView(fxRobot).getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        // Select a playlist first
+        fxRobot.clickOn("Test Playlist");
+        waitForFxEvents();
+        assertThat(treeView(fxRobot).getSelectionModel().getSelectedItems()).isNotEmpty();
+
+        // Clicking "All tracks" should clear the tree selection
+        fxRobot.clickOn("All tracks");
+        waitForFxEvents();
+
+        assertThat(treeView(fxRobot).getSelectionModel().getSelectedItem()).isNull();
+        assertThat(navigationControllerAndView.getController().navigationModeProperty().get())
+                .isEqualTo(ALL_AUDIO_ITEMS);
+    }
+
+    @Test
+    @DisplayName("NavigationController clears nav list selection when a playlist is clicked")
+    void clearsNavListSelectionWhenPlaylistIsClicked(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        Platform.runLater(() -> treeView(fxRobot).getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        // Start on "Artists" nav mode (selected by default)
+        assertThat(navigationControllerAndView.getController().navigationModeProperty().get())
+                .isEqualTo(ARTISTS);
+
+        // Click a playlist
+        fxRobot.clickOn("Test Playlist");
+        waitForFxEvents();
+
+        // Nav list should have no selection
+        var navListView = fxRobot.lookup("#navigationModeListView").<javafx.scene.control.ListView<?>>query();
+        assertThat(navListView.getSelectionModel().getSelectedItem()).isNull();
+    }
+
+    @Test
+    @DisplayName("NavigationController re-fires navigationModeProperty when the same nav mode is re-selected")
+    void reFiresNavigationModePropertyOnReSelection(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        Platform.runLater(() -> treeView(fxRobot).getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        // Select a playlist so nav list gets cleared
+        fxRobot.clickOn("Test Playlist");
+        waitForFxEvents();
+
+        var modeChanges = new AtomicReference<Integer>(0);
+        navigationControllerAndView.getController().navigationModeProperty()
+                .addListener((obs, old, newMode) -> modeChanges.updateAndGet(c -> c + 1));
+
+        // Click "All tracks" — nav list was cleared so this is a fresh selection → fires
+        fxRobot.clickOn("All tracks");
+        waitForFxEvents();
+
+        assertThat(modeChanges.get()).isGreaterThanOrEqualTo(1);
+        assertThat(navigationControllerAndView.getController().navigationModeProperty().get())
+                .isEqualTo(ALL_AUDIO_ITEMS);
+    }
+
+    @SuppressWarnings("unchecked")
+    private TreeView<ObservablePlaylist> treeView(FxRobot fxRobot) {
+        return (TreeView<ObservablePlaylist>) fxRobot.lookup("#playlistTreeView").query();
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class
+        })
+})
+class PlaylistSelectionITConfiguration {
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        var testPlaylist = repository.createPlaylist("Test Playlist");
+        repository.addPlaylistsToDirectory(Set.of(testPlaylist), "ROOT_PLAYLIST");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,
+    // which would call Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/services/PlayerService.java
+++ b/src/main/java/net/transgressoft/musicott/services/PlayerService.java
@@ -30,6 +30,7 @@ import net.transgressoft.musicott.view.custom.table.TrackQueueRow;
 import javafx.application.Platform;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.slf4j.Logger;
@@ -66,6 +67,7 @@ public class PlayerService {
 
     private Optional<ObservableAudioItem> currentTrack = Optional.empty();
     private FXAudioItemPlayer trackPlayer;
+    private ChangeListener<Status> statusListener;
     private PlayedEventSubscriber playedEventSubscriber;
     private boolean playingRandom = false;
 
@@ -109,21 +111,29 @@ public class PlayerService {
     public void play(ObservableAudioItem audioItem) {
         if (!audioItem.getPath().toFile().exists()) {
             applicationEventPublisher.publishEvent(new ErrorEvent("File not found", audioItem.getPath().toString(), this));
-        } else {
-            Status status = playerStatus();
-            if (status.equals(STOPPED) || status.equals(PAUSED) || status.equals(UNKNOWN)) {
-                setPlayer(audioItem);
-            } else if (status.equals(PLAYING)) {
-                stop();
-                setPlayer(audioItem);
-            }
+            return;
         }
+        // After a natural end-of-track the core reports READY, which the old branch list
+        // did not handle — causing silent no-ops and broken auto-advance. Treat every
+        // non-PLAYING status as "idle": stop only when actively playing, then always start
+        // a fresh player. setPlayer() disposes any existing player before constructing the new one.
+        if (playerStatus() == PLAYING) {
+            stop();
+        }
+        setPlayer(audioItem);
     }
 
     private void setPlayer(ObservableAudioItem audioItem) {
         // Release the previous player and its subscription before swapping in a new one — the
         // direct callers (previous, playFromQueue, playFromHistoryQueue) do not stop it themselves.
         if (trackPlayer != null) {
+            // Detach the status listener before stopping/disposing the outgoing player. Otherwise
+            // the dispose-time STOPPED transition is delivered asynchronously and reaches the UI
+            // after the new track's labels are bound, clearing them for the rest of the session.
+            if (statusListener != null) {
+                trackPlayer.getStatusProperty().removeListener(statusListener);
+                statusListener = null;
+            }
             trackPlayer.stop();
             trackPlayer.dispose();
         }
@@ -162,8 +172,9 @@ public class PlayerService {
     private void bindMediaPlayer() {
         applicationEventPublisher.publishEvent(new PlaybackStatusChangedEvent(playerStatus(), this));
 
-        trackPlayer.getStatusProperty().addListener((obs, oldStatus, newStatus) ->
-            applicationEventPublisher.publishEvent(new PlaybackStatusChangedEvent(newStatus, this)));
+        statusListener = (obs, oldStatus, newStatus) ->
+            applicationEventPublisher.publishEvent(new PlaybackStatusChangedEvent(newStatus, this));
+        trackPlayer.getStatusProperty().addListener(statusListener);
     }
 
     public void pause() {

--- a/src/main/java/net/transgressoft/musicott/splash/BootProgressTask.java
+++ b/src/main/java/net/transgressoft/musicott/splash/BootProgressTask.java
@@ -74,8 +74,9 @@ public class BootProgressTask extends Task<ConfigurableApplicationContext> {
         // Stage 1 — Spring boot. Per RESEARCH C-SPLASH-1: SpringApplicationBuilder.run()
         // triggers musicLibrary() bean which loads ALL THREE JSON files synchronously
         // inside FXMusicLibrary.builder().build() (audio + playlist + waveform).
+        // Show indeterminate progress while the long stage is running so the bar animates.
         updateMessage(STAGE_LIBRARY);
-        updateProgress(0.0, 1.0);
+        updateProgress(-1, 1);
         ConfigurableApplicationContext context = new SpringApplicationBuilder()
                 .sources(applicationClass)
                 .run();
@@ -92,11 +93,13 @@ public class BootProgressTask extends Task<ConfigurableApplicationContext> {
         // Stage 2 — playlists. The bean is already instantiated by Spring eager init;
         // the access is a no-op trip but the message change is the user-visible signal.
         updateMessage(STAGE_PLAYLISTS);
+        updateProgress(-1, 1);
         context.getBean(ObservablePlaylistHierarchy.class);
         updateProgress(0.5, 1.0);
 
         // Stage 3 — waveforms.
         updateMessage(STAGE_WAVEFORMS);
+        updateProgress(-1, 1);
         context.getBean(AudioWaveformRepository.class);
         updateProgress(0.75, 1.0);
 
@@ -104,6 +107,7 @@ public class BootProgressTask extends Task<ConfigurableApplicationContext> {
         // FX thread inside the orchestrator's setOnSucceeded handler (FxWeaver
         // loadView is not safe off the FX thread per RESEARCH Open Question 2).
         updateMessage(STAGE_UI);
+        updateProgress(-1, 1);
         // Audio library bean access (so the message-change is bracketed by a real bean
         // request, even though it is a no-op trip).
         context.getBean(ObservableAudioLibrary.class);

--- a/src/main/java/net/transgressoft/musicott/view/MainController.java
+++ b/src/main/java/net/transgressoft/musicott/view/MainController.java
@@ -32,6 +32,7 @@ import net.transgressoft.musicott.service.MediaImportService;
 import net.transgressoft.musicott.services.PlayerService;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+import net.transgressoft.musicott.view.custom.alerts.DeleteAudioItemsConfirmationAlert;
 import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
 import net.transgressoft.musicott.view.itunes.ItunesImportWizard;
 import org.apache.commons.io.FileUtils;
@@ -957,8 +958,7 @@ public class MainController {
             MenuItem deleteMenuItem = new MenuItem("Delete");
             deleteMenuItem.setOnAction(event -> {
                 if (! selection.isEmpty()) {
-                    Alert alert = new Alert(Alert.AlertType.CONFIRMATION, "Delete selected track(s)?");
-                    alert.showAndWait().ifPresent(response -> {
+                    new DeleteAudioItemsConfirmationAlert().showAndWait().ifPresent(response -> {
                         if (response == ButtonType.OK) {
                             var selectionSet = new HashSet<>(selection);
                             applicationContext.publishEvent(new DeleteAudioItemsEvent(selectionSet, this));
@@ -985,7 +985,10 @@ public class MainController {
         }
 
         public void show(ObservableList<ObservableAudioItem> selection, Node anchor, double screenX, double screenY) {
-            this.selection = selection;
+            // In ARTISTS mode the main-table selection is always empty; use the artist-view selection instead.
+            this.selection = navigationController.navigationModeProperty().get() == NavigationController.NavigationMode.ARTISTS
+                    ? artistViewController.getSelectedTracks()
+                    : selection;
             playlistsInMenu.clear();
             addToPlaylistMenu.getItems().clear();
 

--- a/src/main/java/net/transgressoft/musicott/view/NavigationController.java
+++ b/src/main/java/net/transgressoft/musicott/view/NavigationController.java
@@ -41,6 +41,11 @@ import static org.fxmisc.easybind.EasyBind.map;
 import static org.fxmisc.easybind.EasyBind.subscribe;
 
 /**
+ * Controller for the application navigation sidebar, managing navigation modes (All Tracks,
+ * Artists) and the playlist tree view. Keeps nav-mode selection and playlist-tree selection
+ * mutually exclusive: selecting a playlist clears the nav list, and switching to a nav mode
+ * clears the playlist tree.
+ *
  * @author Octavio Calleya
  */
 @FxmlView ("/fxml/NavigationController.fxml")
@@ -65,7 +70,7 @@ public class NavigationController {
     }
 
     private static final String GREEN_STATUS_COLOUR = "-fx-text-fill: rgb(99, 255, 109);";
-    private static final String GRAY_STATUS_COLOUR = "-fx-text-fill: rgb(73, 73, 73);";
+    private static final String GRAY_STATUS_COLOUR = "-fx-text-fill: rgb(170, 170, 170);";
 
     private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
@@ -91,6 +96,9 @@ public class NavigationController {
     private MenuItem newFolderPlaylistMI;
     private Optional<ObservablePlaylist> currentPlayingPlaylist;
 
+    // Held as a field so it is accessible to the navigationModeProperty subscriber for clearing.
+    private NavigationMenuListView navigationMenuListView;
+
     @Autowired
     public NavigationController(PlaylistTreeView playlistTreeView,
                                 KeyCombination.Modifier operativeSystemKeyModifier) {
@@ -102,7 +110,7 @@ public class NavigationController {
     @FXML
     public void initialize() {
         currentPlayingPlaylist = Optional.empty();
-        NavigationMenuListView navigationMenuListView = new NavigationMenuListView();
+        navigationMenuListView = new NavigationMenuListView();
 
         ContextMenu newPlaylistButtonContextMenu = new ContextMenu();
         newPlaylistMI = new MenuItem("New Playlist");
@@ -126,19 +134,16 @@ public class NavigationController {
         playlistsVBox.getChildren().add(1, playlistTreeView);
         VBox.setVgrow(playlistTreeView, Priority.ALWAYS);
 
+        // When a playlist is selected, switch navigation mode and clear the nav-list selection
+        // so re-clicking a nav mode always re-fires (no stale same-value skip).
         subscribe(selectedPlaylistProperty(),
-                  playlist -> playlist.ifPresent(
-                          p -> navigationModeProperty.set(NavigationMode.PLAYLIST))
+                  playlist -> playlist.ifPresent(p -> {
+                      navigationMenuListView.getSelectionModel().clearSelection();
+                      navigationModeProperty.set(NavigationMode.PLAYLIST);
+                  })
         );
 
-        subscribe(playlistTreeView.getSelectionModel().selectedItemProperty(), newItem -> {
-           if (newItem != null) {
-               selectedPlaylistProperty().set(Optional.of(newItem.getValue()));
-           } else {
-               selectedPlaylistProperty().set(Optional.empty());
-           }
-        });
-
+        // When switching to a non-playlist nav mode, clear the playlist tree.
         subscribe(navigationModeProperty, mode -> {
             if (mode == ALL_AUDIO_ITEMS || mode == ARTISTS) {
                 playlistTreeView.getSelectionModel().clearSelection();
@@ -256,7 +261,13 @@ public class NavigationController {
             NavigationMode[] navigationModes = { ALL_AUDIO_ITEMS, ARTISTS};
             setItems(FXCollections.observableArrayList(navigationModes));
             setCellFactory(listView -> new NavigationListCell());
-            EasyBind.subscribe(getSelectionModel().selectedItemProperty(), navigationModeProperty::set);
+            // Clear the nav-list selection first so re-clicking the same mode always
+            // re-fires the selectedItemProperty change (no dead same-value skip).
+            getSelectionModel().selectedItemProperty().addListener((obs, oldMode, newMode) -> {
+                if (newMode != null) {
+                    navigationModeProperty.set(newMode);
+                }
+            });
             getSelectionModel().select(ARTISTS);
         }
     }

--- a/src/main/java/net/transgressoft/musicott/view/custom/PlaylistTreeView.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/PlaylistTreeView.java
@@ -42,8 +42,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.fxmisc.easybind.EasyBind.subscribe;
-
 /**
  * Class that extends from a {@link TreeView} representing a tree of
  * {@link ObservablePlaylist} items, which some of them are folders and could have other
@@ -82,7 +80,9 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
         setId("playlistTreeView");
         getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
-        subscribe(getSelectionModel().selectedItemProperty(), newItem -> {
+        // Single place where selectedPlaylistProperty is driven — NavigationController
+        // must NOT add a second listener for the same purpose.
+        getSelectionModel().selectedItemProperty().addListener((obs, oldItem, newItem) -> {
             if (newItem != null) {
                 selectedPlaylistProperty.set(Optional.of(newItem.getValue()));
             }
@@ -202,6 +202,11 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
      * @return The found {@link PlaylistTreeViewItem} or null otherwise
      */
     private PlaylistTreeViewItem findPlaylistTreeItemGivenPlaylist(ObservablePlaylist playlist) {
+        var rootItem = (PlaylistTreeViewItem) getRoot();
+        // The root node holds ROOT_PLAYLIST but is never one of its own children, so the recursive
+        // search below would miss it — match it explicitly so the root is a valid move destination.
+        if (rootItem != null && rootItem.getValue().equals(playlist))
+            return rootItem;
         return findPlaylistTreeItemRecursively(getRoot(), playlist);
     }
 
@@ -227,20 +232,49 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
             logger.error("Destination playlist is not a directory: {}", destinationPlaylistTreeItem.getValue());
             throw new IllegalArgumentException("Destination playlist is not a directory: " + destinationPlaylistTreeItem.getValue());
         } else {
-            var oldPlaylistFolder = playlistRepository.findParentPlaylist(playlistToMove);
-            oldPlaylistFolder.ifPresent(it -> {
+            var movingTreeItem = findPlaylistTreeItemGivenPlaylist(playlistToMove);
+            if (movingTreeItem == null) {
+                logger.warn("Playlist to move not present in the tree: {}", playlistToMove);
+                return;
+            }
+            if (playlistToMove.equals(destinationPlaylist) || isTreeAncestor(movingTreeItem, destinationPlaylistTreeItem)) {
+                logger.debug("Ignoring move of '{}' into itself or a descendant", playlistToMove);
+                return;
+            }
 
-                // The playlist folder where it was before should exist by forAudioPlaylistRepositoryExceptionce because it was included in some other one
-                var oldPlayListFolderTreeItem = findPlaylistTreeItemGivenPlaylist(it);
-                assert(oldPlayListFolderTreeItem != null);
+            // The repository move is authoritative: it removes the playlist from its current parent
+            // and re-parents it under the destination in one step. The tree is then mirrored from
+            // it — never via addNewPlaylist, which would issue a second, conflicting repository
+            // insert and corrupt the hierarchy (the playlist ending up under two parents at once).
+            playlistRepository.movePlaylist(playlistToMove.getName(), destinationPlaylist.getName());
 
-                oldPlayListFolderTreeItem.removePlaylistChild(playlistToMove);
-                addNewPlaylist(playlistToMove, destinationPlaylistTreeItem);
+            var oldParentTreeItem = (PlaylistTreeViewItem) movingTreeItem.getParent();
+            if (oldParentTreeItem != null)
+                oldParentTreeItem.getChildren().remove(movingTreeItem);
+            addPlaylistTreeItemRecursively(playlistToMove, destinationPlaylistTreeItem);
 
-                playlistRepository.movePlaylist(playlistToMove.getName(), destinationPlaylist.getName());
-                selectPlaylist(destinationPlaylist);
-            });
+            selectPlaylist(destinationPlaylist);
         }
+    }
+
+    private boolean isTreeAncestor(PlaylistTreeViewItem candidateAncestor, TreeItem<ObservablePlaylist> node) {
+        for (var parent = node.getParent(); parent != null; parent = parent.getParent()) {
+            if (parent == candidateAncestor)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Mirrors a playlist (and, for a directory, its whole subtree) into the tree under the given
+     * parent item without touching the repository — used by {@link #movePlaylist} after the
+     * repository has already performed the authoritative data move.
+     */
+    private void addPlaylistTreeItemRecursively(ObservablePlaylist playlist, PlaylistTreeViewItem parentTreeItem) {
+        var treeItem = new PlaylistTreeViewItem(playlist);
+        parentTreeItem.getChildren().add(treeItem);
+        if (playlist.isDirectory())
+            playlist.getPlaylists().forEach(child -> addPlaylistTreeItemRecursively(child, treeItem));
     }
 
     /**
@@ -264,7 +298,14 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
                 .toList();
     }
 
+    /**
+     * Selects the given playlist in the tree, clearing any prior selection first so it becomes
+     * the sole selected item.
+     *
+     * @param playlist The {@link ObservablePlaylist} to select
+     */
     public void selectPlaylist(ObservablePlaylist playlist) {
+        getSelectionModel().clearSelection();
         getSelectionModel().select(findPlaylistTreeItemGivenPlaylist(playlist));
     }
 
@@ -408,6 +449,9 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
                 setStyle(DRAG_OVER_STYLE);
                 setOpacity(0.10);
             } else if (event.getDragboard().hasContent(PLAYLIST_DATA_FORMAT)) {
+                // Accept the transfer here too — without it JavaFX rejects the drop on the empty
+                // area and onDragDropped never fires, making "move to the root level" impossible.
+                event.acceptTransferModes(TransferMode.COPY_OR_MOVE);
                 getTreeView().setStyle(DRAG_OVER_ROOT_PLAYLIST_STYLE);
                 dragOnRoot = true;
             }
@@ -434,13 +478,19 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
                     .toList();
                 getItem().addAudioItems(audioItems);
             } else if (dragBoard.hasContent(PLAYLIST_DATA_FORMAT)) {
-                var droppedPlaylist = (ObservablePlaylist) dragBoard.getContent(PLAYLIST_DATA_FORMAT);
-                var isFolder = getItem() != null && ! getTreeItem().isLeaf();
+                var playlistId = (Integer) dragBoard.getContent(PLAYLIST_DATA_FORMAT);
+                var maybePlaylist = playlistRepository.findById(playlistId);
+                if (maybePlaylist.isPresent()) {
+                    var droppedPlaylist = maybePlaylist.get();
+                    var isFolder = getItem() != null && ! getTreeItem().isLeaf();
 
-                if (isFolder && ! droppedPlaylist.equals(getItem()))
-                    movePlaylist(droppedPlaylist, getItem());
-                else if (dragOnRoot)
-                    movePlaylistToFirstLevelHierarchy(droppedPlaylist);
+                    if (isFolder && ! droppedPlaylist.equals(getItem()))
+                        movePlaylist(droppedPlaylist, getItem());
+                    else if (dragOnRoot)
+                        movePlaylistToFirstLevelHierarchy(droppedPlaylist);
+                } else {
+                    logger.warn("Could not resolve dragged playlist from id: {}", playlistId);
+                }
             }
             event.consume();
         }
@@ -459,7 +509,9 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
                 var dragBoard = startDragAndDrop(TransferMode.MOVE);
                 dragBoard.setDragView(snapshot(null, null));
                 var clipboardContent = new ClipboardContent();
-                clipboardContent.put(PLAYLIST_DATA_FORMAT, getItem());
+                // Put the serializable integer id on the dragboard; the drop handler
+                // resolves it back to the playlist via the hierarchy.
+                clipboardContent.put(PLAYLIST_DATA_FORMAT, (Integer) getItem().getId());
                 dragBoard.setContent(clipboardContent);
             }
             event.consume();

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/ApplicationAlertBase.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/ApplicationAlertBase.java
@@ -20,6 +20,7 @@ public abstract class ApplicationAlertBase extends Alert {
         super(alertType);
         getDialogPane().getStylesheets().add(STYLE);
         initModality(Modality.APPLICATION_MODAL);
+        DialogIconHelper.attachAppIconOnShow(this);
         // Filter on DialogPane (not the scene) — getDialogPane().getScene() is unreliable across the dialog lifecycle.
         getDialogPane().addEventFilter(KeyEvent.KEY_PRESSED, ke -> {
             if (ke.getCode() == KeyCode.ESCAPE) {

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/DeleteAudioItemsConfirmationAlert.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/DeleteAudioItemsConfirmationAlert.java
@@ -1,0 +1,17 @@
+package net.transgressoft.musicott.view.custom.alerts;
+
+/**
+ * Confirmation dialog shown before permanently deleting one or more audio items from the library.
+ *
+ * <p>Extends {@link ApplicationAlertBase} so the application icon and dark stylesheet are applied
+ * automatically, matching the visual treatment of all other application dialogs.
+ *
+ * @author Octavio Calleya
+ */
+public class DeleteAudioItemsConfirmationAlert extends ApplicationAlertBase {
+
+    public DeleteAudioItemsConfirmationAlert() {
+        super(AlertType.CONFIRMATION);
+        setContentText("Delete selected track(s)?");
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/DialogIconHelper.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/DialogIconHelper.java
@@ -1,0 +1,42 @@
+package net.transgressoft.musicott.view.custom.alerts;
+
+import net.transgressoft.musicott.view.custom.ApplicationImage;
+
+import javafx.scene.control.Dialog;
+import javafx.stage.Stage;
+
+/**
+ * Utility that attaches the application icon to any {@link Dialog} window once the
+ * window becomes available. Because {@code getDialogPane().getScene().getWindow()}
+ * returns {@code null} at construction time, the icon is wired via
+ * {@link Dialog#setOnShown(javafx.event.EventHandler)} so it is applied the first
+ * time the dialog is shown.
+ *
+ * <p>Use {@link #attachAppIconOnShow(Dialog)} in every dialog and alert constructor
+ * to avoid duplicating the on-show hook logic.
+ *
+ * @author Octavio Calleya
+ */
+final class DialogIconHelper {
+
+    private DialogIconHelper() {}
+
+    /**
+     * Registers an on-show hook on the given dialog that adds
+     * {@link ApplicationImage#APP_ICON} to the dialog window's icon list the first
+     * time the dialog is shown. Re-shows are guarded against duplicate icon additions.
+     *
+     * @param dialog the dialog to attach the icon to
+     */
+    static void attachAppIconOnShow(Dialog<?> dialog) {
+        dialog.setOnShown(e -> {
+            var window = dialog.getDialogPane().getScene().getWindow();
+            if (window instanceof Stage stage) {
+                var icon = ApplicationImage.APP_ICON.get();
+                if (!stage.getIcons().contains(icon)) {
+                    stage.getIcons().add(icon);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/KeyboardShortcutsDialog.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/KeyboardShortcutsDialog.java
@@ -36,6 +36,7 @@ public class KeyboardShortcutsDialog extends Dialog<Void> {
     public KeyboardShortcutsDialog(MenuBar rootMenuBar) {
         getDialogPane().getStylesheets().add(DIALOG_STYLE);
         initModality(Modality.APPLICATION_MODAL);
+        DialogIconHelper.attachAppIconOnShow(this);
         setTitle("Keyboard Shortcuts");
         setResizable(false);
 

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -111,6 +111,7 @@ public class ArtistAlbumListRow extends HBox {
         sizeLabel.textProperty().bind(map(containedAudioItemsProperty.sizeProperty(), this::getAlbumSizeString));
         yearLabel = new Label(buildYearsString());
         yearLabel.setId("yearLabel");
+        yearLabel.getStyleClass().add("album-info-secondary");
 
         var underImageGridPane = new GridPane();
         var cc1 = new ColumnConstraints(COVER_SIZE / 2);
@@ -136,6 +137,7 @@ public class ArtistAlbumListRow extends HBox {
         albumTitleLabel.setMaxWidth(480);
         relatedArtistsLabel = new Label();
         relatedArtistsLabel.setId("relatedArtistsLabel");
+        relatedArtistsLabel.getStyleClass().add("album-info-secondary");
         relatedArtistsLabel.setWrapText(true);
         relatedArtistsLabel.setMaxWidth(480);
         relatedArtistsLabel.setPrefWidth(USE_COMPUTED_SIZE);
@@ -145,12 +147,14 @@ public class ArtistAlbumListRow extends HBox {
         genresLabel.setMaxWidth(480);
         albumLabelLabel = new Label();
         albumLabelLabel.setId("albumLabelLabel");
+        albumLabelLabel.getStyleClass().add("album-info-secondary");
         buildSimpleTableView();
 
         albumInfoVBox = new VBox(albumTitleLabel, genresLabel, audioItemsTableView);
         if (discNumber > 0) {
             var discLabel = new Label("Disc " + discNumber);
             discLabel.setId("discLabel");
+            discLabel.getStyleClass().add("album-info-secondary");
             albumInfoVBox.getChildren().add(1, discLabel);
         }
         VBox.setVgrow(audioItemsTableView, Priority.ALWAYS);
@@ -169,9 +173,10 @@ public class ArtistAlbumListRow extends HBox {
     private String buildYearsString() {
         return containedAudioItems.stream()
                 .filter(track -> track.getAlbum() != null && track.getAlbum().getYear() != null)
-                .map(track -> String.valueOf(track.getAlbum().getYear()))
-                .sorted()
-                .collect(Collectors.joining(", "));
+                .map(track -> track.getAlbum().getYear().intValue())
+                .min(Integer::compareTo)
+                .map(String::valueOf)
+                .orElse("");
     }
 
     private String getAlbumSizeString(Number numberOfTracks) {
@@ -199,7 +204,9 @@ public class ArtistAlbumListRow extends HBox {
                         && entry.getAlbum().getLabel().getName() != null
                         && !entry.getAlbum().getLabel().getName().isEmpty())
                 .map(entry -> entry.getAlbum().getLabel().getName())
-                .collect(Collectors.joining(", "));
+                .distinct()
+                .findFirst()
+                .orElse("");
 
         albumLabelLabel.setText(labelString);
         if (labelString.isEmpty())
@@ -209,10 +216,13 @@ public class ArtistAlbumListRow extends HBox {
     }
 
     private void setRelatedArtistsLabel() {
-        var relatedArtistsString = containedAudioItems.stream()
+        var relatedArtistNames = containedAudioItems.stream()
                 .flatMap(t -> t.getArtistsInvolved().stream().map(Artist::getName))
                 .filter(artistName -> ! artistName.equalsIgnoreCase(artist.getName()))
-                .collect(Collectors.joining(", ", "with ", ""));
+                .distinct()
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .collect(Collectors.joining(", "));
+        var relatedArtistsString = relatedArtistNames.isEmpty() ? "" : "with " + relatedArtistNames;
 
         relatedArtistsLabel.setText(relatedArtistsString);
         if (relatedArtistsString.isEmpty())
@@ -278,26 +288,10 @@ public class ArtistAlbumListRow extends HBox {
                 .anyMatch(name -> name.toLowerCase().contains(lowerCaseQuery))) {
             return true;
         }
-        if (albumMatchesQuery(item.getAlbum(), lowerCaseQuery)) {
+        if (AudioItemTableViewBase.albumContainsQuery(item.getAlbum(), lowerCaseQuery)) {
             return true;
         }
         return item.getComments() != null && item.getComments().toLowerCase().contains(lowerCaseQuery);
-    }
-
-    @SuppressWarnings("java:S2589")
-    private static boolean albumMatchesQuery(Album album, String lowerCaseQuery) {
-        if (album == null) {
-            return false;
-        }
-        if (album.getName() != null && album.getName().toLowerCase().contains(lowerCaseQuery)) {
-            return true;
-        }
-        if (album.getAlbumArtist() != null && album.getAlbumArtist().getName() != null
-                && album.getAlbumArtist().getName().toLowerCase().contains(lowerCaseQuery)) {
-            return true;
-        }
-        return album.getLabel() != null && album.getLabel().getName() != null
-                && album.getLabel().getName().toLowerCase().contains(lowerCaseQuery);
     }
 
     /**
@@ -308,14 +302,14 @@ public class ArtistAlbumListRow extends HBox {
      * @return The {@link IntegerProperty} of the audioItem number
      */
     private ReadOnlyIntegerProperty listenAudioItemChangesAndSort(ObservableAudioItem audioItem) {
-        subscriptions.add(subscribe(audioItem.getTrackNumberProperty(), tn -> containedAudioItems.sort(this::audioItemComparator)));
-        subscriptions.add(subscribe(audioItem.getDiscNumberProperty(), dn -> containedAudioItems.sort(this::audioItemComparator)));
-        subscriptions.add(subscribe(audioItem.getGenresProperty(), g -> genresLabel.setText(buildGenresString())));
-        subscriptions.add(subscribe(audioItem.getAlbumProperty(), y -> {
+        subscriptions.add(subscribe(audioItem.getTrackNumberProperty(), _ -> containedAudioItems.sort(this::audioItemComparator)));
+        subscriptions.add(subscribe(audioItem.getDiscNumberProperty(), _ -> containedAudioItems.sort(this::audioItemComparator)));
+        subscriptions.add(subscribe(audioItem.getGenresProperty(), _ -> genresLabel.setText(buildGenresString())));
+        subscriptions.add(subscribe(audioItem.getAlbumProperty(), _ -> {
             yearLabel.setText(buildYearsString());
             updateAlbumLabelLabel();
         }));
-        subscriptions.add(subscribe(audioItem.getArtistsInvolvedProperty(), ai ->
+        subscriptions.add(subscribe(audioItem.getArtistsInvolvedProperty(), _ ->
                 Platform.runLater(() -> {
                     setRelatedArtistsLabel();
                     setArtistColumn();

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
@@ -299,7 +299,7 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
     }
 
     @SuppressWarnings("java:S2589")
-    private static boolean albumContainsQuery(Album album, String query) {
+    static boolean albumContainsQuery(Album album, String query) {
         if (album == null) {
             return false;
         }

--- a/src/main/resources/css/artists.css
+++ b/src/main/resources/css/artists.css
@@ -73,14 +73,12 @@
     -fx-padding: 0px 0px 10px 0px;
 }
 
-#albumLabelLabel {
-    -fx-font-size: 16px;
-    -fx-padding: 0px 0px 5px 0px;
-}
-
-#relatedArtistsLabel {
-    -fx-font-size: 15px;
-    -fx-padding: 0px 0px 5px 0px;
+/* Shared style for secondary album-info labels: disc, year, album-label, and related-artists.
+   Keeps them visually subordinate to the primary album and artist title labels. */
+.album-info-secondary {
+    -fx-font-size: 13px;
+    -fx-text-fill: rgb(145, 145, 145);
+    -fx-padding: 0px 0px 4px 0px;
 }
 
 #genresLabel {

--- a/src/main/resources/css/navigation.css
+++ b/src/main/resources/css/navigation.css
@@ -84,3 +84,7 @@
 #playlistsLabel, #libraryLabel {
 	-fx-font-size: 12px;
 }
+
+#statusLabel {
+	-fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.6), 1, 0.0, 0, 1);
+}

--- a/src/test/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRowLabelTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRowLabelTest.java
@@ -1,0 +1,158 @@
+package net.transgressoft.musicott.view.custom.table;
+
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+import net.transgressoft.commons.fx.music.FxAudioItemTestFactory;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.music.audio.AlbumSet;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.audio.AudioItemTestFactory;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.util.List;
+import java.util.Set;
+
+import static net.transgressoft.commons.music.audio.Artist.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the album-info label logic in {@link ArtistAlbumListRow}: related-artists,
+ * year, and album-label display rules.
+ */
+@ExtendWith({ApplicationExtension.class, MockitoExtension.class})
+@DisplayName("ArtistAlbumListRow")
+class ArtistAlbumListRowLabelTest {
+
+    SimpleAudioItemTableView tableView;
+
+    @Start
+    void start(Stage stage) {}
+
+    @BeforeEach
+    void setUp() {
+        tableView = new SimpleAudioItemTableView(mock(ApplicationEventPublisher.class));
+    }
+
+    @Test
+    @DisplayName("related-artists label is absent from the layout when all involved artists are the same as the primary artist")
+    void relatedArtistsLabelIsAbsentWhenNoOtherArtistsAreInvolved() {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track = audioItem("Kiara", bonobo, "Black Sands", bonobo, Set.of(bonobo));
+
+        var row = new ArtistAlbumListRow(bonobo, albumSet("Black Sands", track), tableView, 0);
+
+        // When no other artists are involved the label is removed from the VBox; lookup returns null.
+        assertThat(row.lookup("#relatedArtistsLabel")).isNull();
+    }
+
+    @Test
+    @DisplayName("related-artists label shows 'with <name>' when other artists are involved")
+    void relatedArtistsLabelShowsWithPrefixWhenOtherArtistsAreInvolved() {
+        Artist bonobo = of("Bonobo");
+        Artist guest = of("Erykah Badu");
+        ObservableAudioItem track = audioItem("Kiara", bonobo, "Black Sands", bonobo, Set.of(bonobo, guest));
+
+        var row = new ArtistAlbumListRow(bonobo, albumSet("Black Sands", track), tableView, 0);
+
+        Label relatedArtistsLabel = (Label) row.lookup("#relatedArtistsLabel");
+        assertThat(relatedArtistsLabel).isNotNull();
+        assertThat(relatedArtistsLabel.getText()).startsWith("with ");
+        assertThat(relatedArtistsLabel.getText()).contains("Erykah Badu");
+        assertThat(relatedArtistsLabel.getText()).doesNotContain("Bonobo");
+    }
+
+    @Test
+    @DisplayName("year label shows only the first (lowest) year when tracks in the same album span different years")
+    void yearLabelShowsSingleYearWhenTracksHaveDifferentYears() {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track1 = audioItemWithYear("Kiara", bonobo, "Black Sands", (short) 2010);
+        ObservableAudioItem track2 = audioItemWithYear("Kiara (Live)", bonobo, "Black Sands", (short) 2012);
+
+        var row = new ArtistAlbumListRow(bonobo, albumSet("Black Sands", track1, track2), tableView, 0);
+
+        Label yearLabel = (Label) row.lookup("#yearLabel");
+        assertThat(yearLabel).isNotNull();
+        assertThat(yearLabel.getText()).doesNotContain(",");
+        assertThat(yearLabel.getText()).isEqualTo("2010");
+    }
+
+    @Test
+    @DisplayName("album-label label shows a single value when multiple tracks share the same label")
+    void albumLabelLabelShowsSingleValueWhenTracksDuplicateTheSameLabel() {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track1 = audioItemWithLabel("Kiara", bonobo, "Black Sands", "Ninja Tune");
+        ObservableAudioItem track2 = audioItemWithLabel("Kong", bonobo, "Black Sands", "Ninja Tune");
+
+        var row = new ArtistAlbumListRow(bonobo, albumSet("Black Sands", track1, track2), tableView, 0);
+
+        Label albumLabelLabel = (Label) row.lookup("#albumLabelLabel");
+        assertThat(albumLabelLabel).isNotNull();
+        assertThat(albumLabelLabel.getText()).doesNotContain(",");
+        assertThat(albumLabelLabel.getText()).isEqualTo("Ninja Tune");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AlbumSet<ObservableAudioItem> albumSet(String albumName, ObservableAudioItem... tracks) {
+        var list = List.of(tracks);
+        AlbumSet<ObservableAudioItem> albumSet = mock(AlbumSet.class);
+        lenient().when(albumSet.getAlbumName()).thenReturn(albumName);
+        lenient().when(albumSet.stream()).thenAnswer(inv -> list.stream());
+        lenient().when(albumSet.iterator()).thenAnswer(inv -> list.iterator());
+        lenient().when(albumSet.size()).thenReturn(list.size());
+        lenient().when(albumSet.isEmpty()).thenReturn(list.isEmpty());
+        lenient().when(albumSet.toArray()).thenReturn(list.toArray());
+        lenient().when(albumSet.toArray(any(ObservableAudioItem[].class))).thenAnswer(inv -> list.toArray(inv.<ObservableAudioItem[]>getArgument(0)));
+        return albumSet;
+    }
+
+    private static ObservableAudioItem audioItem(
+            String title,
+            Artist artist,
+            String albumName,
+            Artist albumArtist,
+            Set<Artist> artistsInvolved) {
+        return FxAudioItemTestFactory.createFxAudioItem(attributes -> {
+            attributes.setTitle(title);
+            attributes.setArtist(artist);
+            attributes.setAlbum(AudioItemTestFactory.createAlbum(albumName, albumArtist));
+            attributes.setTrackNumber((short) 1);
+            attributes.setDiscNumber((short) 1);
+        }, artistsInvolved);
+    }
+
+    private static ObservableAudioItem audioItemWithYear(
+            String title,
+            Artist artist,
+            String albumName,
+            short year) {
+        return FxAudioItemTestFactory.createFxAudioItem(attributes -> {
+            attributes.setTitle(title);
+            attributes.setArtist(artist);
+            attributes.setAlbum(AudioItemTestFactory.createAlbum(albumName, artist, false, year));
+            attributes.setTrackNumber((short) 1);
+            attributes.setDiscNumber((short) 1);
+        }, Set.of(artist));
+    }
+
+    private static ObservableAudioItem audioItemWithLabel(
+            String title,
+            Artist artist,
+            String albumName,
+            String labelName) {
+        return FxAudioItemTestFactory.createFxAudioItem(attributes -> {
+            attributes.setTitle(title);
+            attributes.setArtist(artist);
+            attributes.setAlbum(AudioItemTestFactory.createAlbum(
+                    albumName, artist, false, null,
+                    net.transgressoft.commons.music.audio.Label.of(labelName)));
+            attributes.setTrackNumber((short) 1);
+            attributes.setDiscNumber((short) 1);
+        }, Set.of(artist));
+    }
+}


### PR DESCRIPTION
Closes #65.

Resolves eight reported defects across playback, the playlist tree, the artist view, and UI polish. Each fix is scoped to its defect with no broader refactors, and headless regression coverage is added where the behavior is testable without a display.

## Fixes

- **Playback auto-advance** — `PlayerService.play()` no longer ignores the post-finish `READY` status, so the next queued track starts and the waveform + title/artist/album labels update instead of disappearing. The previous player's status listener is now detached on swap, so a late `STOPPED` transition can no longer permanently unbind the new track's labels.
- **Playlist / navigation selection** — a newly created playlist or folder becomes the sole selection, multi-select requires CTRL, and the navigation list and playlist tree are mutually exclusive with no stale cross-view selection or dead re-selection state.
- **Playlist & folder drag-and-drop** — the dragboard carries a serializable playlist id resolved via the hierarchy on drop. The move is driven solely by the repository (authoritative re-parent) and mirrored into the tree, instead of a second conflicting insert that corrupted the hierarchy and made dragged folders vanish. Moving a node back to the first level now works (root resolved as a valid destination and the empty-area drop is accepted), and moving into self or a descendant is ignored.
- **Add selected tracks in the Artists view** — routed through the active artist-view selection so it works identically to the All Tracks view.
- **Status label legibility** — a subtle text drop-shadow plus a lighter idle colour keep the message readable whether or not a progress bar is shown behind it.
- **Dialog icon + stylesheet** — every window, alert, and dialog carries the application icon (attached on show) and stylesheet; the raw delete-tracks alert is replaced with the styled base.
- **Splash progress** — the startup splash shows indeterminate progress while each boot stage is in flight, so a slow boot no longer appears frozen.
- **ArtistAlbumListRow labels** — related-artists hidden when empty; year and album-label show a single de-duplicated value; the secondary labels share one CSS class for consistent size, colour, and spacing.

## Tests

Adds headless regression coverage: `PlayerServiceAutoAdvanceIT` (incl. the player-swap listener-detach case), `PlaylistSelectionIT`, `PlaylistDragAndDropIT` (top-level playlist move, top-level folder move preserving children, nested→first-level move), `ArtistViewAddTracksIT`, and `ArtistAlbumListRowLabelTest`.

`gradle build` passes green across all four source sets (unit, integration, UI, e2e). Visual/audio items (status shadow, dialog icons, splash animation, end-of-track audio, root-drop gesture) verified manually in the running app.