### PR TITLE
Propagate metadata edits to the library table and navigation views

### DIFF
--- a/src/e2eTest/java/net/transgressoft/musicott/AlbumEditPropagationE2E.java
+++ b/src/e2eTest/java/net/transgressoft/musicott/AlbumEditPropagationE2E.java
@@ -1,0 +1,225 @@
+package net.transgressoft.musicott;
+
+import kotlin.Unit;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.audio.AlbumDetails;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.audio.Label;
+import net.transgressoft.musicott.events.EditAudioItemsMetadataEvent;
+import net.transgressoft.musicott.view.EditController.AudioItemMetadataChange;
+import net.transgressoft.musicott.view.MainController;
+import net.transgressoft.musicott.view.NavigationController;
+import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.ListView;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxWeaver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.transgressoft.commons.music.audio.GenreExtensionsKt.parseGenre;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testfx.util.WaitForAsyncUtils.waitFor;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * End-to-end regression proving that editing a track's album name propagates through the reactive
+ * model to the Albums navigation view: the track leaves its previous album grouping and appears
+ * under the new album.
+ *
+ * <p>The edit is driven by publishing the {@link EditAudioItemsMetadataEvent} the editor's OK button
+ * emits — the metadata editor is a modal {@code showAndWait} dialog whose UI mapping is covered by
+ * {@code EditControllerIT}; this test exercises the downstream propagation the bug broke.
+ */
+@SpringBootTest(classes = {MusicottApplication.class, AlbumEditPropagationE2E.E2eTestConfiguration.class})
+@ActiveProfiles("e2e")
+@ExtendWith(ApplicationExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class AlbumEditPropagationE2E {
+
+    static Stage testStage;
+
+    @Autowired
+    FxWeaver fxWeaver;
+
+    @Autowired
+    ObservableAudioLibrary audioLibrary;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        testStage = FxToolkit.registerPrimaryStage();
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            Scene scene = new Scene(fxWeaver.loadView(MainController.class), 1200, 800);
+            testStage.setScene(scene);
+            testStage.show();
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            if (testStage.isShowing()) {
+                testStage.hide();
+            }
+            testStage.setScene(null);
+        });
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    @DisplayName("editing a track album name moves it out of the previous album grouping and into the new one")
+    void editingTrackAlbumMovesItBetweenAlbumGroupings(FxRobot fxRobot) throws Exception {
+        ObservableAudioItem movingTrack = seedTrack("Opener", "The Movers", "Original Album");
+        ObservableAudioItem stableTrack = seedTrack("Closer", "The Keepers", "Untouched Album");
+
+        waitFor(15, TimeUnit.SECONDS, () -> audioLibrary.getAlbum("Original Album").isPresent()
+                && audioLibrary.getAlbum("Untouched Album").isPresent());
+
+        selectNavigationMode(fxRobot, NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+        FullAudioItemTableView table = visibleTrackTable(fxRobot);
+        waitFor(10, TimeUnit.SECONDS, () -> table.getItems().contains(movingTrack) && table.getItems().contains(stableTrack));
+
+        publishAlbumNameEdit(movingTrack, "Relocated Album");
+
+        waitFor(15, TimeUnit.SECONDS, () -> "Relocated Album".equals(movingTrack.getAlbum().getName()));
+        waitFor(15, TimeUnit.SECONDS, () -> !albumGroupingContains("Original Album", movingTrack));
+        waitFor(15, TimeUnit.SECONDS, () -> albumGroupingContains("Relocated Album", movingTrack));
+
+        // The untouched track stays put.
+        assertThat(albumGroupingContains("Untouched Album", stableTrack)).isTrue();
+
+        // The Albums navigation projection the grid binds to reflects the move.
+        selectNavigationMode(fxRobot, NavigationController.NavigationMode.ALBUMS);
+        assertThat(audioLibrary.getAlbumsProperty())
+                .noneMatch(album -> "Original Album".equals(album.getAlbumProperty().get().getName())
+                        && !album.getTracksProperty().isEmpty());
+        assertThat(audioLibrary.getAlbum("Relocated Album")).isPresent()
+                .hasValueSatisfying(album -> assertThat(album.getTracksProperty()).contains(movingTrack));
+    }
+
+    private void publishAlbumNameEdit(ObservableAudioItem track, String newAlbumName) {
+        AudioItemMetadataChange change = new AudioItemMetadataChange(
+                null, null, newAlbumName, null, null, null, null, null, null, null, null, null, null);
+        Platform.runLater(() ->
+                applicationEventPublisher.publishEvent(new EditAudioItemsMetadataEvent(Set.of(track), change, this)));
+        waitForFxEvents();
+    }
+
+    private boolean albumGroupingContains(String albumName, ObservableAudioItem track) {
+        return audioLibrary.getAlbum(albumName)
+                .map(album -> album.getTracksProperty().contains(track))
+                .orElse(false);
+    }
+
+    private ObservableAudioItem seedTrack(String title, String artist, String albumName) throws Exception {
+        Path fixture = copyFixture(title);
+        AtomicReference<ObservableAudioItem> created = new AtomicReference<>();
+        FxToolkit.setupFixture(() -> created.set(audioLibrary.createFromFile(fixture)));
+        ObservableAudioItem item = created.get();
+        FxToolkit.setupFixture(() -> item.mutate(it -> {
+            it.setTitle(title);
+            it.setArtist(Artist.of(artist));
+            it.setGenres(parseGenre("Electronic"));
+            it.setAlbum(new AlbumDetails(albumName, Artist.of(artist), false, (Short) null, Label.UNKNOWN));
+            return Unit.INSTANCE;
+        }));
+        return item;
+    }
+
+    private Path copyFixture(String label) throws IOException {
+        Path target = Files.createTempFile(tempDir, "album-e2e-" + label.replaceAll("\\W", "-") + "-", ".mp3");
+        try (InputStream in = Objects.requireNonNull(
+                getClass().getResourceAsStream("/testfiles/testeable.mp3"), "Missing test resource: /testfiles/testeable.mp3")) {
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return target;
+    }
+
+    private static void selectNavigationMode(FxRobot fxRobot, NavigationController.NavigationMode mode) {
+        ListView<NavigationController.NavigationMode> navigation =
+                fxRobot.lookup("#navigationModeListView").queryListView();
+        Platform.runLater(() -> navigation.getSelectionModel().select(mode));
+        waitForFxEvents();
+    }
+
+    private static FullAudioItemTableView visibleTrackTable(FxRobot fxRobot) {
+        return fxRobot.lookup(node -> node instanceof FullAudioItemTableView && node.isVisible())
+                .queryAs(FullAudioItemTableView.class);
+    }
+
+    @TestConfiguration
+    static class E2eTestConfiguration {
+
+        @Bean
+        @Primary
+        public MusicottApplication.ApplicationPaths applicationPaths() throws IOException {
+            Path tempDir = Files.createTempDirectory("musicott-album-edit-e2e");
+            // File.deleteOnExit no-ops on a non-empty directory, and the framework writes the db/json
+            // files into this dir, so it would leak on every run; recursively delete the tree instead.
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> deleteRecursively(tempDir)));
+            return new MusicottApplication.ApplicationPaths(
+                    tempDir.resolve("audioItems.db"),
+                    tempDir.resolve("playlists.json"),
+                    tempDir.resolve("waveforms.json"));
+        }
+
+        private static void deleteRecursively(Path root) {
+            try (var paths = Files.walk(root)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ignored) {
+                        // Best-effort cleanup on JVM shutdown; a leftover file is not worth failing on.
+                    }
+                });
+            } catch (IOException ignored) {
+                // The directory may already be gone; nothing to clean up.
+            }
+        }
+    }
+}

