### PR TITLE
#70 Make library search non-blocking

### DIFF
--- a/gradle/test-suites.gradle
+++ b/gradle/test-suites.gradle
@@ -74,6 +74,7 @@ tasks.withType(Test).configureEach {
 sourceSets {
     integrationTest {
         java.srcDir 'src/integrationTest/java'
+        kotlin.srcDir 'src/integrationTest/kotlin'
         resources.srcDir 'src/integrationTest/resources'
         compileClasspath += sourceSets.main.output
         runtimeClasspath += sourceSets.main.output

--- a/src/integrationTest/java/net/transgressoft/musicott/view/AlbumViewControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/AlbumViewControllerIT.java
@@ -16,7 +16,7 @@ import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Label;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import java.util.Collections;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -77,7 +77,7 @@ class AlbumViewControllerIT extends ApplicationTestBase<StackPane> {
         // filter before each test so methods stay independent regardless of execution order.
         Platform.runLater(() -> {
             albumsProperty.clear();
-            albumViewAndController.getController().searchTextTypedEvent(new SearchTextTypedEvent("", this));
+            albumViewAndController.getController().applyMatchIds("", Collections.emptySet());
         });
         waitForFxEvents();
         super.beforeEach();
@@ -174,13 +174,13 @@ class AlbumViewControllerIT extends ApplicationTestBase<StackPane> {
         waitForFxEvents();
 
         // Query matches only the "Black Sands" album (by its album name); "Melt!" has no matching track.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("black sands", this)));
+        Platform.runLater(() -> controller.applyMatchIds("black sands", Set.of("Black Sands")));
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> grid.getItems().size() == 1);
         waitForFxEvents();
         assertThat(grid.getItems()).containsExactly(blackSands);
 
         // Clearing the query restores every album.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("", this)));
+        Platform.runLater(() -> controller.applyMatchIds("", Collections.emptySet()));
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> grid.getItems().size() == 2);
         waitForFxEvents();
         assertThat(grid.getItems()).hasSize(2);
@@ -250,6 +250,11 @@ class AlbumViewControllerITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public net.transgressoft.musicott.search.SearchCoordinator searchCoordinator() {
+        return mock(net.transgressoft.musicott.search.SearchCoordinator.class);
     }
 
     // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,

--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewAddTracksIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewAddTracksIT.java
@@ -286,6 +286,11 @@ class ArtistViewAddTracksITConfiguration {
         return KeyCombination.CONTROL_DOWN;
     }
 
+    @Bean
+    public net.transgressoft.musicott.search.SearchCoordinator searchCoordinator() {
+        return mock(net.transgressoft.musicott.search.SearchCoordinator.class);
+    }
+
     @Bean(destroyMethod = "")
     public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
         return new SpringFxWeaver(applicationContext);

--- a/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/ArtistViewControllerIT.java
@@ -22,7 +22,7 @@ import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Label;
 import net.transgressoft.lirp.event.LirpEventPublisher;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import java.util.Collections;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -164,7 +164,7 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
         // Clear accumulated state from previous tests and reset the predicate.
         Platform.runLater(() -> {
             artistCatalogsProperty.clear();
-            controller.searchTextTypedEvent(new SearchTextTypedEvent("", this));
+            controller.applyMatchIds("", Collections.emptySet());
         });
         waitForFxEvents();
 
@@ -175,9 +175,8 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
         });
         waitForFxEvents();
 
-        // Direct invocation bypasses the mocked ApplicationEventPublisher bean — publishEvent(...)
-        // on a mock is a no-op, so the @EventListener method is driven directly here.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("Abe", this)));
+        // Drive applyMatchIds directly — only "Abel" matches "abe".
+        Platform.runLater(() -> controller.applyMatchIds("abe", Set.of("Abel")));
         waitForFxEvents();
 
         @SuppressWarnings("unchecked")
@@ -197,7 +196,7 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
         // Clear accumulated state from previous tests and reset the predicate.
         Platform.runLater(() -> {
             artistCatalogsProperty.clear();
-            controller.searchTextTypedEvent(new SearchTextTypedEvent("", this));
+            controller.applyMatchIds("", Collections.emptySet());
         });
         waitForFxEvents();
 
@@ -211,13 +210,13 @@ class ArtistViewControllerIT extends ApplicationTestBase<SplitPane> {
         @SuppressWarnings("unchecked")
         ListView<ObservableArtistCatalog> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
 
-        // Filter to a single match.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("Abe", this)));
+        // Filter to a single match — drive applyMatchIds directly.
+        Platform.runLater(() -> controller.applyMatchIds("abe", Set.of("Abel")));
         waitForFxEvents();
         assertThat(artistsListView.getItems()).hasSize(1);
 
-        // Clear the query — emulates MainController publishing "" for length < 3 or empty input.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("", this)));
+        // Clear the query — empty ids resets the predicate immediately.
+        Platform.runLater(() -> controller.applyMatchIds("", Collections.emptySet()));
         waitForFxEvents();
 
         assertThat(artistsListView.getItems()).hasSize(3);
@@ -423,6 +422,11 @@ class ArtistViewControllerITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public net.transgressoft.musicott.search.SearchCoordinator searchCoordinator() {
+        return mock(net.transgressoft.musicott.search.SearchCoordinator.class);
     }
 
     // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,

--- a/src/integrationTest/java/net/transgressoft/musicott/view/GenreViewControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/GenreViewControllerIT.java
@@ -14,7 +14,8 @@ import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.audio.ObservableGenreIndex;
 import net.transgressoft.commons.music.audio.Genre;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import java.util.Collections;
+import java.util.Set;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -73,7 +74,7 @@ class GenreViewControllerIT extends ApplicationTestBase<StackPane> {
             genreIndexesProperty.clear();
             // Also reset any search predicate a prior test may have left active on this shared
             // singleton, so an earlier assertion failure cannot leak a narrowed grid into later tests.
-            genreViewAndController.getController().searchTextTypedEvent(new SearchTextTypedEvent("", this));
+            genreViewAndController.getController().applyMatchIds("", Collections.emptySet());
         });
         waitForFxEvents();
         super.beforeEach();
@@ -169,13 +170,13 @@ class GenreViewControllerIT extends ApplicationTestBase<StackPane> {
         GenreViewController controller = genreViewAndController.getController();
 
         // A query matching only the Techno track's title narrows the grid to that genre.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("strobe", this)));
+        Platform.runLater(() -> controller.applyMatchIds("strobe", Set.of("Techno")));
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> grid.getItems().size() == 1);
         waitForFxEvents();
         assertThat(grid.getItems()).containsExactly(techno);
 
         // Clearing the query restores every genre.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("", this)));
+        Platform.runLater(() -> controller.applyMatchIds("", Collections.emptySet()));
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> grid.getItems().size() == 2);
         waitForFxEvents();
         assertThat(grid.getItems()).hasSize(2);
@@ -246,6 +247,11 @@ class GenreViewControllerITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public net.transgressoft.musicott.search.SearchCoordinator searchCoordinator() {
+        return mock(net.transgressoft.musicott.search.SearchCoordinator.class);
     }
 
     // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,

--- a/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerPlaylistFolderIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerPlaylistFolderIT.java
@@ -318,6 +318,11 @@ class MainControllerPlaylistFolderITConfiguration {
         return KeyCombination.CONTROL_DOWN;
     }
 
+    @Bean
+    public net.transgressoft.musicott.search.SearchCoordinator searchCoordinator() {
+        return mock(net.transgressoft.musicott.search.SearchCoordinator.class);
+    }
+
     @Bean(destroyMethod = "")
     public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
         return new SpringFxWeaver(applicationContext);

--- a/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/MainControllerRandomPlaybackIT.java
@@ -375,6 +375,11 @@ class MainControllerRandomPlaybackITConfiguration {
         return KeyCombination.CONTROL_DOWN;
     }
 
+    @Bean
+    public net.transgressoft.musicott.search.SearchCoordinator searchCoordinator() {
+        return mock(net.transgressoft.musicott.search.SearchCoordinator.class);
+    }
+
     @Bean(destroyMethod = "")
     public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
         return new SpringFxWeaver(applicationContext);

--- a/src/integrationTest/java/net/transgressoft/musicott/view/SearchFlowIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/SearchFlowIT.java
@@ -2,6 +2,7 @@ package net.transgressoft.musicott.view;
 
 import javafx.application.Platform;
 import javafx.beans.property.*;
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.*;
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
@@ -19,10 +20,11 @@ import net.transgressoft.commons.music.audio.AlbumDetails;
 import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Label;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.NavigationController;
 import net.transgressoft.musicott.view.custom.table.ArtistAlbumListRow;
 import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
 import net.transgressoft.musicott.view.custom.table.SimpleAudioItemTableView;
@@ -39,25 +41,38 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.testfx.api.FxRobot;
 
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import static net.transgressoft.commons.music.audio.Artist.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.springframework.context.annotation.ComponentScan.Filter;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+import static org.testfx.util.WaitForAsyncUtils.waitFor;
 
 /**
  * Integration test verifying that the global search field triggers live filtering across all
  * subscriber views — the audio item table ({@link FullAudioItemTableView}) and the artist list
- * ({@link ArtistViewController}) — and that clearing the query restores each view to its
- * full unfiltered state.
+ * ({@link ArtistViewController}) — through the {@link SearchCoordinator} async pipeline, and
+ * that clearing the query restores each view to its full unfiltered state.
  *
- * <p>Events are dispatched through the real Spring {@link ApplicationEventPublisher} so the
- * test exercises the production wire: the multicaster, the {@code @EventListener} method
- * resolution, and the bean scope of each subscriber. Direct method invocation would mask
- * scope bugs (e.g. a prototype-scoped table view never registering with the multicaster).
+ * <p>The real {@link SearchCoordinator} is wired so the test exercises the full production path:
+ * nav-mode gating, off-thread ID computation, and FX-thread predicate application.
+ * The coordinator is configured with zero debounce delay (see {@link SearchFlowITCoordinatorSupplier})
+ * to eliminate timing races, while still exercising the full Dispatchers.Default → Dispatchers.JavaFx
+ * coroutine thread-hop.
+ *
+ * <p>Each assertion follows the pattern:
+ * <ol>
+ *   <li>{@code Platform.runLater(() -> searchCoordinator.onQuery(...))} — submit the query on the FX thread</li>
+ *   <li>{@code waitForFxEvents()} — drain the FX queue so the query runs and the new job is assigned</li>
+ *   <li>{@code waitFor(5s, coordinator::isIdle)} — await job completion; the volatile {@code currentJob}
+ *       field provides a happens-before guarantee so any subsequent read on the test thread sees the
+ *       predicate that the FX thread wrote</li>
+ *   <li>Directly assert collection sizes — safe because of the happens-before from step 3</li>
+ * </ol>
  */
