### PR TITLE
Add playlist .m3u/.m3u8 export and import

### DIFF
--- a/gradle/sonar.gradle
+++ b/gradle/sonar.gradle
@@ -19,5 +19,13 @@ sonar {
                 'build/test-results/uiTest',
                 'build/test-results/e2eTest'
         ].join(',')
+
+        // The CSS analyzer validates against W3C CSS, but these are JavaFX stylesheets. JavaFX
+        // defines its own pseudo-classes (:vertical, :horizontal, :selected) and supports custom
+        // ones set programmatically via PseudoClass (:albums, :genres, ...), so S4659
+        // "unknown pseudo-class selector" does not apply here.
+        property 'sonar.issue.ignore.multicriteria', 'javafxCssPseudoClasses'
+        property 'sonar.issue.ignore.multicriteria.javafxCssPseudoClasses.ruleKey', 'css:S4659'
+        property 'sonar.issue.ignore.multicriteria.javafxCssPseudoClasses.resourceKey', '**/*.css'
     }
 }

--- a/gradle/test-suites.gradle
+++ b/gradle/test-suites.gradle
@@ -130,7 +130,7 @@ dependencies {
     testFixturesImplementation libs.kotlinx.coroutines.test
     testFixturesImplementation libs.junit.jupiter
 
-    testImplementation testFixtures(project)
+    testImplementation testFixtures(project(':'))
     testImplementation libs.bundles.music.commons.test
     testImplementation libs.hamcrest
     testImplementation libs.mockito.core
@@ -140,9 +140,9 @@ dependencies {
     testImplementation libs.kotlinx.coroutines.test
     testImplementation libs.junit.jupiter
 
-    integrationTestImplementation testFixtures(project)
-    uiTestImplementation testFixtures(project)
-    e2eTestImplementation testFixtures(project)
+    integrationTestImplementation testFixtures(project(':'))
+    uiTestImplementation testFixtures(project(':'))
+    e2eTestImplementation testFixtures(project(':'))
 }
 
 test {

--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewAddTracksIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewAddTracksIT.java
@@ -9,6 +9,8 @@ import javafx.scene.Node;
 import javafx.scene.control.ListView;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.BorderPane;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
 import net.rgielen.fxweaver.core.FxControllerAndView;
 import net.rgielen.fxweaver.core.FxWeaver;
 import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
@@ -20,6 +22,7 @@ import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.waveform.AudioWaveform;
@@ -54,6 +57,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static net.transgressoft.commons.music.audio.Artist.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -244,6 +248,22 @@ class ArtistViewAddTracksITConfiguration {
     @Bean
     public AlertFactory alertFactory() {
         return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerPlaylistFolderIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerPlaylistFolderIT.java
@@ -3,6 +3,7 @@ package net.transgressoft.musicott.view;
 import net.transgressoft.commons.fx.music.FXMusicLibrary;
 import net.transgressoft.commons.fx.music.audio.*;
 import net.transgressoft.commons.fx.music.playlist.*;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.commons.music.waveform.AudioWaveform;
 import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
 import net.transgressoft.musicott.service.MediaImportService;
@@ -46,6 +47,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.testfx.api.FxRobot;
 import org.testfx.util.WaitForAsyncUtils;
 
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -54,6 +58,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -290,6 +295,22 @@ class MainControllerPlaylistFolderITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
@@ -4,6 +4,7 @@ import net.transgressoft.commons.fx.music.FXMusicLibrary;
 import net.transgressoft.commons.fx.music.audio.ObservableArtistCatalog;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
@@ -50,6 +51,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -61,6 +65,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -347,6 +352,22 @@ class MainControllerRandomPlaybackITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/integrationTest/java/net/transgressoft/musicott/view/NavigationControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/NavigationControllerIT.java
@@ -3,6 +3,7 @@ package net.transgressoft.musicott.view;
 import net.transgressoft.commons.fx.music.*;
 import net.transgressoft.commons.fx.music.audio.*;
 import net.transgressoft.commons.fx.music.playlist.*;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -32,8 +33,13 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Scope;
 import org.testfx.api.FxRobot;
 
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALBUMS;
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.GENRES;
@@ -220,6 +226,27 @@ class NavigationControllerITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/integrationTest/java/net/transgressoft/musicott/view/NavigationControllerM3uExportIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/NavigationControllerM3uExportIT.java
@@ -1,0 +1,267 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
+import net.transgressoft.musicott.events.ErrorEvent;
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Node;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import org.mockito.Mockito;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration test for the M3U export feature of {@link NavigationController},
+ * verifying that selected playlists are written to {@code .m3u} files in the chosen directory
+ * and that correct feedback events are published on success and failure.
+ */
+@JavaFxSpringTest(classes = NavigationControllerM3uExportITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("NavigationController M3U export")
+class NavigationControllerM3uExportIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @AfterAll
+    static void cleanUpExportedFiles() throws IOException {
+        // deleteOnExit() only removes the (then non-empty) directory; recursively delete the .m3u
+        // files written during the tests so nothing leaks into the OS temp directory.
+        FileUtils.deleteDirectory(NavigationControllerM3uExportITConfiguration.TEMP_DIR.toFile());
+    }
+
+    @Test
+    @DisplayName("exports selected playlists to .m3u files in the chosen directory")
+    void exportsSelectedPlaylistsToM3uFiles(FxRobot fxRobot) throws TimeoutException {
+        waitForFxEvents();
+
+        NavigationController controller = navigationControllerAndView.getController();
+
+        // Expand root and select "Playlist Alpha" in the tree
+        TreeView<ObservablePlaylist> treeView = fxRobot.lookup("#playlistTreeView").query();
+        Platform.runLater(() -> treeView.getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        fxRobot.clickOn("Playlist Alpha");
+        waitForFxEvents();
+
+        // Invoke the event listener directly — the mocked DirectoryChooser returns TEMP_DIR
+        controller.exportSelectedPlaylists();
+        waitForFxEvents();
+
+        // Poll for the off-thread export to write the file rather than sleeping a fixed duration
+        File exported = new File(NavigationControllerM3uExportITConfiguration.TEMP_DIR.toFile(), "Playlist Alpha.m3u");
+        WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, exported::exists);
+
+        // The success StatusMessageUpdateEvent is published later on the FX thread, after the export
+        // future completes — poll for it too so the assertion below cannot race the file write.
+        WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, () -> eventPublished(applicationEventPublisher, StatusMessageUpdateEvent.class));
+        waitForFxEvents();
+
+        // The selected playlist's .m3u file must exist in TEMP_DIR
+        assertThat(exported).exists();
+
+        // A StatusMessageUpdateEvent must have been published via the mocked publisher
+        verify(applicationEventPublisher).publishEvent(
+                argThat(event -> event instanceof StatusMessageUpdateEvent &&
+                        ((StatusMessageUpdateEvent) event).statusMessage.contains("playlist")));
+    }
+
+    @Test
+    @DisplayName("publishes error event on collision without overwriting the existing file")
+    void publishesErrorEventOnCollision(FxRobot fxRobot) throws IOException, TimeoutException {
+        waitForFxEvents();
+
+        // Pre-create the target file to force a collision for "Playlist Beta"
+        File collision = new File(NavigationControllerM3uExportITConfiguration.TEMP_DIR.toFile(), "Playlist Beta.m3u");
+        Files.writeString(collision.toPath(), "# pre-existing");
+
+        // Expand root and select "Playlist Beta"
+        NavigationController controller = navigationControllerAndView.getController();
+        TreeView<ObservablePlaylist> treeView = fxRobot.lookup("#playlistTreeView").query();
+        Platform.runLater(() -> treeView.getRoot().setExpanded(true));
+        waitForFxEvents();
+
+        fxRobot.clickOn("Playlist Beta");
+        waitForFxEvents();
+
+        // Invoke the export listener directly
+        controller.exportSelectedPlaylists();
+        waitForFxEvents();
+
+        // Poll until the aggregated failure has been published as an ErrorEvent rather than sleeping
+        WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, () -> eventPublished(applicationEventPublisher, ErrorEvent.class));
+        waitForFxEvents();
+
+        // An ErrorEvent must have been published
+        verify(applicationEventPublisher).publishEvent(
+                argThat(event -> event instanceof ErrorEvent));
+
+        // The pre-existing file must not have been overwritten
+        assertThat(Files.readString(collision.toPath())).isEqualTo("# pre-existing");
+    }
+
+    private static boolean eventPublished(ApplicationEventPublisher publisher, Class<?> eventType) {
+        return Mockito.mockingDetails(publisher).getInvocations().stream()
+                .flatMap(invocation -> Arrays.stream(invocation.getArguments()))
+                .anyMatch(eventType::isInstance);
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class
+        })
+})
+class NavigationControllerM3uExportITConfiguration {
+
+    // Shared temp directory created eagerly so it can be returned by both the bean and the test
+    static final Path TEMP_DIR;
+    static {
+        try {
+            TEMP_DIR = Files.createTempDirectory("musicott-m3u-export-it");
+            TEMP_DIR.toFile().deleteOnExit();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create temp dir for M3U export IT", e);
+        }
+    }
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        var alpha = repository.createPlaylist("Playlist Alpha");
+        var beta = repository.createPlaylist("Playlist Beta");
+        repository.addPlaylistsToDirectory(Set.of(alpha, beta), "ROOT_PLAYLIST");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected it export playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        // Mock DirectoryChooser always returns the shared temp dir so tests can inspect written files
+        DirectoryChooser mockChooser = mock(DirectoryChooser.class);
+        when(mockChooser.showDialog(any())).thenReturn(TEMP_DIR.toFile());
+        return () -> mockChooser;
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        // Stub; not used by the export flow but required by the NavigationController constructor
+        FileChooser mockChooser = mock(FileChooser.class);
+        return () -> mockChooser;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring shutdown(), which would call
+    // Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/NavigationControllerM3uImportIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/NavigationControllerM3uImportIT.java
@@ -1,0 +1,246 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportException;
+import net.transgressoft.commons.music.m3u.M3uImportService;
+import net.transgressoft.musicott.events.ErrorEvent;
+import net.transgressoft.musicott.events.ImportPlaylistsFromM3uEvent;
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Node;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.testfx.util.WaitForAsyncUtils;
+
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration test for the M3U import feature of {@link NavigationController},
+ * verifying that a file selected via the {@link FileChooser} is imported via
+ * {@link M3uImportService}, nested under {@code ROOT_PLAYLIST}, and that the
+ * correct feedback events are published on success and hard failure.
+ */
+@JavaFxSpringTest(classes = NavigationControllerM3uImportITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("NavigationController M3U import")
+class NavigationControllerM3uImportIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    FXMusicLibrary musicLibrary;
+
+    @Autowired
+    FileChooserHolder fileChooserHolder;
+
+    @Autowired
+    @SuppressWarnings("unchecked")
+    M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @Test
+    @DisplayName("imports m3u file and nests the playlist under ROOT_PLAYLIST")
+    void importsM3uFileAndNestsUnderRootPlaylist(FxRobot fxRobot, @TempDir Path tempDir) throws IOException, TimeoutException {
+        waitForFxEvents();
+
+        Path m3uFile = tempDir.resolve("MyImportedPlaylist.m3u");
+        Files.writeString(m3uFile, "#EXTM3U\n");
+
+        // Create the playlist the service will return
+        ObservablePlaylist importedPlaylist = musicLibrary.playlistHierarchy().createPlaylist("MyImportedPlaylist");
+        doReturn(CompletableFuture.completedFuture(importedPlaylist)).when(m3uImportService).importAsync(any());
+        when(fileChooserHolder.mock.showOpenDialog(any())).thenReturn(m3uFile.toFile());
+
+        NavigationController controller = navigationControllerAndView.getController();
+        controller.importPlaylistFromM3u();
+
+        // The controller nests the imported playlist under ROOT_PLAYLIST off the FX thread; poll
+        // until it appears there rather than sleeping for a fixed duration.
+        ObservablePlaylistHierarchy hierarchy = musicLibrary.playlistHierarchy();
+        WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, () -> hierarchy.findByName(PlaylistTreeView.ROOT_PLAYLIST_NAME)
+                .map(root -> root.getPlaylists().stream().anyMatch(p -> p.getName().equals("MyImportedPlaylist")))
+                .orElse(false));
+
+        // The imported playlist must be nested under ROOT_PLAYLIST, not merely present in the repository
+        ObservablePlaylist root = hierarchy.findByName(PlaylistTreeView.ROOT_PLAYLIST_NAME).orElseThrow();
+        assertThat(root.getPlaylists()).anyMatch(p -> p.getName().equals("MyImportedPlaylist"));
+
+        // A StatusMessageUpdateEvent with the playlist name must have been published
+        verify(applicationEventPublisher).publishEvent(
+                argThat(event -> event instanceof StatusMessageUpdateEvent &&
+                        ((StatusMessageUpdateEvent) event).statusMessage.contains("MyImportedPlaylist")));
+    }
+
+    @Test
+    @DisplayName("publishes error event on hard import failure")
+    void publishesErrorEventOnHardFailure(FxRobot fxRobot, @TempDir Path tempDir) throws IOException, InterruptedException {
+        waitForFxEvents();
+
+        Path m3uFile = tempDir.resolve("BadPlaylist.m3u");
+        Files.writeString(m3uFile, "#EXTM3U\n");
+
+        // Configure the service to fail with M3uImportException
+        CompletableFuture<ObservablePlaylist> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new M3uImportException("Playlist with name 'BadPlaylist' already exists"));
+        doReturn(failedFuture).when(m3uImportService).importAsync(any());
+        when(fileChooserHolder.mock.showOpenDialog(any())).thenReturn(m3uFile.toFile());
+
+        NavigationController controller = navigationControllerAndView.getController();
+        controller.importPlaylistFromM3u();
+        waitForFxEvents();
+
+        // The already-completed failed future resolves synchronously; the error is published on the
+        // next FX pulse, so pumping the FX queue is sufficient without a fixed sleep.
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // An ErrorEvent must have been published
+        verify(applicationEventPublisher).publishEvent(argThat(event -> event instanceof ErrorEvent));
+    }
+}
+
+/**
+ * Holder for the shared mutable {@link FileChooser} mock, allowing the test body
+ * to configure its return value after the Spring context is fully built.
+ */
+class FileChooserHolder {
+    final FileChooser mock = mock(FileChooser.class);
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class
+        })
+})
+class NavigationControllerM3uImportITConfiguration {
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected it import playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public FileChooserHolder fileChooserHolder() {
+        return new FileChooserHolder();
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier(FileChooserHolder holder) {
+        // Return the shared mock so tests can configure showOpenDialog() before firing the event
+        return () -> holder.mock;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        // Mocked so individual tests can configure importAsync() return values as needed
+        return mock(M3uImportService.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring shutdown(), which would call
+    // Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistDragAndDropIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistDragAndDropIT.java
@@ -1,13 +1,16 @@
 package net.transgressoft.musicott.view;
 
 import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
 import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
@@ -16,6 +19,8 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
 import net.rgielen.fxweaver.core.FxControllerAndView;
 import net.rgielen.fxweaver.core.FxWeaver;
 import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
@@ -39,6 +44,7 @@ import java.io.Serializable;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -293,6 +299,27 @@ class PlaylistDragAndDropITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistSelectionIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/PlaylistSelectionIT.java
@@ -1,13 +1,16 @@
 package net.transgressoft.musicott.view;
 
 import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
 import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
@@ -16,6 +19,8 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
 import net.rgielen.fxweaver.core.FxControllerAndView;
 import net.rgielen.fxweaver.core.FxWeaver;
 import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
@@ -36,6 +41,7 @@ import org.testfx.api.FxRobot;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALL_AUDIO_ITEMS;
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ARTISTS;
@@ -199,6 +205,27 @@ class PlaylistSelectionITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/main/java/net/transgressoft/musicott/events/ImportPlaylistsFromM3uEvent.java
+++ b/src/main/java/net/transgressoft/musicott/events/ImportPlaylistsFromM3uEvent.java
@@ -1,0 +1,16 @@
+package net.transgressoft.musicott.events;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Published when the user requests to import an M3U playlist file into the music library.
+ * The listener resolves the actual file path via a {@link javafx.stage.FileChooser} dialog.
+ *
+ * @author Octavio Calleya
+ */
+public class ImportPlaylistsFromM3uEvent extends ApplicationEvent {
+
+    public ImportPlaylistsFromM3uEvent(Object source) {
+        super(source);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/AlbumViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/AlbumViewController.java
@@ -75,7 +75,6 @@ public class AlbumViewController {
     private StackPane albumsRootPane;
 
     private GridView<ObservableAlbum> albumGridView;
-    private ObservableList<ObservableAlbum> albumsBacking;
     private FilteredList<ObservableAlbum> filteredAlbums;
 
     /** The shared overlay drawer showing the selected album's tracks. */
@@ -127,7 +126,7 @@ public class AlbumViewController {
      * routed through {@link Platform#runLater} defensively so the grid never mutates off-thread.
      */
     private void configureGridBacking() {
-        albumsBacking = FXCollections.observableArrayList(audioRepository.getAlbumsProperty());
+        ObservableList<ObservableAlbum> albumsBacking = FXCollections.observableArrayList(audioRepository.getAlbumsProperty());
         logger.info("Albums view initialised with {} albums", albumsBacking.size());
 
         // Mirror the ordered projection wholesale on every change so the grid preserves its
@@ -251,6 +250,9 @@ public class AlbumViewController {
      * @param album the album to section
      * @return ordered list of {@code (AlbumTrackGroup, discNumber)} pairs
      */
+    // Defensive null guard — a mock or partially-built album can return a null track list despite
+    // the non-null domain contract; this must not NPE.
+    @SuppressWarnings("java:S2589")
     List<Map.Entry<AlbumTrackGroup, Integer>> buildAlbumSections(ObservableAlbum album) {
         var tracks = album.getTracks();
         if (tracks == null || tracks.isEmpty()) {
@@ -381,6 +383,9 @@ public class AlbumViewController {
      * Resolves the artist line shown under an album title: the album artist when set, "Various
      * Artists" for compilations, otherwise the primary artist of the album's first track.
      */
+    // Defensive null guards — a mock or partially-built album can return a null album artist, track
+    // list, or per-track artist/name despite the non-null domain contract; this must not NPE.
+    @SuppressWarnings("java:S2589")
     private static String displayArtist(ObservableAlbum album) {
         var albumArtist = album.getAlbumArtist();
         if (albumArtist != null && albumArtist.getName() != null && !albumArtist.getName().isBlank()) {

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -322,11 +322,12 @@ public class ArtistViewController {
         if (selectedArtistCatalog.isPresent() && !artistsInvolved.contains(selectedArtistCatalog.get().getArtist())) {
             var newArtist = artistsInvolved.stream().findFirst()
                 .orElseThrow(() -> new IllegalStateException("AudioItem has no artists"));
-            var artistCatalog = audioRepository.getArtistCatalog(newArtist);
-            selectedArtistProperty.setValue((Optional<ObservableArtistCatalog>) artistCatalog);
-
-            artistsListView.getSelectionModel().select(artistCatalog.get());
-            artistsListView.scrollTo(artistCatalog.get());
+            Optional<ObservableArtistCatalog> artistCatalog = (Optional<ObservableArtistCatalog>) audioRepository.getArtistCatalog(newArtist);
+            selectedArtistProperty.setValue(artistCatalog);
+            artistCatalog.ifPresent(catalog -> {
+                artistsListView.getSelectionModel().select(catalog);
+                artistsListView.scrollTo(catalog);
+            });
         } else {
             albumRowsBackingList.forEach(trackSet -> {
                 var album = audioItem.getAlbum();

--- a/src/main/java/net/transgressoft/musicott/view/GenreViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/GenreViewController.java
@@ -91,7 +91,6 @@ public class GenreViewController {
     private StackPane genresRootPane;
 
     private GridView<ObservableGenreIndex> genreGridView;
-    private ObservableList<ObservableGenreIndex> genresBacking;
     private FilteredList<ObservableGenreIndex> filteredGenres;
 
     /** Lower-cased active search query, or empty when no filter is applied. */
@@ -167,7 +166,7 @@ public class GenreViewController {
      * still routed through {@link Platform#runLater} defensively so the grid never mutates off-thread.
      */
     private void configureGridBacking() {
-        genresBacking = FXCollections.observableArrayList(audioRepository.getGenreIndexesProperty());
+        ObservableList<ObservableGenreIndex> genresBacking = FXCollections.observableArrayList(audioRepository.getGenreIndexesProperty());
         logger.info("Genres view initialised with {} genre buckets", genresBacking.size());
 
         // Mirror the ordered projection wholesale on every change so the grid preserves its bucket
@@ -402,6 +401,9 @@ public class GenreViewController {
      * so a genre with real cover variety always has enough to cycle; tracks with no embedded art never
      * contribute. {@code onCoverArrived} runs on the JavaFX thread each time a cover joins the pool.
      */
+    // Coordinates controller-scoped state (the shared cover-pool cache), not solely the genre
+    // parameter, so it belongs in the controller rather than in a single grid cell.
+    @SuppressWarnings("java:S3398")
     private void resolveCoverPool(ObservableGenreIndex genre, Runnable onCoverArrived) {
         CoverPool pool = coverPools.computeIfAbsent(genre, g -> new CoverPool());
         if (pool.started) {
@@ -453,6 +455,9 @@ public class GenreViewController {
      * covers resolve so the default placeholder is replaced by a real cover on the visible cell,
      * regardless of which cell first triggered the pool resolution.
      */
+    // Iterates every cell of the controller's grid view, not solely the genre parameter, so it
+    // belongs in the controller rather than in a single grid cell.
+    @SuppressWarnings("java:S3398")
     private void refreshGenreCover(ObservableGenreIndex genre) {
         genreGridView.lookupAll(".grid-cell").forEach(node -> {
             if (node instanceof GenreGridCell cell && genre.equals(cell.getItem())) {
@@ -593,6 +598,10 @@ public class GenreViewController {
         }
     }
 
+    // Publishes through the controller's application event bus, not solely the genre parameter, so
+    // it belongs in the controller rather than in a single grid cell. The null guard is defensive:
+    // a mock or partial genre index can return a null track list despite the non-null contract.
+    @SuppressWarnings({"java:S3398", "java:S2589"})
     private void playGenre(ObservableGenreIndex genre) {
         var tracks = genre.getTracksProperty();
         if (tracks != null && !tracks.isEmpty()) {

--- a/src/main/java/net/transgressoft/musicott/view/NavigationController.java
+++ b/src/main/java/net/transgressoft/musicott/view/NavigationController.java
@@ -31,7 +31,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import net.rgielen.fxweaver.core.FxmlView;
-import org.fxmisc.easybind.EasyBind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -121,9 +120,6 @@ public class NavigationController {
     private MenuItem newFolderPlaylistMI;
     private Optional<ObservablePlaylist> currentPlayingPlaylist;
 
-    // Held as a field so it is accessible to the navigationModeProperty subscriber for clearing.
-    private NavigationMenuListView navigationMenuListView;
-
     @Autowired
     public NavigationController(PlaylistTreeView playlistTreeView,
                                 KeyCombination.Modifier operativeSystemKeyModifier,
@@ -147,7 +143,7 @@ public class NavigationController {
     @FXML
     public void initialize() {
         currentPlayingPlaylist = Optional.empty();
-        navigationMenuListView = new NavigationMenuListView();
+        NavigationMenuListView navigationMenuListView = new NavigationMenuListView();
 
         ContextMenu newPlaylistButtonContextMenu = new ContextMenu();
         newPlaylistMI = new MenuItem("New Playlist");
@@ -260,29 +256,40 @@ public class NavigationController {
             }
             List<String> failures = Collections.synchronizedList(new ArrayList<>());
             var futures = selected.stream()
-                    .map(pl -> CompletableFuture.runAsync(() -> {
-                        try {
-                            pl.exportToM3uFile(folder.toPath().resolve(toSafeFileName(pl.getName()) + ".m3u"));
-                        } catch (Exception ex) {
-                            throw new CompletionException(ex);
-                        }
-                    }).exceptionally(ex -> {
-                                Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-                                failures.add(pl.getName() + ": " + cause.getMessage());
-                                return null;
-                            }))
+                    .map(pl -> exportPlaylistAsync(pl, folder, failures))
                     .toList();
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                    .whenComplete((ignored, ex) -> Platform.runLater(() -> {
-                        if (failures.isEmpty()) {
-                            applicationEventPublisher.publishEvent(
-                                    new StatusMessageUpdateEvent("Exported " + selected.size() + " playlist(s)", this));
-                        } else {
-                            applicationEventPublisher.publishEvent(
-                                    new ErrorEvent("Export failed", String.join("\n", failures), this));
-                        }
-                    }));
+                    .whenComplete((ignored, ex) -> Platform.runLater(() -> publishExportOutcome(selected.size(), failures)));
         });
+    }
+
+    /**
+     * Exports a single playlist to an {@code .m3u} file under {@code folder} off the FX thread,
+     * recording a {@code "<name>: <reason>"} entry in {@code failures} if the write fails rather
+     * than propagating the error, so one failure does not abort the sibling exports.
+     */
+    private CompletableFuture<Void> exportPlaylistAsync(ObservablePlaylist playlist, File folder, List<String> failures) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                playlist.exportToM3uFile(folder.toPath().resolve(toSafeFileName(playlist.getName()) + ".m3u"));
+            } catch (Exception ex) {
+                throw new CompletionException(ex);
+            }
+        }).exceptionally(ex -> {
+            Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+            failures.add(playlist.getName() + ": " + cause.getMessage());
+            return null;
+        });
+    }
+
+    private void publishExportOutcome(int exportedCount, List<String> failures) {
+        if (failures.isEmpty()) {
+            applicationEventPublisher.publishEvent(
+                    new StatusMessageUpdateEvent("Exported " + exportedCount + " playlist(s)", this));
+        } else {
+            applicationEventPublisher.publishEvent(
+                    new ErrorEvent("Export failed", String.join("\n", failures), this));
+        }
     }
 
     /**

--- a/src/main/java/net/transgressoft/musicott/view/NavigationController.java
+++ b/src/main/java/net/transgressoft/musicott/view/NavigationController.java
@@ -1,13 +1,18 @@
 package net.transgressoft.musicott.view;
 
 import javafx.beans.property.*;
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.music.m3u.M3uImportService;
+import net.transgressoft.musicott.events.ErrorEvent;
 import net.transgressoft.musicott.events.ExportSelectedPlaylistsEvent;
+import net.transgressoft.musicott.events.ImportPlaylistsFromM3uEvent;
 import net.transgressoft.musicott.events.SelectCurrentPlayingAudioItemEvent;
 import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
 import net.transgressoft.musicott.events.StatusProgressUpdateEvent;
 import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -17,6 +22,8 @@ import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
@@ -28,12 +35,20 @@ import org.fxmisc.easybind.EasyBind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Controller;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALBUMS;
 import static net.transgressoft.musicott.view.NavigationController.NavigationMode.ALL_AUDIO_ITEMS;
@@ -44,9 +59,9 @@ import static org.fxmisc.easybind.EasyBind.subscribe;
 
 /**
  * Controller for the application navigation sidebar, managing navigation modes (All Tracks,
- * Artists) and the playlist tree view. Keeps nav-mode selection and playlist-tree selection
- * mutually exclusive: selecting a playlist clears the nav list, and switching to a nav mode
- * clears the playlist tree.
+ * Artists, Albums, Genres) and the playlist tree view. Keeps nav-mode selection and playlist-tree
+ * selection mutually exclusive: selecting a playlist clears the nav list, and switching to a nav
+ * mode clears the playlist tree. Handles M3U playlist export and import via Spring application events.
  *
  * @author Octavio Calleya
  */
@@ -78,8 +93,8 @@ public class NavigationController {
 
     private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
-    private final PlaylistTreeView playlistTreeView;
-    private final ObjectProperty<NavigationMode> navigationModeProperty;
+    final PlaylistTreeView playlistTreeView;
+    final ObjectProperty<NavigationMode> navigationModeProperty;
 
     @FXML
     private VBox navigationPaneVBox;
@@ -94,7 +109,13 @@ public class NavigationController {
     @FXML
     private Label statusLabel;
 
-    private final KeyCombination.Modifier operativeSystemKeyModifier;
+    final KeyCombination.Modifier operativeSystemKeyModifier;
+    final ApplicationEventPublisher applicationEventPublisher;
+    final FXMusicLibrary musicLibrary;
+    final AlertFactory alertFactory;
+    final Supplier<DirectoryChooser> directoryChooserSupplier;
+    final Supplier<FileChooser> fileChooserSupplier;
+    final M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService;
 
     private MenuItem newPlaylistMI;
     private MenuItem newFolderPlaylistMI;
@@ -105,9 +126,21 @@ public class NavigationController {
 
     @Autowired
     public NavigationController(PlaylistTreeView playlistTreeView,
-                                KeyCombination.Modifier operativeSystemKeyModifier) {
+                                KeyCombination.Modifier operativeSystemKeyModifier,
+                                ApplicationEventPublisher applicationEventPublisher,
+                                FXMusicLibrary musicLibrary,
+                                AlertFactory alertFactory,
+                                Supplier<DirectoryChooser> directoryChooserSupplier,
+                                Supplier<FileChooser> fileChooserSupplier,
+                                M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService) {
         this.playlistTreeView = playlistTreeView;
         this.operativeSystemKeyModifier = operativeSystemKeyModifier;
+        this.applicationEventPublisher = applicationEventPublisher;
+        this.musicLibrary = musicLibrary;
+        this.alertFactory = alertFactory;
+        this.directoryChooserSupplier = directoryChooserSupplier;
+        this.fileChooserSupplier = fileChooserSupplier;
+        this.m3uImportService = m3uImportService;
         this.navigationModeProperty = new SimpleObjectProperty<>(this, "navigation mode", NavigationMode.ARTISTS);
     }
 
@@ -198,12 +231,115 @@ public class NavigationController {
         }
     }
 
-    @EventListener (classes = ExportSelectedPlaylistsEvent.class)
-    @SuppressWarnings("java:S1135")
+    /**
+     * Handles an {@link ExportSelectedPlaylistsEvent} by opening a {@link DirectoryChooser} on the
+     * FX thread (required — JavaFX dialogs must run on the Application Thread), then exporting
+     * each selected playlist to an M3U file in a {@link CompletableFuture} off the FX thread to
+     * keep the UI responsive.
+     *
+     * <p>File collisions are treated as per-playlist failures — the underlying
+     * {@code exportToM3uFile} throws {@link java.io.IOException} if the destination already exists,
+     * and this method surfaces that as a named failure rather than overwriting, preventing accidental
+     * data loss. All failures are aggregated into a single {@link ErrorEvent} rather than shown
+     * individually.
+     */
+    @EventListener(classes = ExportSelectedPlaylistsEvent.class)
     public void exportSelectedPlaylists() {
-        // Deferred: read selected playlists via playlistTreeView.selectedPlaylists(), open a
-        // destination-chooser dialog and call exportToM3uFile per selected playlist. Currently
-        // the action is a no-op. Trigger: m3u export feature work.
+        Platform.runLater(() -> {
+            var selected = playlistTreeView.selectedPlaylists();
+            if (selected.isEmpty()) {
+                applicationEventPublisher.publishEvent(
+                        new StatusMessageUpdateEvent("No playlists selected to export", this));
+                return;
+            }
+            DirectoryChooser chooser = directoryChooserSupplier.get();
+            chooser.setTitle("Export playlist(s) to folder");
+            File folder = chooser.showDialog(playlistTreeView.getScene().getWindow());
+            if (folder == null) {
+                return;
+            }
+            List<String> failures = Collections.synchronizedList(new ArrayList<>());
+            var futures = selected.stream()
+                    .map(pl -> CompletableFuture.runAsync(() -> {
+                        try {
+                            pl.exportToM3uFile(folder.toPath().resolve(toSafeFileName(pl.getName()) + ".m3u"));
+                        } catch (Exception ex) {
+                            throw new CompletionException(ex);
+                        }
+                    }).exceptionally(ex -> {
+                                Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+                                failures.add(pl.getName() + ": " + cause.getMessage());
+                                return null;
+                            }))
+                    .toList();
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .whenComplete((ignored, ex) -> Platform.runLater(() -> {
+                        if (failures.isEmpty()) {
+                            applicationEventPublisher.publishEvent(
+                                    new StatusMessageUpdateEvent("Exported " + selected.size() + " playlist(s)", this));
+                        } else {
+                            applicationEventPublisher.publishEvent(
+                                    new ErrorEvent("Export failed", String.join("\n", failures), this));
+                        }
+                    }));
+        });
+    }
+
+    /**
+     * Replaces path separators and filesystem-reserved characters in a playlist name with
+     * underscores so it can be resolved into the export folder without escaping it or producing
+     * an invalid path. A playlist name is user-controlled and validated only for non-emptiness and
+     * uniqueness, so it may legitimately contain characters that are illegal in a file name.
+     */
+    private static String toSafeFileName(String playlistName) {
+        return playlistName.replaceAll("[\\\\/:*?\"<>|]", "_");
+    }
+
+    /**
+     * Handles an {@link ImportPlaylistsFromM3uEvent} by opening a {@link FileChooser} on the FX thread
+     * (required — JavaFX dialogs must run on the Application Thread), importing the chosen M3U file
+     * asynchronously via {@link M3uImportService#importAsync}, and nesting the resulting playlist
+     * under {@code ROOT_PLAYLIST} so it becomes visible in the {@link PlaylistTreeView}.
+     *
+     * <p>The playlist is nested under {@code ROOT_PLAYLIST} via
+     * {@code playlistHierarchy().addPlaylistsToDirectory()} because imported playlists are not
+     * automatically inserted into the tree — they must be explicitly placed in a directory. Feedback
+     * is limited to the status-bar imported-count; skipped entries are not counted and no
+     * partial-import modal is shown.
+     *
+     * <p>Hard failures ({@link net.transgressoft.commons.music.m3u.M3uImportException},
+     * {@link net.transgressoft.commons.music.m3u.M3uParseException},
+     * {@link net.transgressoft.commons.music.m3u.M3uCycleException}) are surfaced as an
+     * {@link ErrorEvent} modal; no playlist is nested on failure.
+     */
+    @EventListener(classes = ImportPlaylistsFromM3uEvent.class)
+    public void importPlaylistFromM3u() {
+        Platform.runLater(() -> {
+            FileChooser chooser = fileChooserSupplier.get();
+            chooser.setTitle("Import playlist from M3U file");
+            if (chooser.getExtensionFilters() != null) {
+                chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("M3U Playlists", "*.m3u", "*.m3u8"));
+            }
+            File file = chooser.showOpenDialog(playlistTreeView.getScene().getWindow());
+            if (file == null) {
+                return;
+            }
+            m3uImportService.importAsync(file.toPath())
+                    .whenComplete((playlist, ex) -> Platform.runLater(() -> {
+                        if (ex != null) {
+                            logger.error("M3U import failed", ex);
+                            applicationEventPublisher.publishEvent(
+                                    new ErrorEvent("Import failed", ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage(), this));
+                        } else {
+                            musicLibrary.playlistHierarchy().addPlaylistsToDirectory(Set.of(playlist), PlaylistTreeView.ROOT_PLAYLIST_NAME);
+                            // Count tracks recursively: a folder playlist's direct audioItems exclude tracks
+                            // held by its nested playlists, so the total imported must span the whole subtree.
+                            applicationEventPublisher.publishEvent(
+                                    new StatusMessageUpdateEvent(
+                                            "Imported playlist '" + playlist.getName() + "' (" + playlist.getAudioItemsRecursive().size() + " tracks)", this));
+                        }
+                    }));
+        });
     }
 
     @EventListener

--- a/src/main/java/net/transgressoft/musicott/view/custom/OverlayTracksDrawer.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/OverlayTracksDrawer.java
@@ -385,6 +385,6 @@ public class OverlayTracksDrawer {
     }
 
     private static double clamp(double value, double low, double high) {
-        return Math.max(low, Math.min(high, value));
+        return Math.clamp(value, low, high);
     }
 }

--- a/src/main/java/net/transgressoft/musicott/view/custom/PlaylistTreeView.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/PlaylistTreeView.java
@@ -517,7 +517,7 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
                 var clipboardContent = new ClipboardContent();
                 // Put the serializable integer id on the dragboard; the drop handler
                 // resolves it back to the playlist via the hierarchy.
-                clipboardContent.put(PLAYLIST_DATA_FORMAT, (Integer) getItem().getId());
+                clipboardContent.put(PLAYLIST_DATA_FORMAT, getItem().getId());
                 dragBoard.setContent(clipboardContent);
             }
             event.consume();

--- a/src/main/java/net/transgressoft/musicott/view/custom/PlaylistTreeView.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/PlaylistTreeView.java
@@ -54,6 +54,12 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
 
     private static final DataFormat PLAYLIST_DATA_FORMAT = new DataFormat("application/observable-playlist");
 
+    /**
+     * Name of the implicit top-level playlist directory that holds every user playlist. The tree
+     * hides this root node; playlists become visible in the tree by being nested under it.
+     */
+    public static final String ROOT_PLAYLIST_NAME = "ROOT_PLAYLIST";
+
     private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
     private final ObservablePlaylistHierarchy playlistRepository;
@@ -94,9 +100,9 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
 
     private PlaylistTreeViewItem createRootPlaylistTreeViewItem() {
         ObservablePlaylist rootPlaylist;
-        var maybeRootPlaylist = playlistRepository.findByName("ROOT_PLAYLIST");
+        var maybeRootPlaylist = playlistRepository.findByName(ROOT_PLAYLIST_NAME);
         if (maybeRootPlaylist.isEmpty()) {
-            rootPlaylist = playlistRepository.createPlaylistDirectory("ROOT_PLAYLIST");
+            rootPlaylist = playlistRepository.createPlaylistDirectory(ROOT_PLAYLIST_NAME);
         } else {
             rootPlaylist = maybeRootPlaylist.get();
         }
@@ -546,7 +552,10 @@ public class PlaylistTreeView extends TreeView<ObservablePlaylist> {
 
             var exportPlaylistsMenuItem = new MenuItem("Export playlist(s) as m3u file(s)");
             exportPlaylistsMenuItem.setOnAction(e -> applicationEventPublisher.publishEvent(new ExportSelectedPlaylistsEvent(e.getSource())));
-            getItems().addAll(addPlaylistMenuItem, addPlaylistFolderMenuItem, deletePlaylistMenuItem, exportPlaylistsMenuItem);
+
+            var importPlaylistMenuItem = new MenuItem("Import playlist from m3u file...");
+            importPlaylistMenuItem.setOnAction(e -> applicationEventPublisher.publishEvent(new ImportPlaylistsFromM3uEvent(e.getSource())));
+            getItems().addAll(addPlaylistMenuItem, addPlaylistFolderMenuItem, deletePlaylistMenuItem, exportPlaylistsMenuItem, importPlaylistMenuItem);
         }
     }
 }

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -43,6 +43,7 @@ import static org.fxmisc.easybind.EasyBind.subscribe;
 public class ArtistAlbumListRow extends HBox {
 
     private static final String BASE_STYLE = "/css/base.css";
+    private static final String SECONDARY_INFO_STYLE_CLASS = "album-info-secondary";
     private static final double COVER_SIZE = 130.0;
 
     private final Artist artist;
@@ -112,11 +113,11 @@ public class ArtistAlbumListRow extends HBox {
         sizeLabel.setId("sizeLabel");
         // Share the secondary style with the year label so both carry the same font size and
         // padding; otherwise the two sit on different baselines under the cover (misaligned).
-        sizeLabel.getStyleClass().add("album-info-secondary");
+        sizeLabel.getStyleClass().add(SECONDARY_INFO_STYLE_CLASS);
         sizeLabel.textProperty().bind(map(containedAudioItemsProperty.sizeProperty(), this::getAlbumSizeString));
         yearLabel = new Label(buildYearsString());
         yearLabel.setId("yearLabel");
-        yearLabel.getStyleClass().add("album-info-secondary");
+        yearLabel.getStyleClass().add(SECONDARY_INFO_STYLE_CLASS);
 
         var underImageGridPane = new GridPane();
         var cc1 = new ColumnConstraints(COVER_SIZE / 2);
@@ -146,7 +147,7 @@ public class ArtistAlbumListRow extends HBox {
         // width (the drawer can be far wider than the artist view, where a 480px cap truncated it).
         relatedArtistsLabel = new Label();
         relatedArtistsLabel.setId("relatedArtistsLabel");
-        relatedArtistsLabel.getStyleClass().add("album-info-secondary");
+        relatedArtistsLabel.getStyleClass().add(SECONDARY_INFO_STYLE_CLASS);
         // Single line that truncates with an ellipsis rather than wrapping — squeezing the drawer
         // must not grow the row vertically. No fixed width cap so it uses the full available width.
         relatedArtistsLabel.setWrapText(false);
@@ -156,14 +157,14 @@ public class ArtistAlbumListRow extends HBox {
         genresLabel.setMaxWidth(480);
         albumLabelLabel = new Label();
         albumLabelLabel.setId("albumLabelLabel");
-        albumLabelLabel.getStyleClass().add("album-info-secondary");
+        albumLabelLabel.getStyleClass().add(SECONDARY_INFO_STYLE_CLASS);
         buildSimpleTableView();
 
         albumInfoVBox = new VBox(albumTitleLabel, genresLabel, audioItemsTableView);
         if (discNumber > 0) {
             var discLabel = new Label("Disc " + discNumber);
             discLabel.setId("discLabel");
-            discLabel.getStyleClass().add("album-info-secondary");
+            discLabel.getStyleClass().add(SECONDARY_INFO_STYLE_CLASS);
             albumInfoVBox.getChildren().add(1, discLabel);
         }
         VBox.setVgrow(audioItemsTableView, Priority.ALWAYS);

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemQueryMatcher.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemQueryMatcher.java
@@ -25,7 +25,7 @@ public final class AudioItemQueryMatcher {
      */
     // Defensive null guards — imported tracks from partial catalogs can carry null artist/album or
     // null name fields; one malformed track must not NPE the whole filter.
-    @SuppressWarnings("java:S2589")
+    @SuppressWarnings({"java:S2589", "java:S2583"})
     public static boolean matches(ObservableAudioItem audioItem, String query) {
         if (contains(audioItem.getTitle(), query)) {
             return true;

--- a/src/main/kotlin/net/transgressoft/musicott/config/ApplicationConfiguration.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/config/ApplicationConfiguration.kt
@@ -20,12 +20,15 @@ package net.transgressoft.musicott.config
 import javafx.beans.property.ObjectProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.input.KeyCombination
+import javafx.stage.DirectoryChooser
+import javafx.stage.FileChooser
 import net.transgressoft.commons.fx.music.FXMusicLibrary
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy
 import net.transgressoft.commons.media.persistence.waveform.AudioWaveformMapSerializer
+import net.transgressoft.commons.music.m3u.M3uImportService
 import net.transgressoft.commons.persistence.fx.music.audio.FXAudioItemSqlTableDef
 import net.transgressoft.commons.persistence.fx.music.playlist.ObservablePlaylistMapSerializer
 import net.transgressoft.commons.music.audio.AudioMetadataIO
@@ -44,6 +47,7 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Optional
+import java.util.function.Supplier
 
 @Configuration
 class ApplicationConfiguration @Autowired constructor(private val applicationPaths: MusicottApplication.ApplicationPaths) {
@@ -128,4 +132,28 @@ class ApplicationConfiguration @Autowired constructor(private val applicationPat
     @Bean
     fun waveformRepository(musicLibrary: FXMusicLibrary): AudioWaveformRepository<AudioWaveform, ObservableAudioItem> =
         musicLibrary.waveformRepository()
+
+    /**
+     * Provides a [DirectoryChooser] factory for production use. The [Supplier] indirection
+     * allows integration tests to inject a pre-configured mock without modifying production code.
+     */
+    @Bean
+    fun directoryChooserSupplier(): Supplier<DirectoryChooser> = Supplier { DirectoryChooser() }
+
+    /**
+     * Provides a [FileChooser] factory for production use. The [Supplier] indirection
+     * allows integration tests to inject a pre-configured mock without modifying production code.
+     */
+    @Bean
+    fun fileChooserSupplier(): Supplier<FileChooser> = Supplier { FileChooser() }
+
+    /**
+     * Creates the M3U import service bound to the application's FX music library.
+     *
+     * Registered with [destroyMethod] = "close" so that the backing [kotlinx.coroutines.CoroutineScope]
+     * is cancelled on Spring context shutdown, preventing resource leaks.
+     */
+    @Bean(destroyMethod = "close")
+    fun m3uImportService(musicLibrary: FXMusicLibrary): M3uImportService<ObservableAudioItem, ObservablePlaylist> =
+        M3uImportService(musicLibrary)
 }

--- a/src/uiTest/java/net/transgressoft/musicott/view/PlaylistFolderSelectionUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/PlaylistFolderSelectionUIT.java
@@ -5,6 +5,7 @@ import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.commons.music.waveform.AudioWaveform;
 import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
 import net.transgressoft.musicott.service.MediaImportService;
@@ -53,11 +54,15 @@ import org.testfx.util.WaitForAsyncUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -231,6 +236,22 @@ class PlaylistFolderSelectionUITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/uiTest/java/net/transgressoft/musicott/view/PlaylistManagementUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/PlaylistManagementUIT.java
@@ -11,12 +11,15 @@ import net.rgielen.fxweaver.core.FxWeaver;
 import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
 import net.rgielen.fxweaver.spring.SpringFxWeaver;
 import net.transgressoft.commons.fx.music.*;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
 import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.musicott.events.*;
 import net.transgressoft.musicott.test.*;
 import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -31,9 +34,13 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.test.annotation.DirtiesContext;
 import org.testfx.api.FxRobot;
 
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -449,6 +456,27 @@ class PlaylistManagementUITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
     }
 
     @Bean

--- a/src/uiTest/java/net/transgressoft/musicott/view/PlaylistTreeViewM3uUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/PlaylistTreeViewM3uUIT.java
@@ -1,0 +1,192 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
+import net.transgressoft.musicott.events.ExportSelectedPlaylistsEvent;
+import net.transgressoft.musicott.events.ImportPlaylistsFromM3uEvent;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Node;
+import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * UI test verifying that the M3U export context-menu items in {@link PlaylistTreeView}
+ * publish the expected application events when fired.
+ */
+@JavaFxSpringTest(classes = PlaylistTreeViewM3uUITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("Playlist M3U context menu actions")
+class PlaylistTreeViewM3uUIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @Test
+    @DisplayName("right-click context menu fires export event when 'Export playlist(s) as m3u file(s)' is clicked")
+    void rightClickContextMenuFiresExportEvent(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        TreeView<ObservablePlaylist> treeView = fxRobot.lookup("#playlistTreeView").query();
+
+        fxRobot.interact(() -> {
+            var items = treeView.getContextMenu().getItems();
+            items.stream()
+                    .filter(mi -> "Export playlist(s) as m3u file(s)".equals(mi.getText()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Export menu item not found"))
+                    .fire();
+        });
+        waitForFxEvents();
+
+        verify(applicationEventPublisher).publishEvent(any(ExportSelectedPlaylistsEvent.class));
+    }
+
+    @Test
+    @DisplayName("right-click context menu fires import event when 'Import playlist from m3u file...' is clicked")
+    void rightClickContextMenuFiresImportEvent(FxRobot fxRobot) {
+        waitForFxEvents();
+
+        TreeView<ObservablePlaylist> treeView = fxRobot.lookup("#playlistTreeView").query();
+
+        fxRobot.interact(() -> {
+            var items = treeView.getContextMenu().getItems();
+            items.stream()
+                    .filter(mi -> "Import playlist from m3u file...".equals(mi.getText()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Import menu item not found"))
+                    .fire();
+        });
+        waitForFxEvents();
+
+        verify(applicationEventPublisher).publishEvent(any(ImportPlaylistsFromM3uEvent.class));
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class
+        })
+})
+class PlaylistTreeViewM3uUITConfiguration {
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        var playlist = repository.createPlaylist("Test M3U Playlist");
+        repository.addPlaylistsToDirectory(Set.of(playlist), "ROOT_PLAYLIST");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected m3u ui test playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        // Stub; the export file I/O is not exercised by this UI test
+        DirectoryChooser mockChooser = mock(DirectoryChooser.class);
+        return () -> mockChooser;
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        // Stub; not exercised by this UI test
+        FileChooser mockChooser = mock(FileChooser.class);
+        return () -> mockChooser;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring shutdown(), which would call
+    // Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}


### PR DESCRIPTION
## Summary

Adds round-trip `.m3u`/`.m3u8` support to the playlist tree: exporting selected playlists to disk and importing existing playlist files into the library. Closes #55 and #63.

## Export (#55)

The "Export playlist(s) as m3u file(s)" context-menu action was previously a no-op that silently consumed its event. It now:

- Opens a `DirectoryChooser` and writes one `<folder>/<name>.m3u` file per selected playlist.
- Runs off the JavaFX thread.
- Reports success in the status bar and aggregates failures — including collisions the user chose not to overwrite — into a single error modal.

## Import (#63)

New "Import playlist from m3u file..." action:

- Opens an `.m3u`/`.m3u8` `FileChooser`.
- Imports through the generic music-commons `M3uImportService`, which reuses audio items already present in the library by normalized path, skips unreadable entries, and resolves nested playlist references with cycle detection.
- Registers the service as an `AutoCloseable` Spring bean.
- Nests the imported playlist under the root so it appears in the tree, and reports the recursive imported track count in the status bar. Hard failures (parse errors, collisions, cycles) surface as an error modal.

## Dependency note

Import consumes a generic `M3uImportService<I, P>` from music-commons, currently pinned as a local snapshot via `libs.versions.toml`. This must be swapped for a published release before merge.

## Testing

- Integration: `NavigationControllerM3uExportIT`, `NavigationControllerM3uImportIT`.
- UI: `PlaylistTreeViewM3uUIT`.
- Existing navigation/playlist IT and UIT suites updated for the new context-menu items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)