--- a/src/e2eTest/java/net/transgressoft/musicott/ArtistEditPropagationE2E.java
+++ b/src/e2eTest/java/net/transgressoft/musicott/ArtistEditPropagationE2E.java
@@ -1,0 +1,231 @@
+package net.transgressoft.musicott;
+
+import kotlin.Unit;
+import net.transgressoft.commons.fx.music.audio.ObservableArtistCatalog;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.audio.AlbumDetails;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.audio.Label;
+import net.transgressoft.musicott.events.EditAudioItemsMetadataEvent;
+import net.transgressoft.musicott.view.EditController.AudioItemMetadataChange;
+import net.transgressoft.musicott.view.MainController;
+import net.transgressoft.musicott.view.NavigationController;
+import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.ListView;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxWeaver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.transgressoft.commons.music.audio.GenreExtensionsKt.parseGenre;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testfx.util.WaitForAsyncUtils.waitFor;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * End-to-end regression proving that editing a track's artist propagates through the reactive model
+ * to the Artists navigation view: the track leaves its previous artist catalog row and appears under
+ * the new artist.
+ *
+ * <p>The edit is driven by publishing the {@link EditAudioItemsMetadataEvent} the editor's OK button
+ * emits — the metadata editor is a modal {@code showAndWait} dialog whose UI mapping is covered by
+ * {@code EditControllerIT}; this test exercises the downstream propagation the bug broke.
+ */
+@SpringBootTest(classes = {MusicottApplication.class, ArtistEditPropagationE2E.E2eTestConfiguration.class})
+@ActiveProfiles("e2e")
+@ExtendWith(ApplicationExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ArtistEditPropagationE2E {
+
+    static Stage testStage;
+
+    @Autowired
+    FxWeaver fxWeaver;
+
+    @Autowired
+    ObservableAudioLibrary audioLibrary;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        testStage = FxToolkit.registerPrimaryStage();
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            Scene scene = new Scene(fxWeaver.loadView(MainController.class), 1200, 800);
+            testStage.setScene(scene);
+            testStage.show();
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            if (testStage.isShowing()) {
+                testStage.hide();
+            }
+            testStage.setScene(null);
+        });
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    @DisplayName("editing a track artist moves it out of the previous artist catalog and into the new one")
+    void editingTrackArtistMovesItBetweenArtistCatalogs(FxRobot fxRobot) throws Exception {
+        ObservableAudioItem movingTrack = seedTrack("Solo", "Alpha Artist", "Alpha Album");
+        ObservableAudioItem stableTrack = seedTrack("Duet", "Beta Artist", "Beta Album");
+
+        waitFor(15, TimeUnit.SECONDS, () -> audioLibrary.getArtistCatalog("Alpha Artist").isPresent()
+                && audioLibrary.getArtistCatalog("Beta Artist").isPresent());
+
+        selectNavigationMode(fxRobot, NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+        FullAudioItemTableView table = visibleTrackTable(fxRobot);
+        waitFor(10, TimeUnit.SECONDS, () -> table.getItems().contains(movingTrack) && table.getItems().contains(stableTrack));
+
+        publishArtistEdit(movingTrack, "Gamma Artist");
+
+        waitFor(15, TimeUnit.SECONDS, () -> "Gamma Artist".equals(movingTrack.getArtist().getName()));
+        waitFor(15, TimeUnit.SECONDS, () -> !artistCatalogContains("Alpha Artist", movingTrack));
+        waitFor(15, TimeUnit.SECONDS, () -> artistCatalogContains("Gamma Artist", movingTrack));
+
+        // The untouched track stays put.
+        assertThat(artistCatalogContains("Beta Artist", stableTrack)).isTrue();
+
+        // The Artists navigation view (list of artist catalogs) reflects the move.
+        selectNavigationMode(fxRobot, NavigationController.NavigationMode.ARTISTS);
+        ListView<?> artistsList = fxRobot.lookup("#artistsListView").queryListView();
+        waitFor(10, TimeUnit.SECONDS, () -> artistsList.getItems().stream()
+                .anyMatch(item -> item instanceof ObservableArtistCatalog catalog
+                        && "Gamma Artist".equals(catalog.getArtistProperty().get().getName())));
+        assertThat(audioLibrary.getArtistCatalogsProperty())
+                .anyMatch(catalog -> "Gamma Artist".equals(catalog.getArtistProperty().get().getName()))
+                .noneMatch(catalog -> "Alpha Artist".equals(catalog.getArtistProperty().get().getName()));
+    }
+
+    private void publishArtistEdit(ObservableAudioItem track, String newArtist) {
+        // Artist catalogs aggregate the track's involved artists, which include the album artist, so a
+        // faithful "move this track to a new artist" edit changes both the primary artist and the
+        // album artist — mirroring how the editor's Artist and Album Artist fields drive membership.
+        AudioItemMetadataChange change = new AudioItemMetadataChange(
+                null, Artist.of(newArtist), null, Artist.of(newArtist), null, null, null, null, null, null, null, null, null);
+        Platform.runLater(() ->
+                applicationEventPublisher.publishEvent(new EditAudioItemsMetadataEvent(Set.of(track), change, this)));
+        waitForFxEvents();
+    }
+
+    private boolean artistCatalogContains(String artistName, ObservableAudioItem track) {
+        return audioLibrary.getArtistCatalog(artistName)
+                .map(catalog -> catalog.albumAudioItemsProperty(track.getAlbum().getName()).contains(track))
+                .orElse(false);
+    }
+
+    private ObservableAudioItem seedTrack(String title, String artist, String albumName) throws Exception {
+        Path fixture = copyFixture(title);
+        AtomicReference<ObservableAudioItem> created = new AtomicReference<>();
+        FxToolkit.setupFixture(() -> created.set(audioLibrary.createFromFile(fixture)));
+        ObservableAudioItem item = created.get();
+        FxToolkit.setupFixture(() -> item.mutate(it -> {
+            it.setTitle(title);
+            it.setArtist(Artist.of(artist));
+            it.setGenres(parseGenre("Electronic"));
+            it.setAlbum(new AlbumDetails(albumName, Artist.of(artist), false, (Short) null, Label.UNKNOWN));
+            return Unit.INSTANCE;
+        }));
+        return item;
+    }
+
+    private Path copyFixture(String label) throws IOException {
+        Path target = Files.createTempFile(tempDir, "artist-e2e-" + label.replaceAll("\\W", "-") + "-", ".mp3");
+        try (InputStream in = Objects.requireNonNull(
+                getClass().getResourceAsStream("/testfiles/testeable.mp3"), "Missing test resource: /testfiles/testeable.mp3")) {
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return target;
+    }
+
+    private static void selectNavigationMode(FxRobot fxRobot, NavigationController.NavigationMode mode) {
+        ListView<NavigationController.NavigationMode> navigation =
+                fxRobot.lookup("#navigationModeListView").queryListView();
+        Platform.runLater(() -> navigation.getSelectionModel().select(mode));
+        waitForFxEvents();
+    }
+
+    private static FullAudioItemTableView visibleTrackTable(FxRobot fxRobot) {
+        return fxRobot.lookup(node -> node instanceof FullAudioItemTableView && node.isVisible())
+                .queryAs(FullAudioItemTableView.class);
+    }
+
+    @TestConfiguration
+    static class E2eTestConfiguration {
+
+        @Bean
+        @Primary
+        public MusicottApplication.ApplicationPaths applicationPaths() throws IOException {
+            Path tempDir = Files.createTempDirectory("musicott-artist-edit-e2e");
+            // File.deleteOnExit no-ops on a non-empty directory, and the framework writes the db/json
+            // files into this dir, so it would leak on every run; recursively delete the tree instead.
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> deleteRecursively(tempDir)));
+            return new MusicottApplication.ApplicationPaths(
+                    tempDir.resolve("audioItems.db"),
+                    tempDir.resolve("playlists.json"),
+                    tempDir.resolve("waveforms.json"));
+        }
+
+        private static void deleteRecursively(Path root) {
+            try (var paths = Files.walk(root)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ignored) {
+                        // Best-effort cleanup on JVM shutdown; a leftover file is not worth failing on.
+                    }
+                });
+            } catch (IOException ignored) {
+                // The directory may already be gone; nothing to clean up.
+            }
+        }
+    }
+}