-@JavaFxSpringTest(classes = SearchFlowITConfiguration.class)
+@JavaFxSpringTest(classes = {SearchFlowITConfiguration.class, SearchFlowITCoordinatorSupplier.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayName("Search flow")
 class SearchFlowIT extends ApplicationTestBase<SplitPane> {
@@ -75,7 +90,10 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
     ObservableAudioLibrary audioRepository;
 
     @Autowired
-    ApplicationEventPublisher applicationEventPublisher;
+    SearchCoordinator searchCoordinator;
+
+    @Autowired
+    ObjectProperty<NavigationController.NavigationMode> navigationModeProperty;
 
     @Override
     protected SplitPane javaFxComponent() {
@@ -86,11 +104,50 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
     @BeforeEach
     protected void beforeEach() {
         super.beforeEach();
+        // Reset filters, source items, and navigation mode between tests.
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+            audioItemTableView.setSourceItems(javafx.collections.FXCollections.observableArrayList());
+            artistCatalogsProperty.clear();
+            // onQuery("") cancels any in-flight job and enqueues a blank-reset coroutine on Default.
+            searchCoordinator.onQuery("");
+        });
+        // Drain: ensures onQuery("") has run on the FX thread, assigning the new job to currentJob.
+        waitForFxEvents();
+        // Wait for the reset coroutine to complete its FX-thread applyMatchIds calls.
+        try {
+            waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        } catch (java.util.concurrent.TimeoutException e) {
+            throw new IllegalStateException("SearchCoordinator did not become idle within 5s in beforeEach", e);
+        }
+        // Extra drain rounds to flush cascading FX tasks (e.g. SetChangeListener → Platform.runLater
+        // from ArtistViewController's reactive backing list).
+        waitForFxEvents();
+        waitForFxEvents();
+        waitForFxEvents();
+    }
+
+    @AfterEach
+    void afterEach() {
+        // Cancel any in-flight search coroutine so no job leaks into subsequent tests or classes.
+        Platform.runLater(() -> {
+            artistCatalogsProperty.clear();
+            searchCoordinator.onQuery("");
+        });
+        waitForFxEvents();
+        try {
+            waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        } catch (java.util.concurrent.TimeoutException e) {
+            throw new IllegalStateException("SearchCoordinator did not become idle within 5s in afterEach", e);
+        }
+        waitForFxEvents();
+        waitForFxEvents();
+        waitForFxEvents();
     }
 
     @Test
-    @DisplayName("AudioItemTableViewBase filters its predicate when SearchTextTypedEvent fires with a non-empty query")
-    void filtersAudioItemTablePredicateOnNonEmptyQuery(FxRobot fxRobot) {
+    @DisplayName("AudioItemTableViewBase filters its predicate when a qualifying query is submitted")
+    void filtersAudioItemTablePredicateOnNonEmptyQuery() throws Exception {
         ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
                 mockAudioItem("Apple", "Artist A", "Album A"),
                 mockAudioItem("Banana", "Artist B", "Album B"),
@@ -102,26 +159,22 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
 
         assertThat(audioItemTableView.getItems()).hasSize(3);
 
-        // Publish through the real Spring multicaster so the test catches scope/registration bugs
-        // that would silently drop the event before reaching the table's @EventListener.
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("App", this)));
+        // Submit query and await quiescence; the volatile currentJob provides happens-before so
+        // the assertion below reads the predicate written by the FX thread.
+        Platform.runLater(() -> searchCoordinator.onQuery("App"));
         waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
 
         assertThat(audioItemTableView.getItems()).hasSize(1);
         assertThat(audioItemTableView.getItems().get(0).getTitle()).isEqualTo("Apple");
     }
 
     @Test
-    @DisplayName("ArtistViewController filters its predicate when SearchTextTypedEvent fires with a non-empty query")
-    void filtersArtistListPredicateOnNonEmptyQuery(FxRobot fxRobot) {
+    @DisplayName("ArtistViewController filters its predicate when a qualifying query is submitted")
+    void filtersArtistListPredicateOnNonEmptyQuery(FxRobot fxRobot) throws Exception {
         Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ARTISTS);
             artistCatalogsProperty.clear();
-            // Reset predicate to unfiltered state first
-            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
-        });
-        waitForFxEvents();
-
-        Platform.runLater(() -> {
             artistCatalogsProperty.add(mockCatalog(of("Aphex Twin")));
             artistCatalogsProperty.add(mockCatalog(of("Bonobo")));
             artistCatalogsProperty.add(mockCatalog(of("Caribou")));
@@ -132,52 +185,93 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         ListView<ObservableArtistCatalog> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
         assertThat(artistsListView.getItems()).hasSize(3);
 
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Aph", this)));
+        Platform.runLater(() -> searchCoordinator.onQuery("Aph"));
         waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
 
         assertThat(artistsListView.getItems()).hasSize(1);
         assertThat(artistsListView.getItems().get(0).getArtistName()).isEqualTo("Aphex Twin");
     }
 
     @Test
-    @DisplayName("All three views restore to full state when SearchTextTypedEvent fires with empty query")
-    void restoresAllViewsToFullStateOnEmptyQuery(FxRobot fxRobot) {
-        // --- Seed audio table ---
+    @DisplayName("A single query filters every registered view at once so switching modes shows an already-filtered view")
+    void singleQueryFiltersAllViewsSimultaneously(FxRobot fxRobot) throws Exception {
+        ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
+                mockAudioItem("Aphelion", "Artist A", "Album A"),
+                mockAudioItem("Banana", "Artist B", "Album B")
+        );
+        Platform.runLater(() -> {
+            audioItemTableView.setSourceItems(items);
+            artistCatalogsProperty.clear();
+            artistCatalogsProperty.add(mockCatalog(of("Aphex Twin")));
+            artistCatalogsProperty.add(mockCatalog(of("Bonobo")));
+        });
+        waitForFxEvents();
+
+        @SuppressWarnings("unchecked")
+        ListView<ObservableArtistCatalog> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        assertThat(audioItemTableView.getItems()).hasSize(2);
+        assertThat(artistsListView.getItems()).hasSize(2);
+
+        // One query submitted without switching modes must filter BOTH views, so navigating to
+        // either view afterward shows it already filtered.
+        Platform.runLater(() -> searchCoordinator.onQuery("Aph"));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+
+        assertThat(audioItemTableView.getItems()).hasSize(1);
+        assertThat(audioItemTableView.getItems().get(0).getTitle()).isEqualTo("Aphelion");
+        assertThat(artistsListView.getItems()).hasSize(1);
+        assertThat(artistsListView.getItems().get(0).getArtistName()).isEqualTo("Aphex Twin");
+    }
+
+    @Test
+    @DisplayName("All views restore to full state when the query is cleared")
+    void restoresAllViewsToFullStateOnClearedQuery(FxRobot fxRobot) throws Exception {
+        // Seed audio table
         ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
                 mockAudioItem("Apple", "Artist A", "Album A"),
                 mockAudioItem("Banana", "Artist B", "Album B"),
                 mockAudioItem("Cherry", "Artist C", "Album C")
         );
-        Platform.runLater(() -> {
-            audioItemTableView.setSourceItems(items);
-            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("App", this));
-        });
+        Platform.runLater(() -> audioItemTableView.setSourceItems(items));
         waitForFxEvents();
-        assertThat(audioItemTableView.getItems()).hasSize(1);
 
-        // --- Seed artist list ---
+        // Seed artist list
         Platform.runLater(() -> {
             artistCatalogsProperty.clear();
-            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
-        });
-        waitForFxEvents();
-
-        Platform.runLater(() -> {
             artistCatalogsProperty.add(mockCatalog(of("Aphex Twin")));
             artistCatalogsProperty.add(mockCatalog(of("Bonobo")));
             artistCatalogsProperty.add(mockCatalog(of("Caribou")));
         });
         waitForFxEvents();
 
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Aph", this)));
-        waitForFxEvents();
-
         @SuppressWarnings("unchecked")
         ListView<ObservableArtistCatalog> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+
+        // Filter the artist list (ARTISTS mode)
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ARTISTS);
+            searchCoordinator.onQuery("Aph");
+        });
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
         assertThat(artistsListView.getItems()).hasSize(1);
 
-        // --- Clear the query — a single SearchTextTypedEvent("") on the bus reaches both subscribers. ---
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this)));
+        // Filter the audio table (ALL_AUDIO_ITEMS mode)
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+            searchCoordinator.onQuery("App");
+        });
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        assertThat(audioItemTableView.getItems()).hasSize(1);
+
+        // Clearing the query triggers immediate reset across ALL registered views
+        Platform.runLater(() -> searchCoordinator.onQuery(""));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        waitForFxEvents();
         waitForFxEvents();
 
         assertThat(audioItemTableView.getItems()).hasSize(3);
@@ -185,13 +279,139 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
     }
 
     @Test
+    @DisplayName("AudioItemTableViewBase shows zero items when query matches nothing")
+    void audioTableShowsZeroItemsWhenQueryMatchesNothing() throws Exception {
+        ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
+                mockAudioItem("Apple", "Artist A", "Album A"),
+                mockAudioItem("Banana", "Artist B", "Album B")
+        );
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+            audioItemTableView.setSourceItems(items);
+        });
+        waitForFxEvents();
+
+        // A query that matches nothing should produce an empty table, not show all items
+        Platform.runLater(() -> searchCoordinator.onQuery("zzqqxx"));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+
+        assertThat(audioItemTableView.getItems()).isEmpty();
+
+        // Clearing the query must restore all items
+        Platform.runLater(() -> searchCoordinator.onQuery(""));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("AudioItemTableViewBase shows only the matching track and hides non-matching tracks in ALL_AUDIO_ITEMS mode")
+    void audioTableFiltersToExactlyOneMatchingTrack() throws Exception {
+        ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
+                mockAudioItem("Unique Track Title", "Artist A", "Album A"),
+                mockAudioItem("Banana", "Artist B", "Album B"),
+                mockAudioItem("Cherry", "Artist C", "Album C")
+        );
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+            audioItemTableView.setSourceItems(items);
+        });
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(3);
+
+        Platform.runLater(() -> searchCoordinator.onQuery("Unique"));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+
+        assertThat(audioItemTableView.getItems()).hasSize(1);
+        assertThat(audioItemTableView.getItems().get(0).getTitle()).isEqualTo("Unique Track Title");
+
+        // Non-matching items must be absent
+        boolean nonMatchingVisible = audioItemTableView.getItems().stream()
+                .anyMatch(item -> !"Unique Track Title".equals(item.getTitle()));
+        assertThat(nonMatchingVisible).isFalse();
+    }
+
+    @Test
+    @DisplayName("ArtistViewController shows zero artists when query matches nothing")
+    void artistViewShowsZeroArtistsWhenQueryMatchesNothing(FxRobot fxRobot) throws Exception {
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ARTISTS);
+            artistCatalogsProperty.clear();
+            artistCatalogsProperty.add(mockCatalog(of("Aphex Twin")));
+            artistCatalogsProperty.add(mockCatalog(of("Bonobo")));
+        });
+        waitForFxEvents();
+
+        @SuppressWarnings("unchecked")
+        ListView<ObservableArtistCatalog> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
+        assertThat(artistsListView.getItems()).hasSize(2);
+
+        // A query matching no artist should show zero results
+        Platform.runLater(() -> searchCoordinator.onQuery("zzqqxx"));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+
+        assertThat(artistsListView.getItems()).isEmpty();
+
+        // Clearing the query restores all artists
+        Platform.runLater(() -> searchCoordinator.onQuery(""));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        waitForFxEvents();
+
+        assertThat(artistsListView.getItems()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("AudioItemTableViewBase triggers search immediately with a single-character query")
+    void singleCharQueryTriggersImmediateSearch() throws Exception {
+        // Use artist names with clearly distinct first letters so a 1-char prefix unambiguously
+        // selects exactly one item.
+        ObservableList<ObservableAudioItem> items = FXCollections.observableArrayList(
+                mockAudioItem("Track X", "Zeppelin", "Album Z"),
+                mockAudioItem("Track Y", "Beethoven", "Album B")
+        );
+        Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+            audioItemTableView.setSourceItems(items);
+        });
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(2);
+
+        // "Z" (single char) matches only "Zeppelin" — single-char search must fire, not be treated as a reset.
+        // waitForFxEvents() ensures onQuery("Z") ran on FX so the new job is assigned before isIdle() is polled.
+        Platform.runLater(() -> searchCoordinator.onQuery("Z"));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+
+        assertThat(audioItemTableView.getItems()).hasSize(1);
+        assertThat(audioItemTableView.getItems().get(0).getTitle()).isEqualTo("Track X");
+
+        // Beethoven's track must be absent
+        boolean beethovenVisible = audioItemTableView.getItems().stream()
+                .anyMatch(item -> "Track Y".equals(item.getTitle()));
+        assertThat(beethovenVisible).isFalse();
+
+        // Clearing the query resets to all items
+        Platform.runLater(() -> searchCoordinator.onQuery(""));
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
+        waitForFxEvents();
+
+        assertThat(audioItemTableView.getItems()).hasSize(2);
+    }
+
+    @Test
     @DisplayName("ArtistViewController matches artists by track title, album, and label when the artist catalog is loaded")
     @SuppressWarnings("unchecked")