--- a/src/e2eTest/java/net/transgressoft/musicott/GenreEditPropagationE2E.java
+++ b/src/e2eTest/java/net/transgressoft/musicott/GenreEditPropagationE2E.java
@@ -1,0 +1,234 @@
+package net.transgressoft.musicott;
+
+import kotlin.Unit;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.music.audio.AlbumDetails;
+import net.transgressoft.commons.music.audio.Artist;
+import net.transgressoft.commons.music.audio.Genre;
+import net.transgressoft.commons.music.audio.Label;
+import net.transgressoft.musicott.events.EditAudioItemsMetadataEvent;
+import net.transgressoft.musicott.view.EditController.AudioItemMetadataChange;
+import net.transgressoft.musicott.view.MainController;
+import net.transgressoft.musicott.view.NavigationController;
+import net.transgressoft.musicott.view.custom.table.FullAudioItemTableView;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.ListView;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxWeaver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.transgressoft.commons.music.audio.GenreExtensionsKt.parseGenre;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testfx.util.WaitForAsyncUtils.waitFor;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * End-to-end regression proving that editing a track's genre propagates through the reactive model
+ * to the all-tracks table and the Genres navigation view: the track leaves its previous genre bucket
+ * and appears under the new one (or the no-genre bucket when the genre is cleared).
+ *
+ * <p>The edit is driven by publishing the {@link EditAudioItemsMetadataEvent} the editor's OK button
+ * emits — the metadata editor is a modal {@code showAndWait} dialog whose UI mapping is covered by
+ * {@code EditControllerIT}; this test exercises the downstream propagation the bug broke.
+ */
+@SpringBootTest(classes = {MusicottApplication.class, GenreEditPropagationE2E.E2eTestConfiguration.class})
+@ActiveProfiles("e2e")
+@ExtendWith(ApplicationExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class GenreEditPropagationE2E {
+
+    static Stage testStage;
+
+    @Autowired
+    FxWeaver fxWeaver;
+
+    @Autowired
+    ObservableAudioLibrary audioLibrary;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        testStage = FxToolkit.registerPrimaryStage();
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            Scene scene = new Scene(fxWeaver.loadView(MainController.class), 1200, 800);
+            testStage.setScene(scene);
+            testStage.show();
+        });
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        FxToolkit.setupFixture(() -> {
+            if (testStage.isShowing()) {
+                testStage.hide();
+            }
+            testStage.setScene(null);
+        });
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    @DisplayName("editing a track genre moves it out of the previous genre grid cell and into the new one")
+    void editingTrackGenreMovesItBetweenGenreBuckets(FxRobot fxRobot) throws Exception {
+        ObservableAudioItem rockTrack = seedTrack("Rock Song", "The Rockers", "Rock", "Rock Album");
+        ObservableAudioItem jazzTrack = seedTrack("Jazz Song", "The Jazzers", "Jazz", "Jazz Album");
+
+        waitFor(15, TimeUnit.SECONDS, () -> audioLibrary.getGenreIndex("Rock").isPresent()
+                && audioLibrary.getGenreIndex("Jazz").isPresent());
+
+        selectNavigationMode(fxRobot, NavigationController.NavigationMode.ALL_AUDIO_ITEMS);
+        FullAudioItemTableView table = visibleTrackTable(fxRobot);
+        waitFor(10, TimeUnit.SECONDS, () -> table.getItems().contains(rockTrack) && table.getItems().contains(jazzTrack));
+
+        // Clearing the genre must drop the track from the Rock bucket into the no-genre bucket.
+        publishGenreEdit(rockTrack, Set.of());
+        waitFor(15, TimeUnit.SECONDS, () -> rockTrack.getGenres().isEmpty());
+        waitFor(15, TimeUnit.SECONDS, () -> !genreBucketContains("Rock", rockTrack));
+        waitFor(15, TimeUnit.SECONDS, () -> noGenreBucketContains(rockTrack));
+
+        // Changing the genre must move the track from its old bucket into the target bucket.
+        publishGenreEdit(jazzTrack, parseGenre("Rock"));
+        waitFor(15, TimeUnit.SECONDS, () -> !genreBucketContains("Jazz", jazzTrack));
+        waitFor(15, TimeUnit.SECONDS, () -> genreBucketContains("Rock", jazzTrack));
+
+        // The Genres navigation projection the grid binds to reflects the moves.
+        selectNavigationMode(fxRobot, NavigationController.NavigationMode.GENRES);
+        assertThat(audioLibrary.getGenreIndexesProperty())
+                .noneMatch(index -> "Jazz".equals(index.getGenreProperty().get().getName())
+                        && !index.getTracksProperty().isEmpty());
+        assertThat(audioLibrary.getGenreIndex("Rock")).isPresent()
+                .hasValueSatisfying(index -> assertThat(index.getTracksProperty()).contains(jazzTrack));
+    }
+
+    private void publishGenreEdit(ObservableAudioItem track, Set<Genre> genres) {
+        AudioItemMetadataChange change = new AudioItemMetadataChange(
+                null, null, null, null, null, null, null, null, genres, null, null, null, null);
+        Platform.runLater(() ->
+                applicationEventPublisher.publishEvent(new EditAudioItemsMetadataEvent(Set.of(track), change, this)));
+        waitForFxEvents();
+    }
+
+    private boolean genreBucketContains(String genreName, ObservableAudioItem track) {
+        return audioLibrary.getGenreIndex(genreName)
+                .map(index -> index.getTracksProperty().contains(track))
+                .orElse(false);
+    }
+
+    private boolean noGenreBucketContains(ObservableAudioItem track) {
+        return audioLibrary.getGenreIndex(Genre.None.INSTANCE)
+                .map(index -> index.getTracksProperty().contains(track))
+                .orElse(false);
+    }
+
+    private ObservableAudioItem seedTrack(String title, String artist, String genre, String albumName) throws Exception {
+        Path fixture = copyFixture(title);
+        AtomicReference<ObservableAudioItem> created = new AtomicReference<>();
+        FxToolkit.setupFixture(() -> created.set(audioLibrary.createFromFile(fixture)));
+        ObservableAudioItem item = created.get();
+        FxToolkit.setupFixture(() -> item.mutate(it -> {
+            it.setTitle(title);
+            it.setArtist(Artist.of(artist));
+            it.setGenres(parseGenre(genre));
+            it.setAlbum(new AlbumDetails(albumName, Artist.of(artist), false, (Short) null, Label.UNKNOWN));
+            return Unit.INSTANCE;
+        }));
+        return item;
+    }
+
+    private Path copyFixture(String label) throws IOException {
+        Path target = Files.createTempFile(tempDir, "genre-e2e-" + label.replaceAll("\\W", "-") + "-", ".mp3");
+        try (InputStream in = Objects.requireNonNull(
+                getClass().getResourceAsStream("/testfiles/testeable.mp3"), "Missing test resource: /testfiles/testeable.mp3")) {
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return target;
+    }
+
+    private static void selectNavigationMode(FxRobot fxRobot, NavigationController.NavigationMode mode) {
+        ListView<NavigationController.NavigationMode> navigation =
+                fxRobot.lookup("#navigationModeListView").queryListView();
+        Platform.runLater(() -> navigation.getSelectionModel().select(mode));
+        waitForFxEvents();
+    }
+
+    private static FullAudioItemTableView visibleTrackTable(FxRobot fxRobot) {
+        return fxRobot.lookup(node -> node instanceof FullAudioItemTableView && node.isVisible())
+                .queryAs(FullAudioItemTableView.class);
+    }
+
+    @TestConfiguration
+    static class E2eTestConfiguration {
+
+        @Bean
+        @Primary
+        public MusicottApplication.ApplicationPaths applicationPaths() throws IOException {
+            Path tempDir = Files.createTempDirectory("musicott-genre-edit-e2e");
+            // File.deleteOnExit no-ops on a non-empty directory, and the framework writes the db/json
+            // files into this dir, so it would leak on every run; recursively delete the tree instead.
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> deleteRecursively(tempDir)));
+            return new MusicottApplication.ApplicationPaths(
+                    tempDir.resolve("audioItems.db"),
+                    tempDir.resolve("playlists.json"),
+                    tempDir.resolve("waveforms.json"));
+        }
+
+        private static void deleteRecursively(Path root) {
+            try (var paths = Files.walk(root)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException ignored) {
+                        // Best-effort cleanup on JVM shutdown; a leftover file is not worth failing on.
+                    }
+                });
+            } catch (IOException ignored) {
+                // The directory may already be gone; nothing to clean up.
+            }
+        }
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/EditControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/EditControllerIT.java
@@ -1,6 +1,7 @@
 package net.transgressoft.musicott.view;
 
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.musicott.events.EditAudioItemsMetadataEvent;
 import net.transgressoft.musicott.events.InvalidAudioItemsForEditionEvent;
 import net.transgressoft.musicott.events.OpenAudioItemEditorView;
@@ -11,6 +12,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static net.transgressoft.commons.music.audio.GenreExtensionsKt.parseGenre;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
@@ -142,5 +145,131 @@ class EditControllerIT {
 
         // The cancel path closes the stage without publishing an EditAudioItemsMetadataEvent (no save).
         verify(applicationEventPublisher, never()).publishEvent(any(EditAudioItemsMetadataEvent.class));
+    }
+
+    @Test
+    @DisplayName("EditController publishes a metadata change carrying the parsed genre set when the genre field is edited")
+    void publishesParsedGenreSetWhenGenreFieldEdited() {
+        var change = fireOkWithGenre("Techno, House");
+        assertThat(change.genres()).isEqualTo(parseGenre("Techno, House"));
+    }
+
+    @Test
+    @DisplayName("EditController publishes an empty genre set when the genre field is cleared")
+    void publishesEmptyGenreSetWhenGenreFieldCleared() {
+        // Reproduces the reported bug at the editor level: clearing the genre must be an explicit
+        // clear (empty set) rather than a skip (null), so the applied edit moves the track to the
+        // no-genre bucket instead of silently leaving the previous genre in place.
+        var change = fireOkWithGenre("");
+        assertThat(change.genres()).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("EditController leaves genres untouched when the multi-value dash sentinel is present")
+    void leavesGenresUntouchedWhenMultiValueDashPresent() {
+        var change = fireOkWithGenre("-");
+        assertThat(change.genres()).isNull();
+    }
+
+    @Test
+    @DisplayName("EditController publishes the edited title, artist and album name from the editor fields")
+    void publishesEditedTitleArtistAndAlbumName() {
+        var mockItem = mock(ObservableAudioItem.class);
+        ReflectionTestUtils.setField(editController, "audioItemSelection", Set.of(mockItem));
+        TextField title = textField("titleTextField");
+        TextField artist = textField("artistTextField");
+        TextField album = textField("albumTextField");
+        Button okButton = (Button) ReflectionTestUtils.getField(editController, "okButton");
+
+        Platform.runLater(() -> {
+            title.setText("She Moves She");
+            artist.setText("Four Tet");
+            album.setText("Rounds");
+            okButton.fire();
+        });
+        waitForFxEvents();
+
+        var change = captureMetadataChange();
+        assertThat(change.title()).isEqualTo("She Moves She");
+        assertThat(change.artist().getName()).isEqualTo("Four Tet");
+        assertThat(change.albumName()).isEqualTo("Rounds");
+    }
+
+    @Test
+    @DisplayName("EditController publishes an empty album artist when the album artist field is cleared")
+    void publishesEmptyAlbumArtistWhenAlbumArtistFieldCleared() {
+        // Reproduces the reported bug: clearing the album artist must be applied (an explicit,
+        // blank album artist) rather than silently skipped, so the track leaves its album-artist row.
+        var change = fireOkWithField("albumArtistTextField", "");
+        assertThat(change.albumArtist()).isEqualTo(Artist.of(""));
+    }
+
+    @Test
+    @DisplayName("EditController leaves the album artist untouched when the multi-value dash is present")
+    void leavesAlbumArtistUntouchedWhenDashPresent() {
+        var change = fireOkWithField("albumArtistTextField", "-");
+        assertThat(change.albumArtist()).isNull();
+    }
+
+    @Test
+    @DisplayName("EditController leaves already-blank artist, album, album artist and genre untouched when only an unrelated field is edited")
+    void leavesAlreadyBlankFieldsUntouchedWhenUnrelatedFieldEdited() {
+        // An untagged track opens with every common field resolved to "": editing only the title must
+        // not force spurious clears (artist/album/albumArtist/genre stay null, so no re-keying churn).
+        var mockItem = mock(ObservableAudioItem.class);
+        ReflectionTestUtils.setField(editController, "audioItemSelection", Set.of(mockItem));
+        ReflectionTestUtils.setField(editController, "initialArtistText", "");
+        ReflectionTestUtils.setField(editController, "initialAlbumText", "");
+        ReflectionTestUtils.setField(editController, "initialAlbumArtistText", "");
+        ReflectionTestUtils.setField(editController, "initialGenreText", "");
+        TextField title = textField("titleTextField");
+        Button okButton = (Button) ReflectionTestUtils.getField(editController, "okButton");
+
+        Platform.runLater(() -> {
+            // artist, album, albumArtist and genre stay blank as opened; only the title is edited.
+            title.setText("Only Title Changed");
+            okButton.fire();
+        });
+        waitForFxEvents();
+
+        var change = captureMetadataChange();
+        assertThat(change.title()).isEqualTo("Only Title Changed");
+        assertThat(change.artist()).isNull();
+        assertThat(change.albumName()).isNull();
+        assertThat(change.albumArtist()).isNull();
+        assertThat(change.genres()).isNull();
+    }
+
+    private EditController.AudioItemMetadataChange fireOkWithGenre(String genreText) {
+        return fireOkWithField("genreTextField", genreText);
+    }
+
+    private EditController.AudioItemMetadataChange fireOkWithField(String fieldName, String text) {
+        var mockItem = mock(ObservableAudioItem.class);
+        ReflectionTestUtils.setField(editController, "audioItemSelection", Set.of(mockItem));
+        // Simulate the dialog opening on tracks whose clearable fields had prior content, so emptying
+        // a field is an explicit clear rather than an already-blank field left untouched.
+        ReflectionTestUtils.setField(editController, "initialArtistText", "prior");
+        ReflectionTestUtils.setField(editController, "initialAlbumText", "prior");
+        ReflectionTestUtils.setField(editController, "initialAlbumArtistText", "prior");
+        ReflectionTestUtils.setField(editController, "initialGenreText", "prior");
+        TextField field = textField(fieldName);
+        Button okButton = (Button) ReflectionTestUtils.getField(editController, "okButton");
+        Platform.runLater(() -> {
+            field.setText(text);
+            okButton.fire();
+        });
+        waitForFxEvents();
+        return captureMetadataChange();
+    }
+
+    private EditController.AudioItemMetadataChange captureMetadataChange() {
+        var captor = ArgumentCaptor.forClass(EditAudioItemsMetadataEvent.class);
+        verify(applicationEventPublisher).publishEvent(captor.capture());
+        return captor.getValue().audioItemMetadataChange;
+    }
+
+    private TextField textField(String fieldName) {
+        return (TextField) ReflectionTestUtils.getField(editController, fieldName);
     }
 }

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -555,11 +555,18 @@ public class ArtistViewController implements Searchable<String> {
         if (itemArtist != null && itemArtist.equals(artist)) {
             return true;
         }
+        var artistsInvolved = audioItem.getArtistsInvolved();
+        if (artistsInvolved == null || !artistsInvolved.contains(artist)) {
+            return false;
+        }
+        // A track surfaces under every artist it involves — including its album artist — so editing
+        // the artist or album artist moves the track between artist rows. The one exception is a
+        // compilation's album artist (e.g. "Various Artists"): individual compilation tracks must not
+        // collapse under that grouping, only under their own performing artist.
         var album = audioItem.getAlbum();
         var albumArtist = album == null ? null : album.getAlbumArtist();
-        return audioItem.getArtistsInvolved() != null
-                && audioItem.getArtistsInvolved().contains(artist)
-                && !artist.equals(albumArtist);
+        boolean isCompilation = album != null && album.isCompilation();
+        return !isCompilation || !artist.equals(albumArtist);
     }
 
     // Guard each metadata access — partial catalogs can have null artist/album/album-artist