-    void matchesArtistsByTrackTitleAlbumAndLabelWhenArtistCatalogIsLoaded(FxRobot fxRobot) {
-        Platform.runLater(() -> {
-            artistCatalogsProperty.clear();
-            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
-        });
+    void matchesArtistsByTrackTitleAlbumAndLabelWhenArtistCatalogIsLoaded(FxRobot fxRobot) throws Exception {
+        Platform.runLater(() -> artistCatalogsProperty.clear());
         waitForFxEvents();
 
         var aphexTwin = of("Aphex Twin");
@@ -201,6 +421,7 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         // selectedArtistListener with an empty catalog and skips ArtistAlbumListRow construction
         // (which would otherwise fail against the bare AlbumSet/ObservableArtistCatalog mocks below).
         Platform.runLater(() -> {
+            navigationModeProperty.set(NavigationController.NavigationMode.ARTISTS);
             artistCatalogsProperty.add(mockCatalog(aphexTwin));
             artistCatalogsProperty.add(mockCatalog(bonobo));
         });
@@ -210,7 +431,7 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         ListView<ObservableArtistCatalog> artistsListView = fxRobot.lookup("#artistsListView").queryAs(ListView.class);
         assertThat(artistsListView.getItems()).hasSize(2);
 
-        // Now wire a populated catalog for aphexTwin so filterArtistsByQuery's catalog-walk branch
+        // Wire a populated catalog for aphexTwin so filterArtistsByQuery's catalog-walk branch
         // exercises the loaded path. selectedArtistListener won't refire because the selected
         // artist hasn't changed identity.
         var album = AudioItemTestFactory.createAlbum("Selected Ambient Works 85-92", aphexTwin, false, null,
@@ -220,8 +441,6 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         when(item.getArtist()).thenReturn(aphexTwin);
         when(item.getAlbum()).thenReturn(album);
 
-        // Stub catalog.getAlbumsProperty() to return the album details set; stub
-        // albumAudioItemsProperty so the catalog-walk predicate can iterate tracks.
         var albumsSetProperty = new javafx.beans.property.SimpleSetProperty<>(
                 javafx.collections.FXCollections.observableSet(album));
         var audioItemsListProperty = new javafx.beans.property.SimpleListProperty<>(
@@ -235,20 +454,23 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         doReturn(java.util.Optional.empty()).when(audioRepository).getArtistCatalog(bonobo);
 
         // Title-only query: matches Aphex Twin via track title; Bonobo has no matching catalog item.
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Xtal", this)));
+        Platform.runLater(() -> searchCoordinator.onQuery("Xtal"));
         waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
         assertThat(artistsListView.getItems()).hasSize(1);
         assertThat(artistsListView.getItems().get(0).getArtistName()).isEqualTo("Aphex Twin");
 
-        // Label-only query: confirms the new label-match branch in artistMatchesQuery.
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Warp", this)));
+        // Label-only query: confirms the label-match branch in artistMatchesQuery.
+        Platform.runLater(() -> searchCoordinator.onQuery("Warp"));
         waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
         assertThat(artistsListView.getItems()).hasSize(1);
         assertThat(artistsListView.getItems().get(0).getArtistName()).isEqualTo("Aphex Twin");
 
         // Album-only query.
-        Platform.runLater(() -> applicationEventPublisher.publishEvent(new SearchTextTypedEvent("Ambient Works", this)));
+        Platform.runLater(() -> searchCoordinator.onQuery("Ambient Works"));
         waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
         assertThat(artistsListView.getItems()).hasSize(1);
         assertThat(artistsListView.getItems().get(0).getArtistName()).isEqualTo("Aphex Twin");
 
@@ -257,9 +479,11 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         doReturn(java.util.Optional.empty()).when(audioRepository).getArtistCatalog(aphexTwin);
         doReturn(java.util.Optional.empty()).when(audioRepository).getArtistCatalog(bonobo);
         Platform.runLater(() -> {
-            applicationEventPublisher.publishEvent(new SearchTextTypedEvent("", this));
             artistCatalogsProperty.clear();
+            searchCoordinator.onQuery("");
         });
+        waitForFxEvents();
+        waitFor(5, TimeUnit.SECONDS, () -> searchCoordinator.isIdle());
         waitForFxEvents();
     }
 
@@ -270,22 +494,36 @@ class SearchFlowIT extends ApplicationTestBase<SplitPane> {
         return catalog;
     }
 
+    private static int nextId = 1;
+
     /**
      * Creates a mock {@link ObservableAudioItem} suitable for audio table predicate testing.
-     * Stubs only the fields examined by {@code AudioItemTableViewBase.audioItemContainsQuery}.
+     * Stubs only the fields examined by {@code AudioItemTableViewBase.audioItemContainsQuery},
+     * and assigns a unique ID so that ID-based predicate filtering is deterministic.
+     *
+     * <p>All album metadata is fully controlled via mocks to prevent random values generated by
+     * {@code AudioItemTestFactory} from contaminating search-match assertions (e.g. a randomly
+     * generated label whose name happens to contain the single-char search query).
      */
     private ObservableAudioItem mockAudioItem(String title, String artistName, String albumName) {
         var item = mock(ObservableAudioItem.class);
+        when(item.getId()).thenReturn(nextId++);
         when(item.getTitle()).thenReturn(title);
 
         var artist = mock(Artist.class);
         when(artist.getName()).thenReturn(artistName);
         when(item.getArtist()).thenReturn(artist);
 
-        var album = AudioItemTestFactory.createAlbum(albumName, Artist.of(artistName));
+        // Mock AlbumDetails directly so label/albumArtist/year are deterministic and do not
+        // contain random strings that could accidentally match the search query under test.
+        var album = mock(AlbumDetails.class);
+        when(album.getName()).thenReturn(albumName);
+        var albumArtistObj = mock(Artist.class);
+        when(albumArtistObj.getName()).thenReturn(artistName);
+        when(album.getAlbumArtist()).thenReturn(albumArtistObj);
+        when(album.getLabel()).thenReturn(null);  // no label → label branch in audioItemContainsQuery returns false
         when(item.getAlbum()).thenReturn(album);
 
-        // Stub path and cover for any defensive null checks in other parts of the table internals
         when(item.getPath()).thenReturn(Path.of("/mock/path/" + title + ".mp3"));
 
         return item;
@@ -322,6 +560,18 @@ class SearchFlowITConfiguration {
         when(repository.getAlbumsProperty()).thenReturn(albumsProperty);
         when(repository.getArtistCatalogPublisher()).thenReturn(mock(LirpEventPublisher.class));
         return repository;
+    }
+
+    @Bean
+    public ObjectProperty<NavigationController.NavigationMode> navigationModeProperty() {
+        return new javafx.beans.property.SimpleObjectProperty<>(NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+    }
+
+    @Bean
+    public NavigationController navigationController(ObjectProperty<NavigationController.NavigationMode> navigationModeProperty) {
+        var mock = mock(NavigationController.class);
+        when(mock.navigationModeProperty()).thenReturn(navigationModeProperty);
+        return mock;
     }
 
     // No @Bean for ApplicationEventPublisher — the test relies on the real Spring multicaster so

--- a/src/integrationTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewIT.java
@@ -4,6 +4,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.stage.Stage;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +32,7 @@ class FullAudioItemTableViewIT {
     @Start
     void start(Stage stage) {
         ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
-        tableView = new FullAudioItemTableView(publisher);
+        tableView = new FullAudioItemTableView(publisher, mock(SearchCoordinator.class));
         stage.setScene(new Scene(tableView, 800, 600));
         stage.show();
     }

--- a/src/integrationTest/kotlin/net/transgressoft/musicott/view/SearchFlowITCoordinator.kt
+++ b/src/integrationTest/kotlin/net/transgressoft/musicott/view/SearchFlowITCoordinator.kt
@@ -1,0 +1,26 @@
+package net.transgressoft.musicott.view
+
+import net.transgressoft.musicott.search.SearchCoordinator
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Kotlin supplement for [SearchFlowITConfiguration] providing the real [SearchCoordinator]
+ * bean. Extracted to a Kotlin source file because Java cannot call Kotlin constructors that
+ * use default parameter values without explicit [@JvmOverloads][kotlin.jvm.JvmOverloads] — and
+ * adding that annotation to [SearchCoordinator] causes Spring's autowiring to fail when
+ * multiple overloads are present. Keeping construction in Kotlin avoids both issues.
+ *
+ * The coordinator is created with `debounceMillis = 0` so that non-blank queries execute
+ * immediately without the production 400 ms wait. This keeps tests deterministic while still
+ * exercising the real Dispatchers.Default → Dispatchers.JavaFx coroutine thread-hop path.
+ */
+@Configuration
+class SearchFlowITCoordinatorSupplier {
+
+    @Bean(destroyMethod = "close")
+    fun searchCoordinator(
+        applicationEventPublisher: ApplicationEventPublisher
+    ): SearchCoordinator = SearchCoordinator(applicationEventPublisher, debounceMillis = 0)
+}

--- a/src/main/java/net/transgressoft/musicott/view/AlbumViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/AlbumViewController.java
@@ -19,26 +19,29 @@ import net.rgielen.fxweaver.core.FxmlView;
 import net.transgressoft.commons.fx.music.audio.ObservableAlbum;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.musicott.search.SearchCoordinator;
+import net.transgressoft.musicott.search.Searchable;
+import net.transgressoft.musicott.view.NavigationController.NavigationMode;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 import net.transgressoft.musicott.view.custom.OverlayTracksDrawer;
 import net.transgressoft.musicott.view.custom.table.AlbumTrackGroup;
 import net.transgressoft.musicott.view.custom.table.AudioItemQueryMatcher;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
 import org.controlsfx.control.GridCell;
 import org.controlsfx.control.GridView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Controller;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Controller for the Albums navigation view. Renders the audio library's album catalog as a grid of
@@ -60,7 +63,7 @@ import java.util.function.Predicate;
  */
 @FxmlView("/fxml/AlbumViewController.fxml")
 @Controller
-public class AlbumViewController {
+public class AlbumViewController implements Searchable<String> {
 
     private static final double CELL_WIDTH = 170.0;
     private static final double CELL_HEIGHT = 210.0;
@@ -70,12 +73,22 @@ public class AlbumViewController {
 
     private final ObservableAudioLibrary audioRepository;
     private final ApplicationContext applicationContext;
+    private final SearchCoordinator searchCoordinator;
 
     @FXML
     private StackPane albumsRootPane;
 
     private GridView<ObservableAlbum> albumGridView;
     private FilteredList<ObservableAlbum> filteredAlbums;
+
+    /** Ordered mirror of the repository's album projection; the source of {@link #filteredAlbums}. */
+    private ObservableList<ObservableAlbum> albumsBacking;
+
+    /**
+     * Immutable snapshot of {@link #albumsBacking} taken on the FX thread by {@link #prepareSnapshot()}
+     * before the background scan begins. Read-only from {@link #computeMatchIds}.
+     */
+    private List<ObservableAlbum> albumsSnapshot = List.of();
 
     /** The shared overlay drawer showing the selected album's tracks. */
     private OverlayTracksDrawer drawer;
@@ -87,9 +100,11 @@ public class AlbumViewController {
     ObservableAlbum selectedAlbum;
 
     @Autowired
-    public AlbumViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext) {
+    public AlbumViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext,
+                               SearchCoordinator searchCoordinator) {
         this.audioRepository = audioLibrary;
         this.applicationContext = applicationContext;
+        this.searchCoordinator = searchCoordinator;
     }
 
     @FXML
@@ -116,6 +131,8 @@ public class AlbumViewController {
         // The shared drawer owns the overlay lifecycle (dim, slide, Esc, dispose-on-detach) so the
         // Albums and Genres views do not each reimplement it.
         drawer = new OverlayTracksDrawer(albumsRootPane, applicationContext);
+
+        searchCoordinator.register(NavigationMode.ALBUMS, this);
     }
 
     /**
@@ -126,7 +143,7 @@ public class AlbumViewController {
      * routed through {@link Platform#runLater} defensively so the grid never mutates off-thread.
      */
     private void configureGridBacking() {
-        ObservableList<ObservableAlbum> albumsBacking = FXCollections.observableArrayList(audioRepository.getAlbumsProperty());
+        albumsBacking = FXCollections.observableArrayList(audioRepository.getAlbumsProperty());
         logger.info("Albums view initialised with {} albums", albumsBacking.size());
 
         // Mirror the ordered projection wholesale on every change so the grid preserves its
@@ -193,19 +210,50 @@ public class AlbumViewController {
     }
 
     /**
-     * Filters the albums view to the current search query, mirroring the artist view. Only albums
-     * with at least one track matching the query stay in the grid; an open drawer is narrowed to the
-     * album's matching tracks and closed if the selected album has no match. An empty query restores
-     * the full view.
+     * Captures an immutable snapshot of {@link #albumsBacking} on the FX thread. The snapshot is
+     * consumed by {@link #computeMatchIds} running on the background dispatcher, preventing data
+     * races with concurrent FX-thread mutations (album add/remove during import).
      */
-    @EventListener
-    public void searchTextTypedEvent(SearchTextTypedEvent event) {
-        currentSearchQuery = event.searchText == null ? "" : event.searchText.toLowerCase();
+    @Override
+    public void prepareSnapshot() {
+        albumsSnapshot = List.copyOf(albumsBacking);
+    }
+
+    /**
+     * Scans the album snapshot (captured on the FX thread by {@link #prepareSnapshot}) for albums
+     * with at least one track matching the query. Must not touch any JavaFX observable or
+     * {@link FilteredList} predicate.
+     *
+     * @param query the lower-cased search text
+     * @return set of album names that have at least one matching track
+     */
+    @Override
+    public Set<String> computeMatchIds(String query) {
+        return albumsSnapshot.stream()
+                .filter(albumMatchesQuery(query)::test)
+                .map(ObservableAlbum::getAlbumName)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Applies the pre-computed album name set to the filtered list and updates the open drawer on the
+     * JavaFX Application Thread. A blank {@code query} resets the view to show every album; for a
+     * non-blank query only albums whose name is in {@code ids} are shown, so an empty {@code ids}
+     * hides all albums. An open drawer is narrowed to the album's matching tracks and closed if the
+     * selected album has no match.
+     *
+     * @param query the lower-cased search text (forwarded to the open drawer)
+     * @param ids   the set of matching album names produced by {@link #computeMatchIds}
+     */
+    @Override
+    public void applyMatchIds(String query, Set<String> ids) {
+        currentSearchQuery = query == null ? "" : query;
+        boolean reset = currentSearchQuery.isBlank();
         if (filteredAlbums != null) {
-            filteredAlbums.setPredicate(albumMatchesQuery(currentSearchQuery));
+            filteredAlbums.setPredicate(reset ? null : album -> ids.contains(album.getAlbumName()));
         }
         if (drawer.isOpen() && selectedAlbum != null) {
-            if (albumMatchesQuery(currentSearchQuery).test(selectedAlbum)) {
+            if (reset || ids.contains(selectedAlbum.getAlbumName())) {
                 drawer.applyQuery(currentSearchQuery);
             } else {
                 drawer.close();

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -15,10 +15,12 @@ import net.transgressoft.lirp.event.*;
 import net.transgressoft.commons.fx.music.audio.*;
 import net.transgressoft.commons.music.audio.*;
 import net.transgressoft.musicott.events.*;
+import net.transgressoft.musicott.search.SearchCoordinator;
+import net.transgressoft.musicott.search.Searchable;
+import net.transgressoft.musicott.view.NavigationController.NavigationMode;
 import net.transgressoft.musicott.view.custom.table.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.context.*;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.*;
 
 import java.util.*;
@@ -33,10 +35,11 @@ import static org.fxmisc.easybind.EasyBind.map;
  */
 @FxmlView("/fxml/ArtistViewController.fxml")
 @Controller
-public class ArtistViewController {
+public class ArtistViewController implements Searchable<String> {
 
     private final ObservableAudioLibrary audioRepository;
     private final ApplicationContext applicationContext;
+    private final SearchCoordinator searchCoordinator;
 
     @FXML
     private SplitPane artistsViewSplitPane;
@@ -60,10 +63,45 @@ public class ArtistViewController {
     private FilteredList<ObservableArtistCatalog> filteredArtists;
     private String currentSearchQuery = "";
 
+    /**
+     * Immutable snapshot of the artists backing list taken on the FX thread by {@link #prepareSnapshot()}
+     * before the background scan begins. Read-only from {@link #computeMatchIds}.
+     */
+    private List<ObservableArtistCatalog> artistsSnapshot = List.of();
+
+    /**
+     * Immutable snapshot of the current album row list taken on the FX thread by {@link #prepareSnapshot()}
+     * before the background scan begins. Read-only from {@link #computeMatchIds}.
+     */
+    private List<ArtistAlbumListRow> albumRowsSnapshot = List.of();
+
+    /**
+     * Precomputed result of the off-thread album-row scan: maps each row to the set of track IDs
+     * that match the search query. Written by {@link #computeMatchIds} and read by
+     * {@link #applyMatchIds} on the FX thread after the coroutine context switch.
+     */
+    private Map<ArtistAlbumListRow, Set<Integer>> matchingTrackIdsByRow = Map.of();
+
+    /**
+     * Immutable snapshot of each artist's tracks taken on the FX thread by {@link #prepareSnapshot()}
+     * via {@link #audioItemsForArtist}. Consumed by {@link #computeMatchIds} for track-content
+     * matching so the scan never iterates a live observable list off-thread.
+     */
+    private Map<Artist, List<ObservableAudioItem>> artistTracksSnapshot = Map.of();
+
+    /**
+     * Immutable snapshot of each album row's contained tracks taken on the FX thread by
+     * {@link #prepareSnapshot()}. Consumed by {@link #computeMatchIds} so the per-row scan never
+     * iterates a live {@code containedAudioItemsProperty} off-thread.
+     */
+    private Map<ArtistAlbumListRow, List<ObservableAudioItem>> rowTracksSnapshot = Map.of();
+
     @Autowired
-    public ArtistViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext) {
+    public ArtistViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext,
+                                SearchCoordinator searchCoordinator) {
         this.audioRepository = audioLibrary;
         this.applicationContext = applicationContext;
+        this.searchCoordinator = searchCoordinator;
     }
 
     @FXML
@@ -76,6 +114,8 @@ public class ArtistViewController {
         nameLabel.textProperty().bind(Bindings.createStringBinding(() ->
                         selectedArtistProperty.get().isPresent() ? selectedArtistProperty.get().get().getArtistName() : "",
                 selectedArtistProperty));
+
+        searchCoordinator.register(NavigationMode.ARTISTS, this);
 
         albumListRowMap = FXCollections.observableMap(new LinkedHashMap<>());
         albumRowsBackingList = FXCollections.observableArrayList();
@@ -167,10 +207,30 @@ public class ArtistViewController {
         albumSetsWithDisc.forEach((albumSet, discNum) -> {
             var audioItemsTableView = applicationContext.getBean(SimpleAudioItemTableView.class);
             var artistListRow = applicationContext.getBean(ArtistAlbumListRow.class, artist, albumSet, audioItemsTableView, discNum);
-            artistListRow.filterTracksByQuery(currentSearchQuery);
             albumListRowMap.put(albumSet, artistListRow);
             albumRowsBackingList.add(artistListRow);
         });
+
+        // When a search query is active, re-apply per-row filtering for the newly loaded rows.
+        // This is a bounded per-artist scan (acceptable on the FX thread) that mirrors the same
+        // name-match-shows-all rule used in computeMatchIds: if the artist name matches the query,
+        // every track in each row is shown; otherwise only tracks matching the query content are shown.
+        if (!currentSearchQuery.isBlank()) {
+            String q = currentSearchQuery;
+            boolean artistNameMatches = artist.getName() != null
+                    && artist.getName().toLowerCase().contains(q);
+            if (artistNameMatches) {
+                // Artist matched by name: show all tracks in all rows, keep rows visible
+                albumRowsBackingList.forEach(row -> row.filterTracks(null));
+                filteredAlbumRows.setPredicate(null);
+            } else {
+                // Artist matched only via track content: filter each row to matching tracks only
+                albumRowsBackingList.forEach(row ->
+                        row.filterTracks(item -> audioItemMatchesQuery(item, q)));
+                filteredAlbumRows.setPredicate(row -> row.hasTracksMatching(item -> audioItemMatchesQuery(item, q)));
+            }
+        }
+
         totalTracksLabel.setText(getTotalArtistTracksString());
         totalAlbumsLabel.setText(getAlbumString());
     }
@@ -352,14 +412,122 @@ public class ArtistViewController {
         albumRowsBackingList.forEach(ArtistAlbumListRow::deselectAllAudioItems);
     }
 
-    @EventListener
-    public void searchTextTypedEvent(SearchTextTypedEvent event) {
-        currentSearchQuery = event.searchText == null ? "" : event.searchText;
-        filteredArtists.setPredicate(filterArtistsByQuery(currentSearchQuery));
-        // Propagate to currently-loaded album rows: hide rows with no matching tracks and let each
-        // visible row narrow its embedded SimpleAudioItemTableView to the matching tracks.
-        albumRowsBackingList.forEach(row -> row.filterTracksByQuery(currentSearchQuery));
-        filteredAlbumRows.setPredicate(albumRowMatchesQuery(currentSearchQuery));
+    /**
+     * Captures immutable snapshots of the artists and album-row backing lists, the repository
+     * audio-item pool, and each row's contained tracks on the FX thread. All snapshots are consumed
+     * by {@link #computeMatchIds} on the background dispatcher, preventing data races with concurrent
+     * FX-thread structural mutations of any of these live observable collections.
+     */
+    @Override
+    public void prepareSnapshot() {
+        artistsSnapshot = List.copyOf(filteredArtists.getSource());
+        albumRowsSnapshot = List.copyOf(albumRowsBackingList);
+        // Resolve each artist's tracks on the FX thread via audioItemsForArtist, which handles the
+        // null-property fallback to per-artist catalogs; the off-thread scan then reads these copies.
+        Map<Artist, List<ObservableAudioItem>> artistTracks = new HashMap<>();
+        for (var catalog : artistsSnapshot) {
+            var artist = catalog.getArtist();
+            artistTracks.computeIfAbsent(artist, a -> audioItemsForArtist(a).toList());
+        }
+        artistTracksSnapshot = Map.copyOf(artistTracks);
+        Map<ArtistAlbumListRow, List<ObservableAudioItem>> rowTracks = new HashMap<>();
+        for (var row : albumRowsSnapshot) {
+            rowTracks.put(row, List.copyOf(row.containedAudioItemsProperty()));
+        }
+        rowTracksSnapshot = Map.copyOf(rowTracks);
+    }
+
+    /**
+     * Scans the artist and album-row snapshots (captured on the FX thread by {@link #prepareSnapshot})
+     * for matching entries. Both the artist-level scan (name and track metadata) and the per-row
+     * track scan run entirely off the FX thread. Precomputed results are stored in
+     * {@link #matchingTrackIdsByRow} for cheap application in {@link #applyMatchIds}.
+     *
+     * <p>For each row the precomputed track-ID set depends on how the artist matched: if the row's
+     * artist name matches the query directly (name-only match), every track in the row is included so
+     * the user sees the full album when they select that artist; if the artist matched only via track
+     * content, only the query-matching track IDs are included.
+     *
+     * @param query the lower-cased search text
+     * @return set of artist names whose catalog has at least one match
+     */
+    @Override
+    public Set<String> computeMatchIds(String query) {
+        // First, build the set of artist names that match the query by name alone. This is used below
+        // to decide whether a row should show all its tracks (name match) or only the matching subset.
+        Set<String> artistNameMatches = artistsSnapshot.stream()
+                .filter(catalog -> catalog.getArtistName() != null
+                        && catalog.getArtistName().toLowerCase().contains(query))
+                .map(ObservableArtistCatalog::getArtistName)
+                .collect(toSet());
+
+        // Precompute which track IDs match per album row so applyMatchIds can apply
+        // cheap membership predicates without any substring scanning on the FX thread.
+        // If the row belongs to a name-matched artist, include ALL track IDs so selecting that
+        // artist reveals its full track list rather than an empty one.
+        Map<ArtistAlbumListRow, Set<Integer>> rowMatchIds = new HashMap<>();
+        for (var row : albumRowsSnapshot) {
+            boolean artistNameMatched = row.getArtist() != null
+                    && artistNameMatches.contains(row.getArtist().getName());
+            List<ObservableAudioItem> rowTracks = rowTracksSnapshot.getOrDefault(row, List.of());
+            Set<Integer> ids;
+            if (artistNameMatched) {
+                ids = rowTracks.stream()
+                        .map(ObservableAudioItem::getId)
+                        .collect(toSet());
+            } else {
+                ids = rowTracks.stream()
+                        .filter(item -> audioItemMatchesQuery(item, query))
+                        .map(ObservableAudioItem::getId)
+                        .collect(toSet());
+            }
+            rowMatchIds.put(row, ids);
+        }
+        matchingTrackIdsByRow = Map.copyOf(rowMatchIds);
+
+        return artistsSnapshot.stream()
+                .filter(filterArtistsByQuery(query)::test)
+                .map(ObservableArtistCatalog::getArtistName)
+                .collect(toSet());
+    }
+
+    /**
+     * Applies the pre-computed results to the artist view on the JavaFX Application Thread.
+     * All three collections are updated using the precomputed ID sets from {@link #computeMatchIds}:
+     * the artist predicate uses a name-membership check, the per-row track tables apply precomputed
+     * track-ID predicates, and the album-row predicate shows only rows with at least one visible track.
+     * No substring scanning is performed in this method.
+     *
+     * <p>A blank {@code query} signals a reset: all predicates are cleared and every artist and row
+     * becomes visible again. For a non-blank query, rows whose artist matched by name show all their
+     * tracks (the precomputed set for that row contains every track ID); rows that matched only by
+     * track content show only the matching subset; rows with no match are hidden.
+     *
+     * @param query the lower-cased search text; blank signals a reset (show all)
+     * @param ids   the set of matching artist names produced by {@link #computeMatchIds}
+     */
+    @Override
+    public void applyMatchIds(String query, Set<String> ids) {
+        currentSearchQuery = query == null ? "" : query;
+        boolean reset = currentSearchQuery.isBlank();
+        filteredArtists.setPredicate(reset ? null : catalog -> ids.contains(catalog.getArtistName()));
+        if (reset) {
+            // Reset: clear all row-level filters
+            albumRowsBackingList.forEach(row -> row.filterTracks(null));
+            filteredAlbumRows.setPredicate(null);
+        } else {
+            // Apply precomputed per-row track-ID sets — no substring scanning.
+            // matchingTrackIdsByRow contains ALL track IDs for name-matched artist rows, and only the
+            // query-matching subset for track-content-only matches. Rows with no matching tracks are hidden.
+            albumRowsBackingList.forEach(row -> {
+                Set<Integer> trackIds = matchingTrackIdsByRow.getOrDefault(row, Set.of());
+                row.filterTracks(item -> trackIds.contains(item.getId()));
+            });
+            filteredAlbumRows.setPredicate(row -> {
+                Set<Integer> trackIds = matchingTrackIdsByRow.getOrDefault(row, Set.of());
+                return !trackIds.isEmpty();
+            });
+        }
     }
 
     private Predicate<ObservableArtistCatalog> filterArtistsByQuery(String query) {
@@ -371,16 +539,11 @@ public class ArtistViewController {
             if (artistCatalog.getArtistName() != null && artistCatalog.getArtistName().toLowerCase().contains(q)) {
                 return true;
             }
-            return audioItemsForArtist(artistCatalog.getArtist())
+            // Scan the FX-thread per-artist track snapshot rather than the live repository list:
+            // this predicate runs off-thread inside computeMatchIds.
+            return artistTracksSnapshot.getOrDefault(artistCatalog.getArtist(), List.of()).stream()
                     .anyMatch(audioItem -> audioItemMatchesQuery(audioItem, q));
         };
-    }
-
-    private Predicate<ArtistAlbumListRow> albumRowMatchesQuery(String query) {
-        if (query == null || query.isEmpty()) {
-            return row -> true;
-        }
-        return row -> row.hasTracksMatching(query);
     }
 
     // Defensive null guards — partial catalogs can ship tracks with null artist/album/album-artist.

--- a/src/main/java/net/transgressoft/musicott/view/GenreViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/GenreViewController.java
@@ -20,7 +20,9 @@ import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.fx.music.audio.ObservableGenreIndex;
 import net.transgressoft.musicott.events.PlayItemEvent;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import net.transgressoft.musicott.search.SearchCoordinator;
+import net.transgressoft.musicott.search.Searchable;
+import net.transgressoft.musicott.view.NavigationController.NavigationMode;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 import net.transgressoft.musicott.view.custom.OverlayTracksDrawer;
 import net.transgressoft.musicott.view.custom.table.AlbumTrackGroup;
@@ -31,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Controller;
 
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
@@ -69,7 +71,7 @@ import static java.util.stream.Collectors.toSet;
  */
 @FxmlView("/fxml/GenreViewController.fxml")
 @Controller
-public class GenreViewController {
+public class GenreViewController implements Searchable<String> {
 
     private static final double CELL_WIDTH = 170.0;
     private static final double CELL_HEIGHT = 210.0;
@@ -86,12 +88,22 @@ public class GenreViewController {
 
     private final ObservableAudioLibrary audioRepository;
     private final ApplicationContext applicationContext;
+    private final SearchCoordinator searchCoordinator;
 
     @FXML
     private StackPane genresRootPane;
 
     private GridView<ObservableGenreIndex> genreGridView;
     private FilteredList<ObservableGenreIndex> filteredGenres;
+
+    /** Ordered mirror of the repository's genre-index projection; the source of {@link #filteredGenres}. */
+    private ObservableList<ObservableGenreIndex> genresBacking;
+
+    /**
+     * Immutable snapshot of {@link #genresBacking} taken on the FX thread by {@link #prepareSnapshot()}
+     * before the background scan begins. Read-only from {@link #computeMatchIds}.
+     */
+    private List<ObservableGenreIndex> genresSnapshot = List.of();
 
     /** Lower-cased active search query, or empty when no filter is applied. */
     private String currentSearchQuery = "";
@@ -127,9 +139,11 @@ public class GenreViewController {
     }
 
     @Autowired
-    public GenreViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext) {
+    public GenreViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext,
+                               SearchCoordinator searchCoordinator) {
         this.audioRepository = audioLibrary;
         this.applicationContext = applicationContext;
+        this.searchCoordinator = searchCoordinator;
     }
 
     @FXML
@@ -156,6 +170,8 @@ public class GenreViewController {
         // The shared drawer owns the overlay lifecycle (dim, slide, Esc, dispose-on-detach) so the
         // Genres and Albums views do not each reimplement it.
         drawer = new OverlayTracksDrawer(genresRootPane, applicationContext);
+
+        searchCoordinator.register(NavigationMode.GENRES, this);
     }
 
     /**
@@ -166,7 +182,7 @@ public class GenreViewController {
      * still routed through {@link Platform#runLater} defensively so the grid never mutates off-thread.
      */
     private void configureGridBacking() {
-        ObservableList<ObservableGenreIndex> genresBacking = FXCollections.observableArrayList(audioRepository.getGenreIndexesProperty());
+        genresBacking = FXCollections.observableArrayList(audioRepository.getGenreIndexesProperty());
         logger.info("Genres view initialised with {} genre buckets", genresBacking.size());
 
         // Mirror the ordered projection wholesale on every change so the grid preserves its bucket
@@ -245,19 +261,52 @@ public class GenreViewController {
     }
 
     /**
-     * Filters the genres view to the current search query, mirroring the album view. Only genres with
-     * at least one track matching the query stay in the grid; an open drawer is narrowed to the
-     * genre's matching tracks and closed if the selected genre has no match. An empty query restores
-     * the full view.
+     * Captures an immutable snapshot of {@link #genresBacking} on the FX thread. The snapshot is
+     * consumed by {@link #computeMatchIds} running on the background dispatcher, preventing data
+     * races with concurrent FX-thread mutations (genre bucket add/remove during import).
      */
-    @EventListener
-    public void searchTextTypedEvent(SearchTextTypedEvent event) {
-        currentSearchQuery = event.searchText == null ? "" : event.searchText.toLowerCase();
+    @Override
+    public void prepareSnapshot() {
+        genresSnapshot = List.copyOf(genresBacking);
+    }
+
+    /**
+     * Scans the genre snapshot (captured on the FX thread by {@link #prepareSnapshot}) for genres
+     * with at least one track matching the query. Must not touch any JavaFX observable or
+     * {@link FilteredList} predicate.
+     *
+     * @param query the lower-cased search text
+     * @return set of genre names that have at least one matching track
+     */
+    @Override
+    public Set<String> computeMatchIds(String query) {
+        return genresSnapshot.stream()
+                .filter(genreMatchesQuery(query)::test)
+                .map(g -> g.getGenreProperty().get().getName())
+                .collect(toSet());
+    }
+
+    /**
+     * Applies the pre-computed genre name set to the filtered list and updates the open drawer on the
+     * JavaFX Application Thread. A blank {@code query} resets the view to show every genre; for a
+     * non-blank query only genres whose name is in {@code ids} are shown, so an empty {@code ids}
+     * hides all genres. An open drawer is narrowed to the genre's matching tracks and closed if the
+     * selected genre has no match.
+     *
+     * @param query the lower-cased search text (forwarded to the open drawer)
+     * @param ids   the set of matching genre names produced by {@link #computeMatchIds}
+     */
+    @Override
+    public void applyMatchIds(String query, Set<String> ids) {
+        currentSearchQuery = query == null ? "" : query;
+        boolean reset = currentSearchQuery.isBlank();
         if (filteredGenres != null) {
-            filteredGenres.setPredicate(genreMatchesQuery(currentSearchQuery));
+            filteredGenres.setPredicate(reset ? null
+                    : g -> ids.contains(g.getGenreProperty().get().getName()));
         }
         if (drawer.isOpen() && selectedGenre != null) {
-            if (genreMatchesQuery(currentSearchQuery).test(selectedGenre)) {
+            String selectedGenreName = selectedGenre.getGenreProperty().get().getName();
+            if (reset || ids.contains(selectedGenreName)) {
                 drawer.applyQuery(currentSearchQuery);
             } else {
                 drawer.close();
@@ -270,7 +319,8 @@ public class GenreViewController {
             return genre -> true;
         }
         return genre -> {
-            var tracks = genre.getTracksProperty();
+            // getTracks() returns the immutable backing list, safe to read off the FX thread.
+            var tracks = genre.getTracks();
             return tracks != null && tracks.stream().anyMatch(track -> AudioItemQueryMatcher.matches(track, query));
         };
     }

--- a/src/main/java/net/transgressoft/musicott/view/MainController.java
+++ b/src/main/java/net/transgressoft/musicott/view/MainController.java
@@ -31,6 +31,7 @@ import net.transgressoft.musicott.events.*;
 import net.transgressoft.musicott.service.MediaImportService;
 import net.transgressoft.musicott.services.PlayerService;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 import net.transgressoft.musicott.view.custom.alerts.DeleteAudioItemsConfirmationAlert;
 import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
@@ -77,6 +78,7 @@ public class MainController {
     private final MediaImportService mediaImportService;
     private final ItunesImportWizard itunesImportWizard;
     private final ApplicationContext applicationContext;
+    private final SearchCoordinator searchCoordinator;
 
     private final ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty;
 
@@ -166,7 +168,8 @@ public class MainController {
                           MediaImportService mediaImportService,
                           ItunesImportWizard itunesImportWizard,
                           ApplicationContext applicationContext,
-                          KeyCombination.Modifier operativeSystemKeyModifier) {
+                          KeyCombination.Modifier operativeSystemKeyModifier,
+                          SearchCoordinator searchCoordinator) {
         this.audioRepository = audioRepository;
         this.playlistRepository = playlistRepository;
         this.playerService = playerService;
@@ -180,6 +183,7 @@ public class MainController {
         this.itunesImportWizard = itunesImportWizard;
         this.applicationContext = applicationContext;
         this.operativeSystemKeyModifier = operativeSystemKeyModifier;
+        this.searchCoordinator = searchCoordinator;
         this.selectedPlaylistProperty = navigationController.selectedPlaylistProperty();
     }
 
@@ -232,13 +236,8 @@ public class MainController {
             }
         });
 
-        searchTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue.length() >= 3) {
-                applicationContext.publishEvent(new SearchTextTypedEvent(newValue, this));
-            } else if (newValue.isEmpty() || newValue.length() < 3) {
-                applicationContext.publishEvent(new SearchTextTypedEvent("", this));
-            }
-        });
+        searchTextField.textProperty().addListener((observable, oldValue, newValue) ->
+                searchCoordinator.onQuery(newValue));
 
         audioItemContextMenu = new AudioItemTableViewContextMenu();
 
@@ -1063,7 +1062,7 @@ public class MainController {
             playlistsInMenu.clear();
             addToPlaylistMenu.getItems().clear();
 
-            // Populate "Add to Playlist" submenu unconditionally in all navigation views (D-07)
+            // Populate "Add to Playlist" submenu unconditionally in all navigation views
             navigationController.playlistsProperty().stream()
                     .filter(p -> ! p.isDirectory())
                     .forEach(this::addPlaylistToMenuList);

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -383,6 +383,10 @@ public class ArtistAlbumListRow extends HBox {
         return albumSet;
     }
 
+    public Artist getArtist() {
+        return artist;
+    }
+
     public ListProperty<ObservableAudioItem> selectedAudioItemsProperty() {
         return selectedAudioItemsProperty;
     }

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
@@ -18,11 +18,11 @@ import net.transgressoft.commons.music.audio.Genre;
 import net.transgressoft.commons.music.audio.GenreExtensionsKt;
 import net.transgressoft.commons.music.player.*;
 import net.transgressoft.musicott.events.*;
+import net.transgressoft.musicott.search.Searchable;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 import org.apache.commons.io.FileUtils;
 import org.fxmisc.easybind.EasyBind;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -30,11 +30,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * @author Octavio Calleya
  */
-public abstract class AudioItemTableViewBase extends TableView<ObservableAudioItem> {
+public abstract class AudioItemTableViewBase extends TableView<ObservableAudioItem> implements Searchable<Integer> {
 
     public static final DataFormat TRACKS_DATA_FORMAT = new DataFormat("application/x-java-tracks-id");
 
@@ -52,6 +53,12 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
 
     private ListChangeListener<ObservableAudioItem> sourceItemsListener;
     private ObservableList<ObservableAudioItem> currentSourceItems;
+
+    /**
+     * Immutable snapshot of the backing source list taken on the FX thread by {@link #prepareSnapshot()}
+     * before the background scan begins. Read-only from {@link #computeMatchIds}.
+     */
+    private List<ObservableAudioItem> audioItemsSnapshot = List.of();
 
     protected TableColumn<ObservableAudioItem, String> nameCol;
     protected TableColumn<ObservableAudioItem, Artist> artistCol;
@@ -225,9 +232,49 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         };
     }
 
-    @EventListener
-    public void searchTextTypedEvent(SearchTextTypedEvent event) {
-        filteredAudioItems.setPredicate(filterAudioItemPredicate(event.searchText));
+    /**
+     * Captures an immutable snapshot of the backing source list on the JavaFX Application Thread.
+     * The snapshot is consumed by {@link #computeMatchIds} on the background dispatcher, preventing
+     * data races with concurrent FX-thread mutations of the source list (view switches and imports
+     * both call {@link #setSourceItems} on the FX thread).
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void prepareSnapshot() {
+        audioItemsSnapshot = List.copyOf((ObservableList<ObservableAudioItem>) filteredAudioItems.getSource());
+    }
+
+    /**
+     * Scans the snapshot captured by {@link #prepareSnapshot} (not the filtered view) and returns the
+     * IDs of items that match the query. Must not touch any JavaFX observable or {@link FilteredList}
+     * predicate.
+     *
+     * @param query the lower-cased search text
+     * @return set of matching audio item IDs
+     */
+    @Override
+    public Set<Integer> computeMatchIds(String query) {
+        return audioItemsSnapshot.stream()
+                .filter(item -> audioItemContainsQuery(item, query))
+                .map(ObservableAudioItem::getId)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Applies the pre-computed ID set to the filtered list on the JavaFX Application Thread.
+     * A blank query signals a reset and removes the predicate so all items are visible; a non-blank
+     * query with an empty {@code ids} set means nothing matched and the list is cleared to zero items.
+     *
+     * @param query the search text; blank signals a reset (show all)
+     * @param ids   the set of matching item IDs produced by {@link #computeMatchIds}
+     */
+    @Override
+    public void applyMatchIds(String query, Set<Integer> ids) {
+        if (query == null || query.isBlank()) {
+            filteredAudioItems.setPredicate(null);
+        } else {
+            filteredAudioItems.setPredicate(item -> ids.contains(item.getId()));
+        }
     }
 
     /**

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableView.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableView.java
@@ -1,6 +1,8 @@
 package net.transgressoft.musicott.view.custom.table;
 
 import javafx.scene.control.TableColumn;
+import net.transgressoft.musicott.search.SearchCoordinator;
+import net.transgressoft.musicott.view.NavigationController.NavigationMode;
 import org.jspecify.annotations.*;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -12,8 +14,13 @@ import java.util.function.*;
 public class FullAudioItemTableView extends AudioItemTableViewBase {
 
     @SuppressWarnings ("unchecked")
-    public FullAudioItemTableView(ApplicationEventPublisher applicationEventPublisher) {
+    public FullAudioItemTableView(ApplicationEventPublisher applicationEventPublisher,
+                                  SearchCoordinator searchCoordinator) {
         super(applicationEventPublisher);
+        // Register this table as the Searchable for both the full-library and playlist navigation
+        // modes — the same table view is shown in both contexts.
+        searchCoordinator.register(NavigationMode.ALL_AUDIO_ITEMS, this);
+        searchCoordinator.register(NavigationMode.PLAYLIST, this);
         // Title-first column order — Title is the column the user reads most often.
         getColumns().addAll(nameCol, artistCol, albumCol, genreCol, labelCol, bpmCol, totalTimeCol);
         getColumns().addAll(yearCol, sizeCol, trackNumberCol, discNumberCol, albumArtistCol, commentsCol);

--- a/src/main/kotlin/net/transgressoft/musicott/search/SearchCoordinator.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/search/SearchCoordinator.kt
@@ -1,0 +1,196 @@
+package net.transgressoft.musicott.search
+
+import jakarta.annotation.PreDestroy
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.javafx.JavaFx
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent
+import net.transgressoft.musicott.view.NavigationController.NavigationMode
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Central Spring service that owns the asynchronous search lifecycle for all navigation modes.
+ *
+ * When [onQuery] is called (from the JavaFX Application Thread via [net.transgressoft.musicott.view.MainController]),
+ * the coordinator:
+ * 1. Cancels any in-flight job (including any pending reset or prior qualifying search).
+ * 2. Increments the generation counter and assigns a new coroutine to [currentJob] so every
+ *    path — both reset and qualifying — participates in the same cancel/coalesce discipline.
+ * 3. For blank (empty or whitespace-only) queries, the coroutine resets all registered views on
+ *    the FX thread without debouncing.
+ * 4. For any non-blank query (even a single character), the coroutine debounces for [debounceMillis]
+ *    milliseconds (default 400), then for EVERY registered view snapshots its backing collection on
+ *    the FX thread via [Searchable.prepareSnapshot], computes match IDs off-thread on
+ *    [Dispatchers.Default], and applies results on [Dispatchers.JavaFx].
+ *
+ * Every registered view is filtered on each query — not just the currently visible one — so all
+ * navigation modes stay in sync: switching to another mode shows an already-filtered view, and
+ * editing or clearing the query updates every view.
+ *
+ * A monotonically increasing generation counter prevents a slow earlier query from overwriting
+ * results already produced by a newer query.
+ *
+ * Views register themselves by calling [register] from their FXML `initialize()` method.
+ * No view controller is constructor-injected, avoiding circular Spring dependencies.
+ *
+ * The internal [CoroutineScope] is backed by a [SupervisorJob] so that a cancelled or failing
+ * child job does not cascade to cancel sibling searches. The scope is cancelled on Spring
+ * context shutdown via [@PreDestroy][PreDestroy].
+ *
+ * @param applicationEventPublisher used to publish "Searching…" status messages
+ * @param dispatcher the background dispatcher used for [Searchable.computeMatchIds];
+ *        defaults to [Dispatchers.Default] and injectable for deterministic testing
+ * @param fxDispatcher the FX-thread dispatcher used for [Searchable.applyMatchIds];
+ *        defaults to [Dispatchers.JavaFx] and injectable for deterministic testing
+ * @param debounceMillis how long to wait before executing a non-blank query, in milliseconds;
+ *        defaults to 400 ms and injectable so tests can pass 0 for deterministic execution
+ */
+@Service
+class SearchCoordinator(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val fxDispatcher: CoroutineContext = Dispatchers.JavaFx,
+    private val debounceMillis: Long = DEBOUNCE_MILLIS
+) {
+    private val logger = KotlinLogging.logger {}
+
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(job + dispatcher)
+
+    @Volatile private var currentJob: Job? = null
+    private val generation = AtomicLong(0)
+
+    private val searchables = ConcurrentHashMap<NavigationMode, Searchable<*>>()
+
+    companion object {
+        private const val DEBOUNCE_MILLIS = 400L
+    }
+
+    /**
+     * Registers a [Searchable] implementation for the given navigation [mode].
+     *
+     * Typically called from a view controller's `initialize()` method. Replaces any previously
+     * registered [Searchable] for that mode.
+     *
+     * @param mode the navigation mode this [Searchable] handles
+     * @param searchable the view implementing [Searchable] for [mode]
+     */
+    fun register(mode: NavigationMode, searchable: Searchable<*>) {
+        searchables[mode] = searchable
+        logger.debug { "Registered Searchable for mode $mode: ${searchable::class.simpleName}" }
+    }
+
+    /**
+     * Entry point called by [net.transgressoft.musicott.view.MainController] on each search field change.
+     *
+     * This is a plain (non-suspending) method so it is directly callable from Java without any
+     * coroutine machinery on the call site. The async lifecycle is entirely internal.
+     *
+     * @param query the current search field text; blank triggers an immediate reset across all views
+     */
+    fun onQuery(query: String) {
+        currentJob?.cancel()
+        val gen = generation.incrementAndGet()
+        val trimmed = query.trim()
+
+        currentJob = scope.launch {
+            if (trimmed.isBlank()) {
+                withContext(fxDispatcher) {
+                    if (generation.get() == gen) {
+                        // Distinct instances only: a single Searchable registered under several modes
+                        // (e.g. the audio table under ALL_AUDIO_ITEMS and PLAYLIST) is reset once.
+                        searchables.values.distinct().forEach { searchable ->
+                            @Suppress("UNCHECKED_CAST")
+                            (searchable as? Searchable<Any>)?.applyMatchIds("", emptySet())
+                        }
+                        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
+                    }
+                }
+                return@launch
+            }
+
+            delay(debounceMillis)
+
+            applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Searching...", this@SearchCoordinator))
+
+            val lowerQuery = trimmed.lowercase()
+
+            // Filter EVERY registered view, not just the visible one, so all navigation modes stay
+            // in sync — switching modes shows an already-filtered view. A stable copy guards against
+            // concurrent registrations during the scan; distinct() ensures a single Searchable
+            // registered under several modes (e.g. the audio table under ALL_AUDIO_ITEMS and
+            // PLAYLIST) is scanned once rather than once per mode.
+            @Suppress("UNCHECKED_CAST")
+            val targets = searchables.values.distinct().map { it as Searchable<Any> }.toList()
+
+            // Snapshot each view's backing collection on the FX thread so the subsequent off-thread
+            // scan reads a stable list rather than a live ObservableList that concurrent
+            // import/edit operations may structurally modify.
+            withContext(fxDispatcher) {
+                targets.forEach { it.prepareSnapshot() }
+            }
+
+            val results = try {
+                withContext(dispatcher) {
+                    targets.map { searchable -> searchable to searchable.computeMatchIds(lowerQuery) }
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error(e) { "Search failed for query='$lowerQuery'" }
+                // Clear the "Searching…" status the failed run published, so it does not linger
+                // until the next query. Guarded by generation so a newer query's status wins.
+                withContext(fxDispatcher) {
+                    if (generation.get() == gen) {
+                        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
+                    }
+                }
+                return@launch
+            }
+
+            withContext(fxDispatcher) {
+                if (generation.get() == gen) {
+                    results.forEach { (searchable, ids) ->
+                        try {
+                            searchable.applyMatchIds(lowerQuery, ids)
+                        } catch (e: Exception) {
+                            logger.error(e) { "Apply search results failed for query='$lowerQuery'" }
+                        }
+                    }
+                    applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns `true` when no search job is currently in-flight.
+     *
+     * Intended for use in tests that need to await quiescence before proceeding.
+     * Because [onQuery] assigns [currentJob] synchronously on the call site, this
+     * method is safe to call from any thread — [currentJob] is marked `@Volatile`.
+     */
+    fun isIdle(): Boolean = currentJob?.isActive != true
+
+    /**
+     * Cancels the internal [CoroutineScope], stopping any in-flight or pending search jobs.
+     *
+     * Invoked automatically by Spring on context shutdown.
+     */
+    @PreDestroy
+    fun close() {
+        job.cancel()
+        logger.debug { "SearchCoordinator scope cancelled" }
+    }
+}

--- a/src/main/kotlin/net/transgressoft/musicott/search/Searchable.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/search/Searchable.kt
@@ -1,0 +1,67 @@
+package net.transgressoft.musicott.search
+
+/**
+ * Contract for a view component that participates in asynchronous search filtering.
+ *
+ * Implementations split filtering into three phases:
+ * - [prepareSnapshot] runs on the JavaFX Application Thread immediately before [computeMatchIds]
+ *   is dispatched to the background. Implementations copy any live JavaFX [javafx.collections.ObservableList]
+ *   they need to scan into a plain immutable list, preventing data races with concurrent FX-thread
+ *   mutations (imports, edits, deletes). The default implementation is a no-op for views whose
+ *   backing data is already thread-safe.
+ * - [computeMatchIds] runs off the JavaFX Application Thread on a background dispatcher
+ *   (typically [kotlinx.coroutines.Dispatchers.Default]), performing the expensive O(n)
+ *   scan over the snapshot produced by [prepareSnapshot] and returning a lightweight set of
+ *   matching identifiers. Implementations must not read or write any JavaFX observable property
+ *   or [javafx.collections.FilteredList] predicate from within this method.
+ * - [applyMatchIds] runs on the JavaFX Application Thread (via [kotlinx.coroutines.Dispatchers.JavaFx]),
+ *   applying the pre-computed ID set as a cheap predicate to the view's [javafx.collections.FilteredList]
+ *   and performing any additional FX-observable mutations. This method must do no substring
+ *   scanning — all heavy matching must have been done in [computeMatchIds].
+ *
+ * Both [computeMatchIds] and [applyMatchIds] receive the raw `query` string.
+ *
+ * @param ID the type of identifier used to uniquely address items in this view's collection
+ *           (e.g. [Int] for audio items, [String] for album or genre names)
+ */
+interface Searchable<ID : Any> {
+
+    /**
+     * Captures an immutable snapshot of the backing collection on the JavaFX Application Thread.
+     *
+     * Called on the JavaFX Application Thread immediately before [computeMatchIds] is dispatched
+     * to the background. The snapshot isolates the off-thread scan from concurrent FX-thread
+     * structural mutations (add/remove) of live [javafx.collections.ObservableList] instances.
+     *
+     * The default implementation is a no-op; views whose backing data is not a live observable list
+     * (or is replaced atomically via `setAll`) do not need to override this method.
+     */
+    fun prepareSnapshot() {}
+
+    /**
+     * Computes the set of item identifiers that match [query].
+     *
+     * Called off the JavaFX Application Thread. Implementations must read only from the immutable
+     * snapshot captured by [prepareSnapshot] — never from live JavaFX observable properties or
+     * [javafx.collections.FilteredList] instances.
+     *
+     * @param query the search text, already trimmed and lower-cased by the coordinator
+     * @return the set of identifiers whose corresponding items match the query
+     */
+    fun computeMatchIds(query: String): Set<ID>
+
+    /**
+     * Applies [ids] to the view's filtered collection and performs any related FX-observable updates.
+     *
+     * Always called on the JavaFX Application Thread. This method must perform only cheap membership
+     * checks against [ids] — no substring scanning. When [query] is blank (empty string), implementations
+     * must reset their [javafx.collections.FilteredList] to show all items (the reset path). For a
+     * non-blank [query], the predicate must admit only items whose ID is present in [ids]; an empty
+     * [ids] with a non-blank [query] means the search matched nothing and zero items should be visible.
+     * Any precomputed row-level or track-level results stored during [computeMatchIds] may be applied here.
+     *
+     * @param query the search text that produced [ids]; a blank string signals a reset (show all)
+     * @param ids the set of identifiers computed by [computeMatchIds]; empty means no matches when query is non-blank
+     */
+    fun applyMatchIds(query: String, ids: @JvmSuppressWildcards Set<ID>)
+}

--- a/src/test/java/net/transgressoft/musicott/view/AlbumViewControllerTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/AlbumViewControllerTest.java
@@ -38,7 +38,7 @@ class AlbumViewControllerTest {
         when(album.getTracks()).thenReturn(List.of(track1, track2));
         when(album.getAlbumName()).thenReturn("Black Sands");
 
-        var controller = new AlbumViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class));
+        var controller = new AlbumViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class), mock(net.transgressoft.musicott.search.SearchCoordinator.class));
         List<Map.Entry<AlbumTrackGroup, Integer>> sections = controller.buildAlbumSections(album);
 
         assertThat(sections).hasSize(1);
@@ -58,7 +58,7 @@ class AlbumViewControllerTest {
         when(album.getTracks()).thenReturn(List.of(disc1Track, disc2Track));
         when(album.getAlbumName()).thenReturn("Black Sands");
 
-        var controller = new AlbumViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class));
+        var controller = new AlbumViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class), mock(net.transgressoft.musicott.search.SearchCoordinator.class));
         List<Map.Entry<AlbumTrackGroup, Integer>> sections = controller.buildAlbumSections(album);
 
         assertThat(sections).hasSize(2);
@@ -80,7 +80,7 @@ class AlbumViewControllerTest {
         when(album.getTracks()).thenReturn(List.of(zeroDiscTrack, nullDiscTrack));
         when(album.getAlbumName()).thenReturn("Black Sands");
 
-        var controller = new AlbumViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class));
+        var controller = new AlbumViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class), mock(net.transgressoft.musicott.search.SearchCoordinator.class));
         List<Map.Entry<AlbumTrackGroup, Integer>> sections = controller.buildAlbumSections(album);
 
         // Both tracks normalize to disc 1 → single-disc album → one section with disc key 0

--- a/src/test/java/net/transgressoft/musicott/view/ArtistViewControllerTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/ArtistViewControllerTest.java
@@ -52,7 +52,7 @@ class ArtistViewControllerTest {
         when(audioLibrary.getAudioItemsProperty()).thenReturn(audioItems);
         when(audioLibrary.getArtistCatalog(akkya)).thenReturn(Optional.empty());
 
-        var controller = new ArtistViewController(audioLibrary, mock(ApplicationContext.class));
+        var controller = new ArtistViewController(audioLibrary, mock(ApplicationContext.class), mock(net.transgressoft.musicott.search.SearchCoordinator.class));
 
         assertThat(controller.albumSetsForArtist(akkya).keySet())
                 .singleElement()

--- a/src/test/java/net/transgressoft/musicott/view/GenreViewControllerTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/GenreViewControllerTest.java
@@ -2,6 +2,7 @@ package net.transgressoft.musicott.view;
 
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.test.FxAudioItems;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
@@ -36,7 +37,7 @@ class GenreViewControllerTest {
 
     @BeforeEach
     void setUp() {
-        controller = new GenreViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class));
+        controller = new GenreViewController(mock(ObservableAudioLibrary.class), mock(ApplicationContext.class), mock(SearchCoordinator.class));
     }
 
     @Test

--- a/src/test/kotlin/net/transgressoft/musicott/search/SearchCoordinatorTest.kt
+++ b/src/test/kotlin/net/transgressoft/musicott/search/SearchCoordinatorTest.kt
@@ -1,0 +1,237 @@
+package net.transgressoft.musicott.search
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.transgressoft.musicott.view.NavigationController.NavigationMode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.springframework.context.ApplicationEventPublisher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("SearchCoordinator")
+class SearchCoordinatorTest {
+
+    val dispatcher = StandardTestDispatcher()
+
+    val applicationEventPublisher: ApplicationEventPublisher = mock(ApplicationEventPublisher::class.java)
+
+    lateinit var coordinator: SearchCoordinator
+
+    // A fake Searchable that records how many times computeMatchIds was called
+    inner class FakeSearchable(private val matchIds: Set<Int> = setOf(1, 2, 3)) : Searchable<Int> {
+        var computeCallCount = 0
+        var lastAppliedQuery: String? = null
+        var lastAppliedIds: Set<Int>? = null
+
+        override fun computeMatchIds(query: String): Set<Int> {
+            computeCallCount++
+            return matchIds
+        }
+
+        override fun applyMatchIds(query: String, ids: Set<Int>) {
+            lastAppliedQuery = query
+            lastAppliedIds = ids
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        // Use the same StandardTestDispatcher for both compute and FX dispatching so
+        // all coroutine work is virtual-time-controlled without needing a real JavaFX toolkit.
+        coordinator = SearchCoordinator(
+            applicationEventPublisher = applicationEventPublisher,
+            dispatcher = dispatcher,
+            fxDispatcher = dispatcher
+        )
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator does not compute for keystrokes arriving within the 400ms debounce gap")
+    fun debouncePreventsDuplicateCompute() = runTest(dispatcher) {
+        val fake = FakeSearchable()
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, fake)
+
+        // First query starts a 400ms debounce
+        coordinator.onQuery("app")
+        // Second query within the gap cancels the first and restarts the debounce
+        coordinator.onQuery("appl")
+
+        // Advance past the debounce only once (501ms total from the second onQuery)
+        advanceTimeBy(501)
+        advanceUntilIdle()
+
+        // Only one compute invocation despite two queries
+        assert(fake.computeCallCount == 1) {
+            "Expected exactly 1 compute call after debounce, but got ${fake.computeCallCount}"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator cancels the prior in-flight job when a new query arrives")
+    fun newQueryCancelsPriorJob() = runTest(dispatcher) {
+        val fake = FakeSearchable()
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, fake)
+
+        // Issue a query and advance only partway through the debounce
+        coordinator.onQuery("mus")
+        advanceTimeBy(200)
+
+        // New query arrives before the first debounce fires
+        coordinator.onQuery("musi")
+        advanceTimeBy(200)
+
+        // First debounce would have fired at t=400 (from the first query),
+        // but it was cancelled. The second debounce fires at t=400 from
+        // the second query, i.e. at t=200+400=600 from test start.
+        advanceUntilIdle()
+
+        // Only the second query's compute should run
+        assert(fake.computeCallCount == 1) {
+            "Expected 1 compute call (second query only), but got ${fake.computeCallCount}"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator applies only the newest query's result across a rapid succession of queries")
+    fun newestQueryResultWins() = runTest(dispatcher) {
+        val computedQueries = mutableListOf<String>()
+        val appliedQueries = mutableListOf<String>()
+        val searchable = object : Searchable<Int> {
+            override fun computeMatchIds(query: String): Set<Int> {
+                computedQueries += query
+                return setOf(query.length)
+            }
+
+            override fun applyMatchIds(query: String, ids: Set<Int>) {
+                appliedQueries += query
+            }
+        }
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, searchable)
+
+        // First query debounces at t=400; a second query arrives before it fires, superseding it.
+        coordinator.onQuery("mus")
+        advanceTimeBy(200)
+        coordinator.onQuery("music")
+        advanceUntilIdle()
+
+        // Only the newest query is computed and applied; the superseded one never reaches compute
+        // (cancellation) and, even if it had, the generation guard would block its apply.
+        assert(computedQueries == listOf("music")) {
+            "Expected only the newest query to be computed, but got $computedQueries"
+        }
+        assert(appliedQueries == listOf("music")) {
+            "Expected only the newest query to be applied, but got $appliedQueries"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator resets immediately without debounce when the query is blank")
+    fun clearedQueryResetsImmediately() = runTest(dispatcher) {
+        val fake = FakeSearchable()
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, fake)
+
+        // Empty query — reset path, no debounce delay
+        coordinator.onQuery("")
+        // Advance only a tiny amount — much less than the 400ms debounce
+        advanceTimeBy(10)
+        advanceUntilIdle()
+
+        // Reset applies an empty set without waiting for the debounce
+        assert(fake.lastAppliedIds == emptySet<Int>()) {
+            "Expected empty ID set on reset, got ${fake.lastAppliedIds}"
+        }
+        assert(fake.lastAppliedQuery == "") {
+            "Expected empty query on reset, got '${fake.lastAppliedQuery}'"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator triggers a debounced search for a single-character query")
+    fun singleCharQueryTriggersSearch() = runTest(dispatcher) {
+        val fake = FakeSearchable()
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, fake)
+
+        // One-character query — must trigger a debounced search, not a reset
+        coordinator.onQuery("m")
+        advanceTimeBy(401)
+        advanceUntilIdle()
+
+        assert(fake.computeCallCount == 1) {
+            "Expected 1 compute call for single-character query, got ${fake.computeCallCount}"
+        }
+        assert(fake.lastAppliedQuery == "m") {
+            "Expected query 'm' applied, got '${fake.lastAppliedQuery}'"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator triggers a debounced search for a two-character query")
+    fun twoCharQueryTriggersSearch() = runTest(dispatcher) {
+        val fake = FakeSearchable()
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, fake)
+
+        // Two-character query — must trigger a debounced search, not a reset
+        coordinator.onQuery("mu")
+        advanceTimeBy(401)
+        advanceUntilIdle()
+
+        assert(fake.computeCallCount == 1) {
+            "Expected 1 compute call for two-character query, got ${fake.computeCallCount}"
+        }
+        assert(fake.lastAppliedQuery == "mu") {
+            "Expected query 'mu' applied, got '${fake.lastAppliedQuery}'"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator drives every registered Searchable so all navigation modes stay filtered")
+    fun allRegisteredSearchablesAreDriven() = runTest(dispatcher) {
+        val audioSearchable = FakeSearchable()
+        val artistSearchable = FakeSearchable()
+
+        // Register searchables for two different navigation modes
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, audioSearchable)
+        coordinator.register(NavigationMode.ARTISTS, artistSearchable)
+
+        coordinator.onQuery("mus")
+        advanceTimeBy(500)
+        advanceUntilIdle()
+
+        // Both views are filtered on the same query — not just the active one — so switching
+        // navigation modes shows an already-filtered view.
+        assert(audioSearchable.computeCallCount == 1) {
+            "Expected ALL_AUDIO_ITEMS Searchable to be computed once, got ${audioSearchable.computeCallCount}"
+        }
+        assert(artistSearchable.computeCallCount == 1) {
+            "Expected ARTISTS Searchable to be computed once, got ${artistSearchable.computeCallCount}"
+        }
+        assert(audioSearchable.lastAppliedQuery == "mus" && artistSearchable.lastAppliedQuery == "mus") {
+            "Expected both Searchables to have the query applied"
+        }
+    }
+
+    @Test
+    @DisplayName("SearchCoordinator cancels its scope on close")
+    fun closeStopsAllFutureCompute() = runTest(dispatcher) {
+        val fake = FakeSearchable()
+        coordinator.register(NavigationMode.ALL_AUDIO_ITEMS, fake)
+
+        // Cancel the coordinator's scope before the debounce fires
+        coordinator.onQuery("mus")
+        coordinator.close()
+
+        advanceUntilIdle()
+
+        // Compute should not have run because scope was cancelled
+        assert(fake.computeCallCount == 0) {
+            "Expected 0 compute calls after close(), got ${fake.computeCallCount}"
+        }
+    }
+}

--- a/src/uiTest/java/net/transgressoft/musicott/view/AlbumViewControllerUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/AlbumViewControllerUIT.java
@@ -20,6 +20,7 @@ import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Label;
 import net.transgressoft.musicott.events.PlayItemEvent;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -476,6 +477,11 @@ class AlbumViewControllerUITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public SearchCoordinator searchCoordinator() {
+        return mock(SearchCoordinator.class);
     }
 
     // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,

--- a/src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/ArtistViewControllerUIT.java
@@ -18,6 +18,7 @@ import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Label;
 import net.transgressoft.lirp.event.LirpEventPublisher;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -220,6 +221,11 @@ class ArtistViewControllerUITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public SearchCoordinator searchCoordinator() {
+        return mock(SearchCoordinator.class);
     }
 
     @Bean(destroyMethod = "")

--- a/src/uiTest/java/net/transgressoft/musicott/view/GenreViewControllerUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/GenreViewControllerUIT.java
@@ -19,7 +19,9 @@ import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Genre;
 import net.transgressoft.commons.music.audio.Label;
 import net.transgressoft.musicott.events.PlayItemEvent;
-import net.transgressoft.musicott.events.SearchTextTypedEvent;
+import java.util.Collections;
+
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -90,7 +92,7 @@ class GenreViewControllerUIT extends ApplicationTestBase<StackPane> {
             controller.closeDrawer();
             // The controller singleton is reused across tests; clear any search query a prior test
             // set so it does not filter this test's freshly opened drawer.
-            controller.searchTextTypedEvent(new SearchTextTypedEvent("", this));
+            controller.applyMatchIds("", Collections.emptySet());
             if (root.getChildren().size() > 1) {
                 root.getChildren().subList(1, root.getChildren().size()).clear();
             }
@@ -148,15 +150,20 @@ class GenreViewControllerUIT extends ApplicationTestBase<StackPane> {
                 () -> fxRobot.from(root).lookup("Kiara").tryQuery().isPresent());
         waitForFxEvents();
 
+        // getSelectedTracks() iterates the live JavaFX selection model, which is only safe on the FX
+        // thread — read it via asyncFx so the poll never races the FX-thread selection mutation.
         Platform.runLater(controller::selectAllTracks);
-        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> controller.getSelectedTracks().size() == 2);
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS,
+                () -> WaitForAsyncUtils.asyncFx(() -> controller.getSelectedTracks().size()).get() == 2);
         waitForFxEvents();
-        assertThat(controller.getSelectedTracks()).containsExactlyInAnyOrder(track1, track2);
+        assertThat(WaitForAsyncUtils.asyncFx(() -> List.copyOf(controller.getSelectedTracks())).get())
+                .containsExactlyInAnyOrder(track1, track2);
 
         Platform.runLater(controller::deselectAllTracks);
-        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> controller.getSelectedTracks().isEmpty());
+        WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS,
+                () -> WaitForAsyncUtils.asyncFx(() -> controller.getSelectedTracks().isEmpty()).get());
         waitForFxEvents();
-        assertThat(controller.getSelectedTracks()).isEmpty();
+        assertThat(WaitForAsyncUtils.asyncFx(() -> List.copyOf(controller.getSelectedTracks())).get()).isEmpty();
     }
 
     @Test
@@ -172,8 +179,8 @@ class GenreViewControllerUIT extends ApplicationTestBase<StackPane> {
         StackPane root = genreViewAndController.getView().get();
         GenreViewController controller = genreViewAndController.getController();
 
-        // Type a query matching only "Strobe" before opening — the drawer applies it on open.
-        Platform.runLater(() -> controller.searchTextTypedEvent(new SearchTextTypedEvent("strobe", this)));
+        // Apply a query matching only "Strobe" before opening — the drawer applies it on open.
+        Platform.runLater(() -> controller.applyMatchIds("strobe", Set.of("TECHNO")));
         waitForFxEvents();
         Platform.runLater(() -> controller.openDrawer(genre));
         WaitForAsyncUtils.waitFor(5, TimeUnit.SECONDS, () -> root.getChildren().size() > 1);
@@ -484,6 +491,11 @@ class GenreViewControllerUITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public SearchCoordinator searchCoordinator() {
+        return mock(SearchCoordinator.class);
     }
 
     // destroyMethod = "" prevents Spring from auto-inferring the shutdown() method as the destroy callback,

--- a/src/uiTest/java/net/transgressoft/musicott/view/PlaylistFolderSelectionUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/PlaylistFolderSelectionUIT.java
@@ -8,6 +8,7 @@ import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
 import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.commons.music.waveform.AudioWaveform;
 import net.transgressoft.commons.music.waveform.AudioWaveformRepository;
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.service.MediaImportService;
 import net.transgressoft.musicott.services.PlayerService;
 import net.transgressoft.musicott.test.ApplicationTestBase;
@@ -257,6 +258,11 @@ class PlaylistFolderSelectionUITConfiguration {
     @Bean
     public KeyCombination.Modifier operativeSystemKeyModifier() {
         return KeyCombination.CONTROL_DOWN;
+    }
+
+    @Bean
+    public SearchCoordinator searchCoordinator() {
+        return mock(SearchCoordinator.class);
     }
 
     @Bean(destroyMethod = "")

--- a/src/uiTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewLayoutUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/custom/table/FullAudioItemTableViewLayoutUIT.java
@@ -1,5 +1,6 @@
 package net.transgressoft.musicott.view.custom.table;
 
+import net.transgressoft.musicott.search.SearchCoordinator;
 import net.transgressoft.musicott.test.ApplicationTestBase;
 import net.transgressoft.musicott.test.JavaFxSpringTest;
 import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
@@ -133,6 +134,11 @@ class FullAudioItemTableViewLayoutUITConfiguration {
     @Bean
     public ApplicationEventPublisher applicationEventPublisher() {
         return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public SearchCoordinator searchCoordinator() {
+        return mock(SearchCoordinator.class);
     }
 
     // destroyMethod = "" prevents Spring from auto-inferring shutdown() as the destroy callback,


### PR DESCRIPTION
## Problem

Typing in the search field filtered the library synchronously on the JavaFX Application Thread. On large libraries this froze the UI while every keystroke recomputed matches, making search feel unresponsive.

Closes #70.

## Solution

A central `SearchCoordinator` (Kotlin `@Service`) owns the async search lifecycle:

- **Debounces** keystrokes (400 ms) so a burst of typing triggers a single search.
- **Cancels superseded jobs** and guards against stale results with a generation counter.
- **Cancels its scope on shutdown.**

Views implement a small `Searchable<ID>` contract:

- `computeMatchIds` runs off-thread (`Dispatchers.Default`) over an FX-thread snapshot and returns the set of matching ids.
- `applyMatchIds` applies a cheap id-set predicate back on the FX thread (`Dispatchers.JavaFx`).

The four filtering views — audio table, artists, albums, genres — register themselves by navigation mode.

## Behavior

- Any non-blank query triggers a search (no minimum length); a blank query resets immediately without debouncing.
- Every registered view is filtered on each query, so switching navigation modes shows an already-filtered view, and editing or clearing the query updates all views.
- A query matching nothing shows nothing (empty result is distinct from a reset); a transient "Searching…" status shows while a search runs.

## Testing

- Deterministic unit tests (`kotlinx-coroutines-test`) covering debounce, cancellation, staleness, empty-result, and immediate-trigger paths.
- Integration tests (TestFX) covering the same behaviors plus cross-view filtering.