--- a/src/main/java/net/transgressoft/musicott/view/EditController.java
+++ b/src/main/java/net/transgressoft/musicott/view/EditController.java
@@ -106,6 +106,13 @@ public class EditController {
     private Set<ObservableAudioItem> audioItemSelection;
     private byte[] newCoverImageBytes;
     private Optional<byte[]> commonCover = Optional.empty();
+
+    // Common field values shown when the dialog opened, captured so an empty clearable field can be
+    // told apart from a field that was already blank and left untouched (both render as "").
+    private String initialArtistText;
+    private String initialAlbumText;
+    private String initialAlbumArtistText;
+    private String initialGenreText;
     private Alert multipleEditionConfirmationAlert;
 
     @FXML
@@ -326,11 +333,11 @@ public class EditController {
         newCoverImageBytes = null;
 
         titleTextField.textProperty().set(commonTitle());
-        artistTextField.textProperty().set(commonArtist());
-        albumTextField.textProperty().set(commonAlbum());
-        genreTextField.textProperty().set(commonGenre());
+        artistTextField.textProperty().set(initialArtistText = commonArtist());
+        albumTextField.textProperty().set(initialAlbumText = commonAlbum());
+        genreTextField.textProperty().set(initialGenreText = commonGenre());
         commentsTextField.textProperty().set(commonComments());
-        albumArtistTextField.textProperty().set(commonAlbumArtist());
+        albumArtistTextField.textProperty().set(initialAlbumArtistText = commonAlbumArtist());
         labelTextField.textProperty().set(commonLabel());
         trackNumTextField.textProperty().set(commonTrackNumber());
         discNumTextField.textProperty().set(commonDiscNumber());
@@ -452,15 +459,16 @@ public class EditController {
 
     private AudioItemMetadataChange getEditionResult() {
        String title = getEditionFieldResult(titleTextField);
-       Artist artist = getEditionFieldResult(artistTextField) != null ? Artist.of(getEditionFieldResult(artistTextField)) : null;
-       String albumName = getEditionFieldResult(albumTextField);
-       Artist albumArtist = getEditionFieldResult(albumArtistTextField) != null ? Artist.of(getEditionFieldResult(albumArtistTextField)) : null;
+       String artistName = getClearableFieldResult(artistTextField, initialArtistText);
+       Artist artist = artistName != null ? Artist.of(artistName) : null;
+       String albumName = getClearableFieldResult(albumTextField, initialAlbumText);
+       String albumArtistName = getClearableFieldResult(albumArtistTextField, initialAlbumArtistText);
+       Artist albumArtist = albumArtistName != null ? Artist.of(albumArtistName) : null;
        Boolean isCompilation = isCompilationCheckBox.isIndeterminate() ? null : isCompilationCheckBox.isSelected();
        Short year = getEditionFieldResult(yearTextField) != null ? Short.valueOf(getEditionFieldResult(yearTextField)) : null;
        String labelValue = getEditionFieldResult(labelTextField);
        net.transgressoft.commons.music.audio.Label label = labelValue != null ? net.transgressoft.commons.music.audio.Label.of(labelValue) : null;
-       String genreValue = getEditionFieldResult(genreTextField);
-       Set<Genre> genres = genreValue != null ? GenreExtensionsKt.parseGenre(genreValue) : null;
+       Set<Genre> genres = getEditionGenres(initialGenreText);
        String comments = getEditionFieldResult(commentsTextField);
        Short trackNum = getEditionFieldResult(trackNumTextField) != null ? Short.valueOf(getEditionFieldResult(trackNumTextField)) : null;
        Short discNum = getEditionFieldResult(discNumTextField) != null ? Short.valueOf(getEditionFieldResult(discNumTextField)) : null;
@@ -475,6 +483,44 @@ public class EditController {
         // unset metadata with empty strings.
         String value = textField.getText();
         return value == null || value.isEmpty() || value.equals("-") ? null : value;
+    }
+
+    /**
+     * Resolves a text field whose backing metadata always has a value (album name, artist, album
+     * artist), distinguishing a deliberate clear from a skip: {@code null} for the {@code "-"}
+     * multi-value sentinel (leave untouched) and for a field that was already blank on open and left
+     * untouched, otherwise the field text — an empty string that had prior content is an explicit
+     * clear that is applied. Unlike {@link #getEditionFieldResult(TextInputControl)}, emptying a
+     * field that had content is not swallowed, so clearing e.g. the album artist takes effect; but
+     * an unrelated edit (e.g. BPM) on an untagged track no longer forces a spurious clear.
+     */
+    private String getClearableFieldResult(TextInputControl textField, String initialValue) {
+        String value = textField.getText();
+        if (value == null || value.equals("-")) {
+            return null;
+        }
+        // Already blank on open and still blank: nothing to clear, skip instead of forcing a write.
+        return value.isEmpty() && (initialValue == null || initialValue.isEmpty()) ? null : value;
+    }
+
+    /**
+     * Resolves the genre edition into three outcomes the change record distinguishes: {@code null}
+     * to leave genres untouched (the {@code "-"} multi-value sentinel, or a field that was already
+     * blank on open and left untouched), an empty set when the user cleared a previously populated
+     * field (the track moves to the no-genre bucket), and the parsed set otherwise. Unlike
+     * {@link #getEditionFieldResult(TextInputControl)}, emptying a genre field that had content is an
+     * explicit clear rather than a skip.
+     */
+    private Set<Genre> getEditionGenres(String initialValue) {
+        String value = genreTextField.getText();
+        if (value == null || value.equals("-")) {
+            return null;
+        }
+        if (value.isEmpty()) {
+            // Already blank on open and still blank: leave untouched rather than force the no-genre bucket.
+            return initialValue == null || initialValue.isEmpty() ? null : Set.of();
+        }
+        return GenreExtensionsKt.parseGenre(value);
     }
 
     private void close() {

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRow.java
@@ -59,6 +59,7 @@ public class ArtistAlbumListRow extends HBox {
 
     private ImageView coverImageView;
     private VBox albumInfoVBox;
+    private Label albumTitleLabel;
     private Label genresLabel;
     private Label albumLabelLabel;
     private Label yearLabel;
@@ -141,7 +142,7 @@ public class ArtistAlbumListRow extends HBox {
     }
 
     private void placeRightVBox() {
-        var albumTitleLabel = new Label(albumSet.getAlbumName());
+        albumTitleLabel = new Label(buildAlbumNameString());
         albumTitleLabel.setId("albumTitleLabel");
         // No fixed width cap: the title takes as much horizontal space as it needs, up to the row
         // width (the drawer can be far wider than the artist view, where a 480px cap truncated it).
@@ -171,6 +172,18 @@ public class ArtistAlbumListRow extends HBox {
         HBox.setHgrow(albumInfoVBox, Priority.SOMETIMES);
         HBox.setMargin(albumInfoVBox, new Insets(20, 20, 5, 0));
         getChildren().add(albumInfoVBox);
+    }
+
+    // Derives the album title from the live tracks so an in-place album-name edit refreshes the row.
+    // Falls back to the album-set's captured name for synthetic groupings (e.g. the genre view's
+    // "Unknown Album" section) whose tracks carry no album name.
+    @SuppressWarnings("java:S2589")
+    private String buildAlbumNameString() {
+        return containedAudioItems.stream()
+                .map(item -> item.getAlbum() == null ? null : item.getAlbum().getName())
+                .filter(name -> name != null && !name.isEmpty())
+                .findFirst()
+                .orElseGet(albumSet::getAlbumName);
     }
 
     private String buildGenresString() {
@@ -330,6 +343,7 @@ public class ArtistAlbumListRow extends HBox {
         subscriptions.add(subscribe(audioItem.getDiscNumberProperty(), _ -> containedAudioItems.sort(this::audioItemComparator)));
         subscriptions.add(subscribe(audioItem.getGenresProperty(), _ -> genresLabel.setText(buildGenresString())));
         subscriptions.add(subscribe(audioItem.getAlbumProperty(), _ -> {
+            albumTitleLabel.setText(buildAlbumNameString());
             yearLabel.setText(buildYearsString());
             updateAlbumLabelLabel();
         }));

--- a/src/main/kotlin/net/transgressoft/musicott/MusicLibraryEventSubscriber.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/MusicLibraryEventSubscriber.kt
@@ -1,10 +1,13 @@
 package net.transgressoft.musicott
 
 import mu.KotlinLogging
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem
+import net.transgressoft.commons.music.audio.AlbumDetails
 import net.transgressoft.commons.music.audio.AudioItemManipulationException
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.musicott.events.EditAudioItemsMetadataEvent
 import net.transgressoft.musicott.events.ExceptionEvent
+import net.transgressoft.musicott.view.EditController.AudioItemMetadataChange
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -17,12 +20,51 @@ class MusicLibraryEventSubscriber(
 
     @EventListener
     fun editAudioItemsListener(editAudioItemsMetadataEvent: EditAudioItemsMetadataEvent) {
+        val change = editAudioItemsMetadataEvent.audioItemMetadataChange
         editAudioItemsMetadataEvent.audioItems.forEach { updatedAudioItem ->
             try {
+                applyMetadataChange(updatedAudioItem, change)
                 audioMetadataIO.writeMetadata(updatedAudioItem)
             } catch (exception: AudioItemManipulationException) {
                 logger.error("Error during audio metadata edition", exception)
                 applicationEventPublisher.publishEvent(ExceptionEvent(exception, this))
+            }
+        }
+    }
+
+    /**
+     * Applies the collected editor changes onto the live item so the reactive setters fire and the
+     * library projections (all-tracks table, genre/album/artist views) re-key. A {@code null} field
+     * in the change means "leave untouched"; only fields the editor actually resolved are written.
+     * All writes happen inside a single [ObservableAudioItem.mutate] block so downstream projections
+     * re-key once per item rather than once per field.
+     */
+    private fun applyMetadataChange(audioItem: ObservableAudioItem, change: AudioItemMetadataChange) {
+        audioItem.mutate {
+            change.title()?.let { title = it }
+            change.artist()?.let { artist = it }
+            change.genres()?.let { genres = it }
+            change.comments()?.let { comments = it }
+            change.trakNum()?.let { trackNumber = it }
+            change.discNum()?.let { discNumber = it }
+            change.bpm()?.let { bpm = it }
+            change.coverImageBytes()?.let { coverImageBytes = it }
+
+            // Album attributes live on the immutable AlbumDetails value; rebuild it once from the
+            // current album, overriding only the fields the editor resolved, so a single album
+            // property change re-keys the album projection.
+            val albumName = change.albumName()
+            val albumArtist = change.albumArtist()
+            val compilation = change.isCompilation()
+            val year = change.year()
+            val label = change.label()
+            if (albumName != null || albumArtist != null || compilation != null || year != null || label != null) {
+                album = AlbumDetails(
+                    albumName ?: album.name,
+                    albumArtist ?: album.albumArtist,
+                    compilation ?: album.isCompilation,
+                    year ?: album.year,
+                    label ?: album.label)
             }
         }
     }

--- a/src/test/java/net/transgressoft/musicott/view/ArtistViewControllerTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/ArtistViewControllerTest.java
@@ -2,17 +2,16 @@ package net.transgressoft.musicott.view;
 
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
-import net.transgressoft.musicott.test.FxAudioItems;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
 import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import net.transgressoft.commons.music.audio.Label;
+import net.transgressoft.musicott.test.FxAudioItems;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -62,6 +61,50 @@ class ArtistViewControllerTest {
                 });
     }
 
+    @Test
+    @DisplayName("ArtistViewController shows a non-compilation track under its album artist as well as its performer")
+    void showsNonCompilationTrackUnderItsAlbumArtist() {
+        Artist performer = of("Feature Guy");
+        Artist albumArtist = of("Album Owner");
+        ObservableAudioItem track = audioItem(
+                "Guest Spot", performer, "Owner's Album", albumArtist, 1, Set.of(performer, albumArtist));
+
+        var audioItems = new SimpleListProperty<>(FXCollections.observableArrayList(track));
+        var audioLibrary = mock(ObservableAudioLibrary.class);
+        when(audioLibrary.getAudioItemsProperty()).thenReturn(audioItems);
+        var controller = new ArtistViewController(audioLibrary, mock(ApplicationContext.class), mock(net.transgressoft.musicott.search.SearchCoordinator.class));
+
+        assertThat(controller.albumSetsForArtist(albumArtist).keySet())
+                .as("track surfaces under its album artist")
+                .singleElement()
+                .satisfies(albumSet -> assertThat(albumSet.tracks()).containsExactly(track));
+        assertThat(controller.albumSetsForArtist(performer).keySet())
+                .as("track still surfaces under its performing artist")
+                .singleElement()
+                .satisfies(albumSet -> assertThat(albumSet.tracks()).containsExactly(track));
+    }
+
+    @Test
+    @DisplayName("ArtistViewController does not show a compilation track under its album artist")
+    void doesNotShowCompilationTrackUnderItsAlbumArtist() {
+        Artist performer = of("Track Artist");
+        Artist various = of("Various Artists");
+        ObservableAudioItem track = compilationItem(
+                "Comp Track", performer, "Best Of 2010", various, Set.of(performer, various));
+
+        var audioItems = new SimpleListProperty<>(FXCollections.observableArrayList(track));
+        var audioLibrary = mock(ObservableAudioLibrary.class);
+        when(audioLibrary.getAudioItemsProperty()).thenReturn(audioItems);
+        var controller = new ArtistViewController(audioLibrary, mock(ApplicationContext.class), mock(net.transgressoft.musicott.search.SearchCoordinator.class));
+
+        assertThat(controller.albumSetsForArtist(performer).keySet())
+                .as("compilation track still surfaces under its performer")
+                .isNotEmpty();
+        assertThat(controller.albumSetsForArtist(various))
+                .as("compilation track does not collapse under the Various Artists grouping")
+                .isEmpty();
+    }
+
     private static ObservableAudioItem audioItem(
             String title,
             Artist artist,
@@ -69,13 +112,33 @@ class ArtistViewControllerTest {
             Artist albumArtist,
             int trackNumber,
             Set<Artist> artistsInvolved) {
+        return audioItem(title, artist, albumName, albumArtist, trackNumber, artistsInvolved, false);
+    }
+
+    private static ObservableAudioItem compilationItem(
+            String title,
+            Artist artist,
+            String albumName,
+            Artist albumArtist,
+            Set<Artist> artistsInvolved) {
+        return audioItem(title, artist, albumName, albumArtist, 1, artistsInvolved, true);
+    }
+
+    private static ObservableAudioItem audioItem(
+            String title,
+            Artist artist,
+            String albumName,
+            Artist albumArtist,
+            int trackNumber,
+            Set<Artist> artistsInvolved,
+            boolean isCompilation) {
         return FxAudioItems.createFxAudioItem(attributes -> {
             attributes.setTitle(title);
             attributes.setArtist(artist);
             attributes.setAlbum(AudioItemTestFactory.createAlbum(
                     albumName,
                     albumArtist,
-                    false,
+                    isCompilation,
                     null,
                     Label.of("Test Label")));
             attributes.setTrackNumber((short) trackNumber);

--- a/src/test/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRowLabelTest.java
+++ b/src/test/java/net/transgressoft/musicott/view/custom/table/ArtistAlbumListRowLabelTest.java
@@ -1,9 +1,12 @@
 package net.transgressoft.musicott.view.custom.table;
 
+import javafx.application.Platform;
+import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.stage.Stage;
 import net.transgressoft.musicott.test.FxAudioItems;
 import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.music.audio.AlbumDetails;
 import net.transgressoft.commons.music.audio.Artist;
 import net.transgressoft.commons.music.audio.AudioItemTestFactory;
 import org.junit.jupiter.api.*;
@@ -19,6 +22,7 @@ import java.util.Set;
 import static net.transgressoft.commons.music.audio.Artist.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
 
 /**
  * Unit tests for the album-info label logic in {@link ArtistAlbumListRow}: related-artists,
@@ -29,9 +33,12 @@ import static org.mockito.Mockito.*;
 class ArtistAlbumListRowLabelTest {
 
     SimpleAudioItemTableView tableView;
+    Stage stage;
 
     @Start
-    void start(Stage stage) {}
+    void start(Stage stage) {
+        this.stage = stage;
+    }
 
     @BeforeEach
     void setUp() {
@@ -94,6 +101,34 @@ class ArtistAlbumListRowLabelTest {
         assertThat(albumLabelLabel).isNotNull();
         assertThat(albumLabelLabel.getText()).doesNotContain(",");
         assertThat(albumLabelLabel.getText()).isEqualTo("Ninja Tune");
+    }
+
+    @Test
+    @DisplayName("album title label updates live when a track's album name is edited in place")
+    void albumTitleLabelUpdatesWhenAlbumNameEditedInPlace() {
+        Artist bonobo = of("Bonobo");
+        ObservableAudioItem track = audioItem("Kiara", bonobo, "Black Sands", bonobo, Set.of(bonobo));
+        var row = new ArtistAlbumListRow(bonobo, albumSet("Black Sands", track), tableView, 0);
+
+        // Render the row so the embedded table's cell value factory registers the per-track album
+        // subscription that drives the live title refresh.
+        Platform.runLater(() -> {
+            stage.setScene(new Scene(row, 640, 480));
+            stage.show();
+        });
+        waitForFxEvents();
+
+        Label albumTitleLabel = (Label) row.lookup("#albumTitleLabel");
+        assertThat(albumTitleLabel).isNotNull();
+        assertThat(albumTitleLabel.getText()).isEqualTo("Black Sands");
+
+        // Editing the album name in place must refresh the drawer/row title, not leave the stale name.
+        Platform.runLater(() -> track.setAlbum(
+                new AlbumDetails("Migration", bonobo, false, null,
+                        net.transgressoft.commons.music.audio.Label.UNKNOWN)));
+        waitForFxEvents();
+
+        assertThat(albumTitleLabel.getText()).isEqualTo("Migration");
     }
 
     private static AlbumTrackGroup albumSet(String albumName, ObservableAudioItem... tracks) {


### PR DESCRIPTION
Fixes #79.

## Problem

Editing an audio item's metadata through the editor did not update the library table or the navigation views (genre, album, artist groupings), and the change was not persisted.

The editor collected the user's edits into an `AudioItemMetadataChange`, but the only handler of `EditAudioItemsMetadataEvent` ignored that payload and called `writeMetadata` on the **unchanged** item. As a result no reactive setter fired, the projections never re-keyed, and the stale tag was written back to disk. The fault was localized to Musicott; `music-commons` and `lirp` propagation were verified correct once the change is actually applied.

Clearing a field (empty album name / artist / album artist / genre) was also silently swallowed, so a user could not remove those values.

## Changes

**Editing**
- `MusicLibraryEventSubscriber` applies the change to each item in a single `mutate {}` block (rebuilding the immutable `AlbumDetails` for album-nested fields) before writing tags, so per-item property changes drive projection re-keying.
- `EditController` applies explicit clears: an empty genre becomes the no-genre bucket, and empty album name / artist / album artist are applied instead of being skipped. The `-` multi-value sentinel still means "leave untouched".

**Views**
- Artist view: a track now surfaces under its album artist as well as its performer, so editing artist or album artist moves it between artist rows — except for a compilation's album artist, which stays excluded so compilation tracks don't collapse under it.
- `ArtistAlbumListRow` derives the album title from its live tracks, so an in-place album-name edit refreshes the drawer/row title (shared by the Albums, Genres and Artists drawers).

## Testing

- `EditControllerIT` asserts the published change payload for edited/cleared/multi-value genre and album artist plus title/artist/album.
- `ArtistViewControllerTest` covers album-artist membership and the compilation carve-out; `ArtistAlbumListRowLabelTest` covers the live album title.
- `GenreEditPropagationE2E`, `AlbumEditPropagationE2E` and `ArtistEditPropagationE2E` seed a library from the bundled test audio file, publish the editor's edit event, and assert the track moves between genre, album and artist groupings.