### PR TITLE
Add in-app application log viewer window (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ After years of this refactoring and redesign work, in April 2026 I moved the old
 - **Cover-grid browsing modes** — browse your library visually through the **Artists**, **Albums**, and **Genres** navigation modes, each presenting a grid of cover art. In the **Genres** mode each genre cell shows a cover drawn from that genre's tracks and cycles through a different cover on hover; clicking a genre cell opens a right overlay drawer that lists the genre's tracks grouped by album, with a textual header showing the genre name and track count. An album may appear with only a subset of its tracks when just some of them carry that genre. Tracks with no album metadata collect under an "Unknown Album" section at the bottom. Double-click a track in the drawer to play it; press Esc or click outside the drawer to close it.
 - **Contextual random playback** — pressing play with an empty queue or clicking shuffle starts random playback from the active view (all tracks, the selected playlist, or the selected artist), with a status message when no playable tracks exist
 - **Waveform visualization** — generated once per track, cached locally, and used for visual seeking during playback
+- **In-app log viewer** — a "Show Application Logs" item in the View menu opens a resizable, modeless window showing the most recent application log lines (read-only, selectable, scrollable). A level-filter combo box (TRACE / DEBUG / INFO / WARN / ERROR, defaulting to INFO) limits the visible lines; an export button saves the full current buffer to a `.log` file of your choice. When a completed operation (import, metadata edit, export) produces warnings or errors, the status bar label turns amber and becomes clickable — clicking it opens the log viewer directly so you can inspect what happened without digging through the file system
 - **Native installers** for Linux (AppImage / AUR), Windows, and macOS — no JDK install required by end users
 
 ## Download
@@ -59,6 +60,7 @@ WIP documentation lives in the **[GitHub wiki](https://github.com/octaviospain/M
 - [Playback](https://github.com/octaviospain/Musicott/wiki/Playback)
 - [Playlists](https://github.com/octaviospain/Musicott/wiki/Playlists)
 - [Search](https://github.com/octaviospain/Musicott/wiki/Search)
+- [Application logs](https://github.com/octaviospain/Musicott/wiki/Logs)
 
 ## Build from source
 

--- a/src/integrationTest/java/net/transgressoft/musicott/PrimaryStageInitializerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/PrimaryStageInitializerIT.java
@@ -1,0 +1,72 @@
+package net.transgressoft.musicott;
+
+import net.transgressoft.musicott.view.EditController;
+import net.transgressoft.musicott.view.ErrorDialogController;
+import net.transgressoft.musicott.view.LogViewerController;
+import net.transgressoft.musicott.view.MainController;
+
+import javafx.scene.layout.AnchorPane;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxWeaver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.testfx.api.FxToolkit;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testfx.util.WaitForAsyncUtils.asyncFx;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration test for {@link PrimaryStageInitializer}, pinning the auxiliary-view prewarm
+ * contract. Windows that are opened later purely in response to an application event (the log
+ * viewer) depend on their FXML being loaded here so their {@code @FXML} fields — including the
+ * scene root — are injected into the Spring singleton before the window is built.
+ */
+@DisplayName("PrimaryStageInitializer")
+class PrimaryStageInitializerIT {
+
+    @BeforeAll
+    static void initFx() throws Exception {
+        FxToolkit.registerPrimaryStage();
+    }
+
+    @AfterAll
+    static void cleanUp() throws Exception {
+        FxToolkit.cleanupStages();
+    }
+
+    @Test
+    @DisplayName("prewarms every auxiliary view, including the log viewer, without throwing")
+    void prewarmsEveryAuxiliaryViewIncludingTheLogViewerWithoutThrowing() throws Exception {
+        FxWeaver fxWeaver = mock(FxWeaver.class);
+        when(fxWeaver.loadView(any())).thenAnswer(invocation -> new AnchorPane());
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+
+        PrimaryStageInitializer initializer = new PrimaryStageInitializer(fxWeaver, publisher);
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        asyncFx(() -> {
+            try {
+                initializer.initializePrimaryStage(new Stage());
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        waitForFxEvents();
+
+        assertThat(failure.get()).as("primary stage initialization must not throw").isNull();
+        verify(fxWeaver).loadView(ErrorDialogController.class);
+        verify(fxWeaver).loadView(EditController.class);
+        verify(fxWeaver).loadView(LogViewerController.class);
+        verify(fxWeaver).loadView(MainController.class);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/LogViewerControllerIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/LogViewerControllerIT.java
@@ -1,0 +1,290 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.musicott.logging.RingBufferHolder;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.AnchorPane;
+import javafx.stage.FileChooser;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration tests for {@link LogViewerController}, verifying that the log viewer window
+ * opens as a modeless resizable stage, displays captured log records in a read-only text
+ * area, filters records by level, exports the held buffer to a file, and shows records
+ * that were emitted before the window was opened (including boot-time and error-dialog errors).
+ */
+@JavaFxSpringTest(classes = LogViewerControllerITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("LogViewerController")
+class LogViewerControllerIT extends ApplicationTestBase<AnchorPane> {
+
+    @Autowired
+    FxControllerAndView<LogViewerController, AnchorPane> logViewerControllerAndView;
+
+    @Autowired
+    LogViewerFileChooserHolder fileChooserHolder;
+
+    @Override
+    @BeforeEach
+    protected void beforeEach() {
+        RingBufferHolder.INSTANCE.resetForTest();
+        super.beforeEach();
+    }
+
+    @AfterEach
+    void closeLogViewerStage() {
+        LogViewerController controller = logViewerControllerAndView.getController();
+        Platform.runLater(() -> {
+            if (controller.stage != null && controller.stage.isShowing()) {
+                controller.stage.hide();
+            }
+            controller.stage = null;
+        });
+        waitForFxEvents();
+    }
+
+    @Override
+    protected AnchorPane javaFxComponent() {
+        // Return a placeholder pane for the test stage, not the controller's root.
+        // The controller's root is placed into its own modeless Stage by showWindow();
+        // mounting it in the test stage's scene too would trigger
+        // "already set as root of another scene" on the second call to showWindow().
+        return new AnchorPane();
+    }
+
+    @Test
+    @DisplayName("opens a modeless resizable window titled Application Logs")
+    void opensAModelessResizableWindowTitledApplicationLogs() throws Exception {
+        LogViewerController controller = logViewerControllerAndView.getController();
+
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        Stage logStage = waitForDialogStage("Application Logs");
+        assertThat(logStage).as("Application Logs stage").isNotNull();
+        assertThat(logStage.isResizable()).isTrue();
+        assertThat(logStage.getModality()).isEqualTo(Modality.NONE);
+    }
+
+    @Test
+    @DisplayName("renders a non-editable but selectable text area")
+    void rendersANonEditableButSelectableTextArea() {
+        LogViewerController controller = logViewerControllerAndView.getController();
+        TextArea textArea = controller.logTextArea;
+
+        assertThat(textArea.isEditable()).isFalse();
+        assertThat(textArea).isInstanceOf(TextArea.class);
+    }
+
+    @Test
+    @DisplayName("shows only records at or above the selected level when the filter changes")
+    void showsOnlyRecordsAtOrAboveSelectedLevelWhenFilterChanges() throws Exception {
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.test - info message\n", ch.qos.logback.classic.Level.INFO);
+        RingBufferHolder.INSTANCE.add("DEBUG net.transgressoft.test - debug message\n", ch.qos.logback.classic.Level.DEBUG);
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.test - warn message\n", ch.qos.logback.classic.Level.WARN);
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.test - error message\n", ch.qos.logback.classic.Level.ERROR);
+
+        LogViewerController controller = logViewerControllerAndView.getController();
+
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        // Switch to WARN filter
+        Platform.runLater(() -> {
+            ComboBox<String> combo = controller.levelFilterCombo;
+            combo.setValue("WARN");
+            // Trigger the action listener
+            combo.getOnAction().handle(null);
+        });
+        waitForFxEvents();
+
+        String text = controller.logTextArea.getText();
+        assertThat(text).contains("warn message");
+        assertThat(text).contains("error message");
+        assertThat(text).doesNotContain("info message");
+        assertThat(text).doesNotContain("debug message");
+    }
+
+    @Test
+    @DisplayName("exports the currently held buffer to the chosen file")
+    void exportsTheCurrentlyHeldBufferToTheChosenFile(@TempDir Path tempDir) throws Exception {
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.test - export line one\n", ch.qos.logback.classic.Level.INFO);
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.test - export line two\n", ch.qos.logback.classic.Level.WARN);
+
+        LogViewerController controller = logViewerControllerAndView.getController();
+
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        // Filter the VIEW to ERROR so neither seeded line (INFO, WARN) is visible. Export must
+        // still write the FULL held buffer, independent of the active level filter.
+        Platform.runLater(() -> {
+            controller.levelFilterCombo.setValue("ERROR");
+            controller.levelFilterCombo.getOnAction().handle(null);
+        });
+        waitForFxEvents();
+        assertThat(controller.logTextArea.getText())
+                .as("ERROR filter hides the INFO/WARN lines from the displayed view")
+                .doesNotContain("export line one")
+                .doesNotContain("export line two");
+
+        File exportFile = tempDir.resolve("test-export.log").toFile();
+        when(fileChooserHolder.mock.showSaveDialog(any())).thenReturn(exportFile);
+
+        Platform.runLater(controller::exportLogs);
+        waitForFxEvents();
+
+        assertThat(exportFile).exists();
+        String exportContent = Files.readString(exportFile.toPath());
+        assertThat(exportContent)
+                .as("export writes the full buffer regardless of the active filter")
+                .contains("export line one")
+                .contains("export line two");
+    }
+
+    @Test
+    @DisplayName("captures records emitted before the window is opened")
+    void capturesRecordsEmittedBeforeTheWindowIsOpened() throws Exception {
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.test - pre-open boot message\n", ch.qos.logback.classic.Level.INFO);
+
+        LogViewerController controller = logViewerControllerAndView.getController();
+
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        String text = controller.logTextArea.getText();
+        assertThat(text).contains("pre-open boot message");
+    }
+
+    @Test
+    @DisplayName("live-tails records appended while the window is open")
+    void liveTailsRecordsAppendedWhileTheWindowIsOpen() throws Exception {
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.test - seeded before open\n", ch.qos.logback.classic.Level.INFO);
+
+        LogViewerController controller = logViewerControllerAndView.getController();
+
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        assertThat(controller.logTextArea.getText()).contains("seeded before open");
+
+        // A record added after the window opened must tail into the text area.
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.test - tailed after open\n", ch.qos.logback.classic.Level.WARN);
+        waitForFxEvents();
+
+        String text = controller.logTextArea.getText();
+        assertThat(text).contains("seeded before open");
+        assertThat(text).contains("tailed after open");
+    }
+
+    @Test
+    @DisplayName("shows error-dialog errors that were added to the buffer")
+    void showsErrorDialogErrorsThatWereAddedToTheBuffer() throws Exception {
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.test - simulated error-dialog error\n", ch.qos.logback.classic.Level.ERROR);
+        // Set filter to include ERROR (INFO default already passes ERROR, but be explicit)
+        LogViewerController controller = logViewerControllerAndView.getController();
+        controller.currentLevelFilter = "INFO";
+
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        String text = controller.logTextArea.getText();
+        assertThat(text).contains("simulated error-dialog error");
+    }
+}
+
+/**
+ * Holder for the shared mutable {@link FileChooser} mock, allowing the test body
+ * to configure return values after the Spring context is fully built.
+ * {@code getExtensionFilters()} is pre-stubbed to return a real observable list because
+ * {@code exportLogs()} calls {@code .add()} on the returned list before invoking
+ * {@code showSaveDialog}.
+ */
+class LogViewerFileChooserHolder {
+    final FileChooser mock = mock(FileChooser.class);
+
+    LogViewerFileChooserHolder() {
+        ObservableList<FileChooser.ExtensionFilter> filters = FXCollections.observableArrayList();
+        when(mock.getExtensionFilters()).thenReturn(filters);
+    }
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                LogViewerController.class
+        })
+})
+class LogViewerControllerITConfiguration {
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public Supplier<Stage> stageSupplier() {
+        return Stage::new;
+    }
+
+    @Bean
+    public LogViewerFileChooserHolder fileChooserHolder() {
+        return new LogViewerFileChooserHolder();
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier(LogViewerFileChooserHolder holder) {
+        return () -> holder.mock;
+    }
+
+    // destroyMethod = "" prevents Spring from auto-inferring shutdown(), which would call
+    // Platform.exit() and kill the JavaFX Application Thread between test classes
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/integrationTest/java/net/transgressoft/musicott/view/StatusSignalIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/StatusSignalIT.java
@@ -1,0 +1,268 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
+import net.transgressoft.musicott.logging.RingBufferHolder;
+
+import ch.qos.logback.classic.Level;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Node;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * Integration test verifying that the per-operation WARN/ERROR delta is correctly propagated
+ * through the status signal path: a WARN-emitting M3U import yields a
+ * {@link StatusMessageUpdateEvent} with {@code warnErrorDelta > 0}, whereas a clean import
+ * yields {@code warnErrorDelta == 0}.
+ *
+ * <p>Scope: these tests exercise the mark/delta accounting and the status-signal wiring
+ * (mark captured at operation start, delta computed at completion, {@code warnErrorDelta}
+ * propagated on the event). The WARN case injects the record directly into
+ * {@code RingBufferHolder} rather than through SLF4J, because duplicate {@code logback-test.xml}
+ * resources from test-fixture JARs prevent the WARN from reaching the appender in this source set.
+ * The full SLF4J → {@code RingBufferAppender} → buffer pipeline is therefore not covered here; the
+ * ring-buffer and appender contracts are covered by their own unit tests. A true end-to-end
+ * variant depends on resolving that logback-classpath conflict.
+ */
+@JavaFxSpringTest(classes = StatusSignalITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("StatusSignal — per-operation WARN/ERROR delta")
+class StatusSignalIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    FXMusicLibrary musicLibrary;
+
+    @Autowired
+    StatusSignalITFileChooserHolder fileChooserHolder;
+
+    @Autowired
+    @SuppressWarnings("unchecked")
+    M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @BeforeEach
+    void resetBuffer() {
+        RingBufferHolder.INSTANCE.resetForTest();
+    }
+
+    @Test
+    @DisplayName("M3U import with no WARN/ERROR emits warnErrorDelta of zero")
+    void m3uImportWithNoWarnsEmitsZeroDelta(@TempDir Path tempDir) throws IOException, TimeoutException {
+        waitForFxEvents();
+
+        Path m3uFile = tempDir.resolve("CleanImport.m3u");
+        Files.writeString(m3uFile, "#EXTM3U\n");
+
+        ObservablePlaylist importedPlaylist = musicLibrary.playlistHierarchy().createPlaylist("CleanImport");
+        doReturn(CompletableFuture.completedFuture(importedPlaylist)).when(m3uImportService).importAsync(any());
+        when(fileChooserHolder.mock.showOpenDialog(any())).thenReturn(m3uFile.toFile());
+
+        // Clean import — no WARN/ERROR emitted into the ring buffer
+        NavigationController controller = navigationControllerAndView.getController();
+        controller.importPlaylistFromM3u();
+        waitForFxEvents();
+
+        verify(applicationEventPublisher).publishEvent(
+                argThat(event -> event instanceof StatusMessageUpdateEvent &&
+                        ((StatusMessageUpdateEvent) event).statusMessage.contains("CleanImport") &&
+                        ((StatusMessageUpdateEvent) event).warnErrorDelta == 0));
+    }
+
+    @Test
+    @DisplayName("M3U import with WARN emitted during the operation yields warnErrorDelta greater than zero")
+    void m3uImportWithWarnYieldsPositiveDelta(@TempDir Path tempDir) throws IOException, TimeoutException, InterruptedException {
+        waitForFxEvents();
+
+        Path m3uFile = tempDir.resolve("WarnImport.m3u");
+        Files.writeString(m3uFile, "#EXTM3U\n");
+
+        ObservablePlaylist importedPlaylist = musicLibrary.playlistHierarchy().createPlaylist("WarnImport");
+
+        // The future is a manually-completable one. The test drives it to completion only AFTER
+        // the mark has been captured inside importPlaylistFromM3u (which runs on the FX thread).
+        // This prevents a race where the WARN is logged before the mark is set.
+        CompletableFuture<ObservablePlaylist> controllableFuture = new CompletableFuture<>();
+        doReturn(controllableFuture).when(m3uImportService).importAsync(any());
+        when(fileChooserHolder.mock.showOpenDialog(any())).thenReturn(m3uFile.toFile());
+
+        NavigationController controller = navigationControllerAndView.getController();
+        controller.importPlaylistFromM3u();
+
+        // Pump the FX queue so importPlaylistFromM3u's Platform.runLater body runs, capturing the mark.
+        waitForFxEvents();
+
+        // Inject a WARN record directly into the ring buffer — the mark has already been captured,
+        // so this increments warnErrorCount within the bracketed operation window. Calling add()
+        // directly avoids a logback-classpath conflict (duplicate logback-test.xml resources from
+        // test fixture JARs) that would otherwise prevent the WARN from reaching the appender.
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft - Simulated import warning", Level.WARN);
+
+        // Complete the future with the imported playlist, triggering the whenComplete callback.
+        controllableFuture.complete(importedPlaylist);
+        waitForFxEvents();
+        waitForFxEvents();
+
+        // Poll until the event is captured by the mock before asserting
+        WaitForAsyncUtils.waitFor(3, TimeUnit.SECONDS, () ->
+                Mockito.mockingDetails(applicationEventPublisher).getInvocations().stream()
+                        .flatMap(inv -> Arrays.stream(inv.getArguments()))
+                        .anyMatch(e -> e instanceof StatusMessageUpdateEvent &&
+                                ((StatusMessageUpdateEvent) e).statusMessage.contains("WarnImport")));
+
+        verify(applicationEventPublisher).publishEvent(
+                argThat(event -> event instanceof StatusMessageUpdateEvent &&
+                        ((StatusMessageUpdateEvent) event).statusMessage.contains("WarnImport") &&
+                        ((StatusMessageUpdateEvent) event).warnErrorDelta > 0));
+    }
+}
+
+/**
+ * Holds the shared mutable {@link FileChooser} mock for {@link StatusSignalIT},
+ * allowing each test to configure its return value after the Spring context is built.
+ */
+class StatusSignalITFileChooserHolder {
+    final FileChooser mock = mock(FileChooser.class);
+}
+
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class
+        })
+})
+class StatusSignalITConfiguration {
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected it signal playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher() {
+        return mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public StatusSignalITFileChooserHolder fileChooserHolder() {
+        return new StatusSignalITFileChooserHolder();
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier(StatusSignalITFileChooserHolder holder) {
+        return () -> holder.mock;
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/PrimaryStageInitializer.java
+++ b/src/main/java/net/transgressoft/musicott/PrimaryStageInitializer.java
@@ -3,6 +3,7 @@ package net.transgressoft.musicott;
 import net.transgressoft.musicott.events.StopApplicationEvent;
 import net.transgressoft.musicott.view.EditController;
 import net.transgressoft.musicott.view.ErrorDialogController;
+import net.transgressoft.musicott.view.LogViewerController;
 import net.transgressoft.musicott.view.MainController;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 
@@ -69,10 +70,16 @@ public class PrimaryStageInitializer {
      * Pre-loads the auxiliary FXML views so their controllers and node trees are cached
      * by FxWeaver before the user can trigger them. Without this, the first error-dialog
      * raise would block on FXML parsing and node construction on the FX thread.
+     *
+     * <p>This is also the point at which each auxiliary controller's {@code @FXML} fields are
+     * injected into its Spring-managed singleton. Windows opened later purely in response to an
+     * application event (e.g. the log viewer) rely on this: without a prior {@code loadView} the
+     * controller's root node is {@code null} and building its scene fails.
      */
     private void prewarmAuxiliaryViews() {
         fxWeaver.loadView(ErrorDialogController.class);
         fxWeaver.loadView(EditController.class);
+        fxWeaver.loadView(LogViewerController.class);
     }
 
     /**

--- a/src/main/java/net/transgressoft/musicott/events/OpenLogViewerEvent.java
+++ b/src/main/java/net/transgressoft/musicott/events/OpenLogViewerEvent.java
@@ -1,0 +1,18 @@
+package net.transgressoft.musicott.events;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Published when a component requests that the log viewer window be opened.
+ *
+ * <p>Consumers must not block the publishing thread. The viewer opens asynchronously
+ * on the JavaFX Application Thread via {@code Platform.runLater}.
+ *
+ * @author Octavio Calleya
+ */
+public class OpenLogViewerEvent extends ApplicationEvent {
+
+    public OpenLogViewerEvent(Object source) {
+        super(source);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/events/StatusMessageUpdateEvent.java
+++ b/src/main/java/net/transgressoft/musicott/events/StatusMessageUpdateEvent.java
@@ -3,14 +3,60 @@ package net.transgressoft.musicott.events;
 import org.springframework.context.ApplicationEvent;
 
 /**
+ * Published whenever a component needs to update the status-bar text. Carries an optional
+ * {@link #warnErrorDelta} count so the status label can signal how many WARN/ERROR records were
+ * observed while an operation ran. A delta of {@code 0} means a clean run; a positive value
+ * drives the amber clickable status signal.
+ *
+ * <p>The delta is derived from a process-wide WARN/ERROR counter bracketed around the operation,
+ * so it is a best-effort signal rather than an exact attribution: WARN/ERROR records emitted by an
+ * unrelated thread or a concurrent operation during the same window are counted too, and the delta
+ * may over-count. It is reliable for strictly serialized operations (e.g. file/directory imports,
+ * which are mutually exclusive). Consumers should treat any positive value as "warnings or errors
+ * occurred — check the log viewer" rather than an exact per-operation total.
+ *
+ * <p>Use the two-argument constructor for intermediate progress messages or clean completions
+ * (delta defaults to {@code 0}). Use the three-argument constructor at the final completion
+ * publish point of any operation that brackets a per-operation ring-buffer mark/delta.
+ *
  * @author Octavio Calleya
  */
 public class StatusMessageUpdateEvent extends ApplicationEvent {
 
+    /** The text to display in the status bar. */
     public final String statusMessage;
 
+    /**
+     * The best-effort number of WARN or ERROR records observed in the ring buffer while the
+     * operation ran. {@code 0} means no warnings or errors were observed; a positive value drives
+     * the amber clickable status signal. May over-count under concurrent operations — see the
+     * class documentation.
+     */
+    public final int warnErrorDelta;
+
+    /**
+     * Creates a status update with no WARN/ERROR delta (clean run or intermediate progress).
+     * All existing call sites that do not bracket a per-operation mark/delta use this constructor.
+     *
+     * @param statusMessage the text to display in the status bar
+     * @param source        the object that published the event
+     */
     public StatusMessageUpdateEvent(String statusMessage, Object source) {
+        this(statusMessage, 0, source);
+    }
+
+    /**
+     * Creates a status update carrying the per-operation WARN/ERROR count. Use this at the final
+     * completion publish point of an operation that captures a ring-buffer mark at its start and
+     * computes the delta on completion.
+     *
+     * @param statusMessage  the text to display in the status bar
+     * @param warnErrorDelta non-negative count of WARN/ERROR records observed during the operation
+     * @param source         the object that published the event
+     */
+    public StatusMessageUpdateEvent(String statusMessage, int warnErrorDelta, Object source) {
         super(source);
         this.statusMessage = statusMessage;
+        this.warnErrorDelta = warnErrorDelta;
     }
 }

--- a/src/main/java/net/transgressoft/musicott/logging/RingBufferAppender.java
+++ b/src/main/java/net/transgressoft/musicott/logging/RingBufferAppender.java
@@ -1,0 +1,71 @@
+package net.transgressoft.musicott.logging;
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Logback appender that encodes each log event using a configured {@link PatternLayoutEncoder}
+ * and stores the resulting string in the shared {@link RingBufferHolder}. This class is
+ * instantiated exclusively by the logback framework via {@code logback.xml} — it must not
+ * carry any Spring stereotype annotation, as doing so would create a separate Spring-managed
+ * instance that logback never uses.
+ *
+ * <p>Thread safety: {@link AppenderBase#doAppend} holds the appender's intrinsic lock before
+ * delegating to {@link #append}, preventing concurrent logback writes through the same appender.
+ * {@link RingBufferHolder} uses its own {@link java.util.concurrent.locks.ReentrantLock} to
+ * protect the buffer from concurrent reads by the JavaFX Application Thread.
+ *
+ * @author Octavio Calleya
+ */
+public class RingBufferAppender extends AppenderBase<ILoggingEvent> {
+
+    PatternLayoutEncoder encoder;
+
+    /**
+     * Sets the encoder used to convert log events to strings. Logback resolves the nested
+     * {@code <encoder>} XML element by calling this setter during configuration.
+     *
+     * @param encoder the pattern layout encoder to use
+     */
+    public void setEncoder(PatternLayoutEncoder encoder) {
+        this.encoder = encoder;
+    }
+
+    /**
+     * Returns the currently configured encoder.
+     *
+     * @return the pattern layout encoder, or {@code null} if not yet configured
+     */
+    public PatternLayoutEncoder getEncoder() {
+        return encoder;
+    }
+
+    /**
+     * Validates the encoder is present and starts the appender. Reports a logback error and
+     * returns without starting if no encoder has been configured.
+     */
+    @Override
+    public void start() {
+        if (encoder == null) {
+            addError("No encoder set for appender [" + name + "]");
+            return;
+        }
+        super.start();
+    }
+
+    /**
+     * Encodes the log event using the configured encoder and writes the resulting UTF-8 string
+     * to {@link RingBufferHolder#INSTANCE}, passing the event level for WARN+ERROR counting.
+     *
+     * @param event the logging event to encode and store
+     */
+    @Override
+    protected void append(ILoggingEvent event) {
+        byte[] bytes = encoder.encode(event);
+        String line = new String(bytes, StandardCharsets.UTF_8);
+        RingBufferHolder.INSTANCE.add(line, event.getLevel());
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/logging/RingBufferHolder.java
+++ b/src/main/java/net/transgressoft/musicott/logging/RingBufferHolder.java
@@ -1,0 +1,207 @@
+package net.transgressoft.musicott.logging;
+
+import ch.qos.logback.classic.Level;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+/**
+ * Shared ring buffer that bridges the logback {@link RingBufferAppender} and any Spring-managed
+ * component that needs to read captured log records. The appender calls {@link #add} from logback
+ * background threads; Spring beans read the buffer from the JavaFX Application Thread.
+ *
+ * <p>Each record is stored as a {@link LogRecord} pairing the pre-encoded text with its logback
+ * {@link Level}, so consumers can filter by level without re-parsing the encoded string. The
+ * buffer is bounded at {@link #MAX_RECORDS}; the oldest record is evicted whenever the cap is
+ * reached, ensuring a deterministic memory ceiling regardless of how many log events are produced.
+ * {@link #add}, {@link #snapshot}, {@link #snapshotRecords} and {@link #attachAndSnapshot} acquire
+ * the same {@link ReentrantLock} to guarantee a consistent view across threads.
+ *
+ * <p>A monotonically increasing WARN+ERROR counter is maintained separately via an
+ * {@link AtomicLong}, so callers can read the count without acquiring the buffer lock. It supports
+ * a best-effort per-operation delta (capture the count before an operation, subtract after). The
+ * delta is reliable only for strictly serialized operations: because the counter is process-wide,
+ * any WARN/ERROR emitted by an unrelated thread or a concurrent operation during the window is
+ * attributed to whichever operation happens to be measuring, so the delta may over-count.
+ *
+ * <p>A single live-tail listener can be registered atomically together with a seed snapshot via
+ * {@link #attachAndSnapshot}. Registering the listener and copying the buffer under the same lock
+ * guarantees every record is delivered exactly once — either it is present in the returned
+ * snapshot, or it is delivered to the listener, never both and never neither. The listener is
+ * invoked on the logback appender thread, outside the buffer lock, so it must dispatch to the
+ * JavaFX Application Thread itself (e.g. via {@code Platform.runLater}).
+ *
+ * @author Octavio Calleya
+ */
+public final class RingBufferHolder {
+
+    /** Singleton instance; created once at class-load time before any Spring context. */
+    public static final RingBufferHolder INSTANCE = new RingBufferHolder();
+
+    /** Hard cap on the number of records held in the buffer. */
+    public static final int MAX_RECORDS = 5_000;
+
+    private final ArrayDeque<LogRecord> buffer = new ArrayDeque<>(MAX_RECORDS);
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private final AtomicLong warnErrorCount = new AtomicLong(0);
+
+    /**
+     * Live-tail listener called for each new record; {@code volatile} so the appender thread
+     * always sees the latest assignment without holding the buffer lock. Registered and cleared
+     * under {@link #lock} so it stays consistent with the seed snapshot returned by
+     * {@link #attachAndSnapshot}.
+     */
+    private volatile Consumer<LogRecord> liveTailListener;
+
+    private RingBufferHolder() {}
+
+    /**
+     * A single captured log record: the pre-encoded, newline-terminated text together with the
+     * logback {@link Level} of the originating event.
+     *
+     * @param text  the encoded log line, always ending in a newline
+     * @param level the logback level of the originating event
+     */
+    public record LogRecord(String text, Level level) {}
+
+    /**
+     * Appends {@code line} to the buffer, evicting the oldest record if the buffer is already
+     * at capacity. The line is normalised to end with a newline so consumers can concatenate
+     * records without depending on the encoder pattern. Increments the WARN+ERROR counter when
+     * {@code level} is WARN or higher. The live-tail listener, if registered, is invoked after
+     * the buffer lock is released.
+     *
+     * @param line  the pre-encoded log record string to store
+     * @param level the logback level of the originating event
+     */
+    public void add(String line, Level level) {
+        if (level.isGreaterOrEqual(Level.WARN)) {
+            warnErrorCount.incrementAndGet();
+        }
+        String normalised = line.endsWith("\n") ? line : line + "\n";
+        LogRecord record = new LogRecord(normalised, level);
+        Consumer<LogRecord> listener;
+        lock.lock();
+        try {
+            if (buffer.size() == MAX_RECORDS) {
+                buffer.pollFirst();
+            }
+            buffer.addLast(record);
+            listener = liveTailListener;
+        } finally {
+            lock.unlock();
+        }
+        // Invoke listener outside the lock to prevent deadlock if the FX thread
+        // attempts a snapshot() while the listener is dispatching.
+        if (listener != null) {
+            listener.accept(record);
+        }
+    }
+
+    /**
+     * Returns a point-in-time snapshot of all held record texts, ordered oldest-first.
+     * The returned list is a detached copy; mutations do not affect the buffer.
+     *
+     * @return a new list containing the encoded text of all currently buffered records
+     */
+    public List<String> snapshot() {
+        lock.lock();
+        try {
+            List<String> texts = new ArrayList<>(buffer.size());
+            for (LogRecord record : buffer) {
+                texts.add(record.text());
+            }
+            return texts;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns a point-in-time snapshot of all held records (text and level), ordered oldest-first.
+     * The returned list is a detached copy; mutations do not affect the buffer.
+     *
+     * @return a new list containing all currently buffered records
+     */
+    public List<LogRecord> snapshotRecords() {
+        lock.lock();
+        try {
+            return new ArrayList<>(buffer);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Atomically registers {@code listener} as the live-tail listener and returns a seed snapshot
+     * of the records already buffered. Because both happen under the same lock, every record is
+     * delivered exactly once: records present at registration time are in the returned snapshot
+     * and are not delivered to the listener; records added afterwards are delivered to the
+     * listener and are not in the snapshot. This closes the gap between seeding a view and
+     * subscribing to new records.
+     *
+     * @param listener the consumer to call with each new record added after registration
+     * @return a detached, oldest-first snapshot of the records buffered at registration time
+     */
+    public List<LogRecord> attachAndSnapshot(Consumer<LogRecord> listener) {
+        lock.lock();
+        try {
+            this.liveTailListener = listener;
+            return new ArrayList<>(buffer);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the cumulative count of WARN and ERROR records ever added since the buffer
+     * was created (or last reset). This value is readable without acquiring the buffer lock,
+     * making it suitable for capturing a mark before an operation and computing the delta
+     * after completion. The delta is a best-effort signal — see the class documentation for the
+     * over-counting caveat under concurrent operations.
+     *
+     * @return cumulative WARN+ERROR record count
+     */
+    public long warnErrorCount() {
+        return warnErrorCount.get();
+    }
+
+    /**
+     * Deregisters {@code listener} as the live-tail listener, but only if it is the currently
+     * registered one. The compare-and-clear avoids a later-registered listener being silently
+     * dropped by a stale caller's detach.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeLiveTailListener(Consumer<LogRecord> listener) {
+        lock.lock();
+        try {
+            if (this.liveTailListener == listener) {
+                this.liveTailListener = null;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Clears the buffer, resets the WARN+ERROR counter to zero, and deregisters any live-tail
+     * listener. Intended for test isolation only — call this in {@code @BeforeEach} to ensure a
+     * clean buffer state between tests.
+     */
+    public void resetForTest() {
+        lock.lock();
+        try {
+            buffer.clear();
+            warnErrorCount.set(0);
+            liveTailListener = null;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/services/PlayerService.java
+++ b/src/main/java/net/transgressoft/musicott/services/PlayerService.java
@@ -110,6 +110,7 @@ public class PlayerService {
 
     public void play(ObservableAudioItem audioItem) {
         if (!audioItem.getPath().toFile().exists()) {
+            logger.error("File not found: {}", audioItem.getPath());
             applicationEventPublisher.publishEvent(new ErrorEvent("File not found", audioItem.getPath().toString(), this));
             return;
         }

--- a/src/main/java/net/transgressoft/musicott/view/EditController.java
+++ b/src/main/java/net/transgressoft/musicott/view/EditController.java
@@ -201,8 +201,8 @@ public class EditController {
                 optionalImage.ifPresent(coverImage::setImage);
             }
             catch (IOException exception) {
-                applicationEventPublisher.publishEvent(new ExceptionEvent(exception, this));
                 logger.error("Error changing cover image", exception);
+                applicationEventPublisher.publishEvent(new ExceptionEvent(exception, this));
             }
         }
     }
@@ -225,8 +225,8 @@ public class EditController {
         catch (IOException exception) {
             image = Optional.empty();
             newCoverImageBytes = null;
-            applicationEventPublisher.publishEvent(new ExceptionEvent(exception, this));
             logger.error("Error trying to set image", exception);
+            applicationEventPublisher.publishEvent(new ExceptionEvent(exception, this));
         }
         return image;
     }

--- a/src/main/java/net/transgressoft/musicott/view/LogViewerController.java
+++ b/src/main/java/net/transgressoft/musicott/view/LogViewerController.java
@@ -1,0 +1,287 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.musicott.events.ErrorEvent;
+import net.transgressoft.musicott.events.OpenLogViewerEvent;
+import net.transgressoft.musicott.logging.RingBufferHolder;
+import net.transgressoft.musicott.logging.RingBufferHolder.LogRecord;
+import net.transgressoft.musicott.view.custom.ApplicationImage;
+
+import ch.qos.logback.classic.Level;
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.AnchorPane;
+import javafx.stage.FileChooser;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxmlView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Controller;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Modeless, resizable window that displays captured application log records from the
+ * {@link RingBufferHolder} ring buffer. The text area is read-only and scrollable; users can
+ * select and copy text. A level-filter combo box limits visible entries to lines at or above
+ * the chosen level (default INFO). New records appended while the window is open tail
+ * automatically into the text area via a single batched {@code Platform.runLater} per burst.
+ *
+ * <p>The window is opened by handling an {@link OpenLogViewerEvent}, allowing publishers
+ * to remain decoupled from this controller. The window is modeless — it coexists with the
+ * application's main window and the error dialog without blocking interaction.
+ *
+ * <p>Seeding the view and subscribing to new records is done atomically through
+ * {@link RingBufferHolder#attachAndSnapshot}, so no record is lost or duplicated across the
+ * open/refresh handoff. All level filtering happens on the JavaFX Application Thread, using the
+ * level stored with each record rather than re-parsing the encoded text.
+ *
+ * <p>Export writes the full current buffer snapshot to a user-chosen {@code *.log} file.
+ *
+ * @author Octavio Calleya
+ */
+@FxmlView("/fxml/LogViewerController.fxml")
+@Controller
+public class LogViewerController {
+
+    private static final List<String> LEVELS = Arrays.asList("TRACE", "DEBUG", "INFO", "WARN", "ERROR");
+
+    private final Logger logger = LoggerFactory.getLogger(getClass().getName());
+
+    @FXML
+    AnchorPane root;
+    @FXML
+    TextArea logTextArea;
+    @FXML
+    ComboBox<String> levelFilterCombo;
+    @FXML
+    Button exportButton;
+
+    private final Supplier<Stage> stageSupplier;
+    private final Supplier<FileChooser> fileChooserSupplier;
+    private final ApplicationEventPublisher eventPublisher;
+
+    Stage stage;
+
+    /**
+     * Currently selected log level filter; retained across opens (singleton controller).
+     * Read and written only on the JavaFX Application Thread.
+     */
+    String currentLevelFilter = "INFO";
+
+    /** Queue of records received from the live-tail listener, drained on the FX thread. */
+    private final ConcurrentLinkedQueue<LogRecord> pendingRecords = new ConcurrentLinkedQueue<>();
+
+    /** Guards single-flush scheduling: only one Platform.runLater per burst of records. */
+    private final AtomicBoolean flushScheduled = new AtomicBoolean(false);
+
+    /** Stable listener reference so attach and compare-and-clear detach use the same instance. */
+    private final Consumer<LogRecord> liveTailListener = this::onLiveTailRecord;
+
+    @Autowired
+    public LogViewerController(Supplier<Stage> stageSupplier,
+                                Supplier<FileChooser> fileChooserSupplier,
+                                ApplicationEventPublisher eventPublisher) {
+        this.stageSupplier = stageSupplier;
+        this.fileChooserSupplier = fileChooserSupplier;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @FXML
+    public void initialize() {
+        logTextArea.setEditable(false);
+        logTextArea.setWrapText(false);
+
+        levelFilterCombo.getItems().addAll(LEVELS);
+        levelFilterCombo.setValue(currentLevelFilter);
+        levelFilterCombo.setOnAction(e -> {
+            currentLevelFilter = levelFilterCombo.getValue();
+            // Re-seed only while showing; before the first show there is no attached listener.
+            if (stage != null && stage.isShowing()) {
+                reseed();
+            }
+        });
+
+        exportButton.setOnAction(e -> exportLogs());
+    }
+
+    /**
+     * Opens the log viewer window. If already showing, brings it to front.
+     * On open the view is seeded from the buffer and subscribed to new records atomically, so
+     * records emitted before the window was opened (including boot-time and error-dialog records)
+     * are visible on first open and no record is lost across the handoff.
+     */
+    void showWindow() {
+        if (stage == null) {
+            stage = stageSupplier.get();
+            stage.setTitle("Application Logs");
+            stage.initModality(Modality.NONE);
+            stage.setResizable(true);
+            stage.setScene(new Scene(root, 900, 600));
+            stage.getScene().getStylesheets().add("/css/logviewer.css");
+            stage.getIcons().add(ApplicationImage.APP_ICON.get());
+            stage.setOnHidden(e -> detachLiveTail());
+        }
+        if (!stage.isShowing()) {
+            reseed();
+            stage.show();
+        }
+        stage.toFront();
+    }
+
+    /**
+     * Detaches any current live-tail listener, re-registers it atomically with a fresh seed
+     * snapshot, and re-renders the text area. Used both when the window opens and when the level
+     * filter changes. Must be called on the JavaFX Application Thread.
+     */
+    private void reseed() {
+        RingBufferHolder.INSTANCE.removeLiveTailListener(liveTailListener);
+        pendingRecords.clear();
+        flushScheduled.set(false);
+        List<LogRecord> snapshot = RingBufferHolder.INSTANCE.attachAndSnapshot(liveTailListener);
+        renderFull(snapshot);
+    }
+
+    /**
+     * Replaces the text-area content with the filtered text of {@code records}.
+     * Runs on the JavaFX Application Thread.
+     */
+    private void renderFull(List<LogRecord> records) {
+        String filtered = records.stream()
+                .filter(record -> passesFilter(record.level()))
+                .map(LogRecord::text)
+                .collect(Collectors.joining());
+        logTextArea.setText(filtered);
+        logTextArea.setScrollTop(Double.MAX_VALUE);
+    }
+
+    /**
+     * Live-tail callback invoked on the logback appender thread. Enqueues the record and schedules
+     * a single FX-thread flush per burst; filtering is deferred to the flush so the level filter
+     * is only ever read on the FX thread.
+     */
+    private void onLiveTailRecord(LogRecord record) {
+        pendingRecords.offer(record);
+        if (flushScheduled.compareAndSet(false, true)) {
+            Platform.runLater(this::flushPending);
+        }
+    }
+
+    /** Drains queued records, appends those passing the current filter, and scrolls to the end. */
+    private void flushPending() {
+        flushScheduled.set(false);
+        StringBuilder sb = new StringBuilder();
+        LogRecord record;
+        while ((record = pendingRecords.poll()) != null) {
+            if (passesFilter(record.level())) {
+                sb.append(record.text());
+            }
+        }
+        if (!sb.isEmpty()) {
+            logTextArea.appendText(sb.toString());
+            trimToCapacity();
+            logTextArea.setScrollTop(Double.MAX_VALUE);
+        }
+    }
+
+    /**
+     * Trims the oldest lines from the text area so it never displays more than
+     * {@link RingBufferHolder#MAX_RECORDS} lines. The ring buffer is bounded and evicts old
+     * records, but live tailing only ever appends — without this the text area would grow without
+     * limit over a long session with the window left open.
+     */
+    private void trimToCapacity() {
+        int max = RingBufferHolder.MAX_RECORDS;
+        int paragraphs = logTextArea.getParagraphs().size();
+        if (paragraphs <= max) {
+            return;
+        }
+        String text = logTextArea.getText();
+        int excess = paragraphs - max;
+        int cut = 0;
+        for (int i = 0; i < excess; i++) {
+            int newline = text.indexOf('\n', cut);
+            if (newline < 0) {
+                cut = text.length();
+                break;
+            }
+            cut = newline + 1;
+        }
+        logTextArea.deleteText(0, cut);
+    }
+
+    /**
+     * Deregisters the live-tail listener from the ring buffer. Called when the window is hidden.
+     */
+    void detachLiveTail() {
+        RingBufferHolder.INSTANCE.removeLiveTailListener(liveTailListener);
+        pendingRecords.clear();
+        flushScheduled.set(false);
+    }
+
+    /**
+     * Opens a save dialog and writes the full current buffer snapshot to the chosen {@code *.log}
+     * file. The export writes the complete buffer, not filtered by the current level selection.
+     * If the user cancels the dialog or an I/O error occurs, no crash results.
+     */
+    void exportLogs() {
+        FileChooser chooser = fileChooserSupplier.get();
+        chooser.setTitle("Export logs");
+        chooser.setInitialFileName("musicott.log");
+        chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Log files", "*.log"));
+        File file = chooser.showSaveDialog(stage);
+        if (file != null) {
+            List<String> snapshot = RingBufferHolder.INSTANCE.snapshot();
+            String content = String.join("", snapshot);
+            try {
+                Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                logger.error("Failed to export logs to {}", file.getAbsolutePath(), e);
+                eventPublisher.publishEvent(new ErrorEvent("Export failed",
+                        "Could not write log file: " + file.getName(), this));
+            }
+        }
+    }
+
+    /**
+     * Listens for {@link OpenLogViewerEvent} and opens the log viewer window on the
+     * JavaFX Application Thread.
+     *
+     * @param event the event signalling that the viewer should be shown
+     */
+    @EventListener
+    public void openLogViewerEventListener(OpenLogViewerEvent event) {
+        Platform.runLater(this::showWindow);
+    }
+
+    /**
+     * Returns {@code true} when {@code level} is at or above the currently selected filter level.
+     * Comparison uses the record's stored logback level, so it is independent of the encoder
+     * pattern and cannot be defeated by a leading timestamp or thread token.
+     *
+     * @param level the logback level of a buffered record
+     * @return {@code true} if a record at {@code level} should be shown given the current filter
+     */
+    boolean passesFilter(Level level) {
+        if (level == null) return false;
+        Level threshold = Level.toLevel(currentLevelFilter, Level.INFO);
+        return level.isGreaterOrEqual(threshold);
+    }
+}

--- a/src/main/java/net/transgressoft/musicott/view/MainController.java
+++ b/src/main/java/net/transgressoft/musicott/view/MainController.java
@@ -674,6 +674,8 @@ public class MainController {
         @FXML
         private MenuItem showHideTableInfoPaneMenuItem;
         @FXML
+        private MenuItem showApplicationLogsMenuItem;
+        @FXML
         private Menu aboutMenu;
         @FXML
         private MenuItem aboutMenuItem;
@@ -799,6 +801,9 @@ public class MainController {
                     hideTableInfoPane();
                 }
             });
+
+            showApplicationLogsMenuItem.setOnAction(e ->
+                applicationContext.publishEvent(new OpenLogViewerEvent(this)));
         }
 
         private void bindShowHideTableInfo() {
@@ -854,6 +859,7 @@ public class MainController {
             newPlaylistFolderMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.N, operativeSystemKeyModifier, shiftDown));
             showHideNavigationPaneMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.R, operativeSystemKeyModifier, shiftDown));
             showHideTableInfoPaneMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.U, operativeSystemKeyModifier, shiftDown));
+            showApplicationLogsMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.L, operativeSystemKeyModifier, shiftDown));
             selectAllMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.A, operativeSystemKeyModifier));
             unselectMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.A, operativeSystemKeyModifier, shiftDown));
             findMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.F, operativeSystemKeyModifier));

--- a/src/main/java/net/transgressoft/musicott/view/NavigationController.java
+++ b/src/main/java/net/transgressoft/musicott/view/NavigationController.java
@@ -8,9 +8,11 @@ import net.transgressoft.commons.music.m3u.M3uImportService;
 import net.transgressoft.musicott.events.ErrorEvent;
 import net.transgressoft.musicott.events.ExportSelectedPlaylistsEvent;
 import net.transgressoft.musicott.events.ImportPlaylistsFromM3uEvent;
+import net.transgressoft.musicott.events.OpenLogViewerEvent;
 import net.transgressoft.musicott.events.SelectCurrentPlayingAudioItemEvent;
 import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
 import net.transgressoft.musicott.events.StatusProgressUpdateEvent;
+import net.transgressoft.musicott.logging.RingBufferHolder;
 import net.transgressoft.musicott.view.custom.PlaylistTreeView;
 import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
 
@@ -21,6 +23,7 @@ import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
+import javafx.scene.Cursor;
 import javafx.scene.control.*;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
@@ -89,6 +92,7 @@ public class NavigationController {
 
     private static final String GREEN_STATUS_COLOUR = "-fx-text-fill: rgb(99, 255, 109);";
     private static final String GRAY_STATUS_COLOUR = "-fx-text-fill: rgb(170, 170, 170);";
+    private static final String ORANGE_STATUS_COLOUR = "-fx-text-fill: rgb(255, 160, 50);";
 
     private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
@@ -255,11 +259,12 @@ public class NavigationController {
                 return;
             }
             List<String> failures = Collections.synchronizedList(new ArrayList<>());
+            long exportMark = RingBufferHolder.INSTANCE.warnErrorCount();
             var futures = selected.stream()
                     .map(pl -> exportPlaylistAsync(pl, folder, failures))
                     .toList();
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                    .whenComplete((ignored, ex) -> Platform.runLater(() -> publishExportOutcome(selected.size(), failures)));
+                    .whenComplete((ignored, ex) -> Platform.runLater(() -> publishExportOutcome(selected.size(), failures, exportMark)));
         });
     }
 
@@ -282,11 +287,13 @@ public class NavigationController {
         });
     }
 
-    private void publishExportOutcome(int exportedCount, List<String> failures) {
+    private void publishExportOutcome(int exportedCount, List<String> failures, long warnErrorMark) {
         if (failures.isEmpty()) {
+            int delta = (int) (RingBufferHolder.INSTANCE.warnErrorCount() - warnErrorMark);
             applicationEventPublisher.publishEvent(
-                    new StatusMessageUpdateEvent("Exported " + exportedCount + " playlist(s)", this));
+                    new StatusMessageUpdateEvent("Exported " + exportedCount + " playlist(s)", delta, this));
         } else {
+            logger.error("Playlist export failed: {}", String.join("; ", failures));
             applicationEventPublisher.publishEvent(
                     new ErrorEvent("Export failed", String.join("\n", failures), this));
         }
@@ -331,6 +338,7 @@ public class NavigationController {
             if (file == null) {
                 return;
             }
+            long m3uMark = RingBufferHolder.INSTANCE.warnErrorCount();
             m3uImportService.importAsync(file.toPath())
                     .whenComplete((playlist, ex) -> Platform.runLater(() -> {
                         if (ex != null) {
@@ -341,22 +349,32 @@ public class NavigationController {
                             musicLibrary.playlistHierarchy().addPlaylistsToDirectory(Set.of(playlist), PlaylistTreeView.ROOT_PLAYLIST_NAME);
                             // Count tracks recursively: a folder playlist's direct audioItems exclude tracks
                             // held by its nested playlists, so the total imported must span the whole subtree.
+                            int delta = (int) (RingBufferHolder.INSTANCE.warnErrorCount() - m3uMark);
                             applicationEventPublisher.publishEvent(
                                     new StatusMessageUpdateEvent(
-                                            "Imported playlist '" + playlist.getName() + "' (" + playlist.getAudioItemsRecursive().size() + " tracks)", this));
+                                            "Imported playlist '" + playlist.getName() + "' (" + playlist.getAudioItemsRecursive().size() + " tracks)", delta, this));
                         }
                     }));
         });
     }
 
     @EventListener
-    public void setStatusMessage(StatusMessageUpdateEvent statusMessageUpdateEvent) {
+    public void setStatusMessage(StatusMessageUpdateEvent event) {
         Platform.runLater(() -> {
-            if (Double.isNaN(taskProgressBar.getProgress()))
-                statusLabel.setStyle(GREEN_STATUS_COLOUR);
-            else
-                statusLabel.setStyle(GRAY_STATUS_COLOUR);
-            statusLabel.setText(String.valueOf(statusMessageUpdateEvent.statusMessage));
+            if (event.warnErrorDelta > 0) {
+                statusLabel.setStyle(ORANGE_STATUS_COLOUR);
+                statusLabel.setText(event.statusMessage + " — " + event.warnErrorDelta + " warning(s)/error(s)");
+                statusLabel.setOnMouseClicked(e -> applicationEventPublisher.publishEvent(new OpenLogViewerEvent(this)));
+                statusLabel.setCursor(Cursor.HAND);
+            } else {
+                if (Double.isNaN(taskProgressBar.getProgress()))
+                    statusLabel.setStyle(GREEN_STATUS_COLOUR);
+                else
+                    statusLabel.setStyle(GRAY_STATUS_COLOUR);
+                statusLabel.setText(String.valueOf(event.statusMessage));
+                statusLabel.setOnMouseClicked(null);
+                statusLabel.setCursor(Cursor.DEFAULT);
+            }
         });
     }
 

--- a/src/main/kotlin/net/transgressoft/musicott/MusicLibraryEventSubscriber.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/MusicLibraryEventSubscriber.kt
@@ -7,6 +7,8 @@ import net.transgressoft.commons.music.audio.AudioItemManipulationException
 import net.transgressoft.commons.music.audio.AudioMetadataIO
 import net.transgressoft.musicott.events.EditAudioItemsMetadataEvent
 import net.transgressoft.musicott.events.ExceptionEvent
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent
+import net.transgressoft.musicott.logging.RingBufferHolder
 import net.transgressoft.musicott.view.EditController.AudioItemMetadataChange
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
@@ -20,6 +22,7 @@ class MusicLibraryEventSubscriber(
 
     @EventListener
     fun editAudioItemsListener(editAudioItemsMetadataEvent: EditAudioItemsMetadataEvent) {
+        val mark = RingBufferHolder.INSTANCE.warnErrorCount()
         val change = editAudioItemsMetadataEvent.audioItemMetadataChange
         editAudioItemsMetadataEvent.audioItems.forEach { updatedAudioItem ->
             try {
@@ -30,6 +33,8 @@ class MusicLibraryEventSubscriber(
                 applicationEventPublisher.publishEvent(ExceptionEvent(exception, this))
             }
         }
+        val delta = (RingBufferHolder.INSTANCE.warnErrorCount() - mark).toInt()
+        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Metadata updated", delta, this))
     }
 
     /**

--- a/src/main/kotlin/net/transgressoft/musicott/service/MediaImportService.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/service/MediaImportService.kt
@@ -33,6 +33,7 @@ import net.transgressoft.lirp.event.LirpEventSubscription
 import net.transgressoft.musicott.events.ExceptionEvent
 import net.transgressoft.musicott.events.StatusMessageUpdateEvent
 import net.transgressoft.musicott.events.StatusProgressUpdateEvent
+import net.transgressoft.musicott.logging.RingBufferHolder
 import net.transgressoft.musicott.view.custom.alerts.AlertFactory
 import org.jetbrains.annotations.UnknownNullability
 import org.springframework.context.ApplicationEventPublisher
@@ -84,6 +85,7 @@ class MediaImportService(
     fun importFiles(filesToOpen: List<File>) {
         if (!tryStartImport()) return
 
+        val mark = RingBufferHolder.INSTANCE.warnErrorCount()
         applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Importing files...", this))
 
         val paths = filesToOpen.map(File::toPath)
@@ -97,12 +99,13 @@ class MediaImportService(
             }
 
         audioLibrary.createFromFileBatchAsync(paths)
-            .whenComplete(completeImport(progressSubscription))
+            .whenComplete(completeImport(progressSubscription, mark))
     }
 
     fun importDirectory(directory: File) {
         if (!tryStartImport()) return
 
+        val mark = RingBufferHolder.INSTANCE.warnErrorCount()
         applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Importing files...", this))
         applicationEventPublisher.publishEvent(StatusProgressUpdateEvent(-1.0, this))
 
@@ -122,11 +125,12 @@ class MediaImportService(
 
         CompletableFuture.supplyAsync { findAcceptedFiles(directory, extensions) }
             .thenCompose(audioLibrary::createFromFileBatchAsync)
-            .whenComplete(completeImport(progressSubscription))
+            .whenComplete(completeImport(progressSubscription, mark))
     }
 
     private fun completeImport(
-        progressSubscription: LirpEventSubscription<in LirpEntity, CrudEvent.Type, CrudEvent<Int, ObservableAudioItem>>):
+        progressSubscription: LirpEventSubscription<in LirpEntity, CrudEvent.Type, CrudEvent<Int, ObservableAudioItem>>,
+        mark: Long):
             BiConsumer<in @UnknownNullability List<ObservableAudioItem>, in @UnknownNullability Throwable?> =
         { _, ex ->
             progressSubscription.cancel()
@@ -134,7 +138,8 @@ class MediaImportService(
                 logger.error(ex.message, ex)
                 applicationEventPublisher.publishEvent(ExceptionEvent(ex, this))
             }
-            applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Import process completed", this))
+            val delta = (RingBufferHolder.INSTANCE.warnErrorCount() - mark).toInt()
+            applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Import process completed", delta, this))
             finishImport()
         }
 
@@ -170,6 +175,7 @@ class MediaImportService(
 
         val library = lastParsedLibrary
             ?: run { finishImport(); throw IllegalStateException("No iTunes library parsed. Call parseLibrary() first.") }
+        val mark = RingBufferHolder.INSTANCE.warnErrorCount()
         applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Importing from iTunes...", this))
 
         val future = coreItunesImportService.importAsync(
@@ -196,7 +202,8 @@ class MediaImportService(
                 } else if (result != null) {
                     alertFactory.itunesImportResultAlert(result).showAndWait()
                 }
-                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("iTunes import completed", this))
+                val delta = (RingBufferHolder.INSTANCE.warnErrorCount() - mark).toInt()
+                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("iTunes import completed", delta, this))
                 applicationEventPublisher.publishEvent(StatusProgressUpdateEvent(0.0, this))
                 finishImport()
             }

--- a/src/main/resources/css/logviewer.css
+++ b/src/main/resources/css/logviewer.css
@@ -1,0 +1,105 @@
+@import url("base.css");
+
+.root {
+    -fx-background-color: rgb(28, 28, 28);
+    -fx-font-family: "Avenir", sans-serif;
+}
+
+/* Top toolbar bar */
+.h-box {
+    -fx-background-color: rgb(40, 40, 40);
+    -fx-border-color: rgb(60, 60, 60);
+    -fx-border-width: 0 0 1 0;
+}
+
+/* Monospace log text area */
+.text-area {
+    -fx-font-family: "Monospaced", "Courier New", monospace;
+    -fx-font-size: 12px;
+    -fx-background-color: rgb(22, 22, 22);
+    -fx-text-fill: rgb(220, 220, 220);
+    -fx-control-inner-background: rgb(22, 22, 22);
+    -fx-border-color: transparent;
+}
+
+.text-area .content {
+    -fx-background-color: rgb(22, 22, 22);
+}
+
+.text-area:focused {
+    -fx-border-color: transparent;
+}
+
+/* Scrollbars — the default theme renders them invisibly against the dark text area */
+.text-area .scroll-bar:horizontal,
+.text-area .scroll-bar:vertical {
+    -fx-background-color: rgb(30, 30, 30);
+}
+
+.text-area .scroll-bar .track {
+    -fx-background-color: rgb(30, 30, 30);
+    -fx-background-radius: 0;
+}
+
+.text-area .scroll-bar .thumb {
+    -fx-background-color: rgb(90, 90, 90);
+    -fx-background-radius: 4;
+}
+
+.text-area .scroll-bar .thumb:hover {
+    -fx-background-color: rgb(120, 120, 120);
+}
+
+.text-area .scroll-bar .increment-button,
+.text-area .scroll-bar .decrement-button {
+    -fx-background-color: transparent;
+    -fx-padding: 0;
+}
+
+.text-area .scroll-bar .increment-arrow,
+.text-area .scroll-bar .decrement-arrow {
+    -fx-background-color: rgb(150, 150, 150);
+}
+
+/* Combo box */
+.combo-box {
+    -fx-background-color: rgb(55, 55, 55);
+    -fx-text-fill: white;
+}
+
+.combo-box .list-cell {
+    -fx-background-color: rgb(55, 55, 55);
+    -fx-text-fill: white;
+}
+
+.combo-box-popup .list-view {
+    -fx-background-color: rgb(50, 50, 50);
+}
+
+.combo-box-popup .list-view .list-cell {
+    -fx-background-color: rgb(50, 50, 50);
+    -fx-text-fill: white;
+}
+
+.combo-box-popup .list-view .list-cell:filled:hover {
+    -fx-background-color: rgb(73, 73, 73);
+}
+
+.combo-box-popup .list-view .list-cell:filled:selected {
+    -fx-background-color: rgb(73, 73, 73);
+}
+
+/* Export button */
+.button {
+    -fx-background-color: rgb(73, 73, 73);
+    -fx-text-fill: white;
+    -fx-font-family: "Avenir", sans-serif;
+}
+
+.button:hover {
+    -fx-background-color: rgb(100, 100, 100);
+}
+
+.button:pressed {
+    -fx-background-color: rgb(50, 50, 50);
+}

--- a/src/main/resources/fxml/LogViewerController.fxml
+++ b/src/main/resources/fxml/LogViewerController.fxml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<AnchorPane fx:id="root"
+            xmlns="http://javafx.com/javafx/10.0.1"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="net.transgressoft.musicott.view.LogViewerController">
+    <children>
+        <BorderPane AnchorPane.topAnchor="0.0"
+                    AnchorPane.bottomAnchor="0.0"
+                    AnchorPane.leftAnchor="0.0"
+                    AnchorPane.rightAnchor="0.0">
+            <top>
+                <HBox alignment="CENTER_LEFT" spacing="10.0">
+                    <padding>
+                        <Insets top="8.0" bottom="8.0" left="10.0" right="10.0"/>
+                    </padding>
+                    <Label text="Level:"/>
+                    <ComboBox fx:id="levelFilterCombo" prefWidth="100.0"/>
+                    <Button fx:id="exportButton" mnemonicParsing="false" text="Export…"/>
+                </HBox>
+            </top>
+            <center>
+                <TextArea fx:id="logTextArea"
+                          wrapText="false"
+                          editable="false"
+                          BorderPane.alignment="CENTER"/>
+            </center>
+        </BorderPane>
+    </children>
+</AnchorPane>

--- a/src/main/resources/fxml/MenuBarController.fxml
+++ b/src/main/resources/fxml/MenuBarController.fxml
@@ -43,6 +43,8 @@
             <items>
                 <MenuItem fx:id="showHideNavigationPaneMenuItem" mnemonicParsing="false" text="Hide navigation panel"/>
                 <MenuItem fx:id="showHideTableInfoPaneMenuItem" mnemonicParsing="false" text="Hide table info panel"/>
+                <SeparatorMenuItem mnemonicParsing="false"/>
+                <MenuItem fx:id="showApplicationLogsMenuItem" mnemonicParsing="false" text="Show Application Logs"/>
             </items>
         </Menu>
         <Menu fx:id="aboutMenu" mnemonicParsing="false" text="About">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,15 +2,35 @@
 <configuration>
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
+    <!-- Console stays at INFO+ even though application loggers are at DEBUG (so the in-app log
+         viewer can capture DEBUG). The ThresholdFilter keeps the terminal readable while the
+         RING_BUFFER appender still receives the full DEBUG stream. -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%-5level %logger{36} - %msg%n</pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+    </appender>
+
+    <!-- In-memory ring buffer appender — captures DEBUG+ application records for the in-app
+         log viewer. The ThresholdFilter at DEBUG allows the level filter combo to be useful.
+         Keep root at INFO so Spring and other framework loggers are not captured at DEBUG. -->
+    <appender name="RING_BUFFER" class="net.transgressoft.musicott.logging.RingBufferAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
     </appender>
 
     <logger name="org.springframework" level="INFO"/>
     <logger name="org.jaudiotagger" level="ERROR"/>
-    <logger name="net.transgressoft" level="INFO"/>
+    <!-- Lowered to DEBUG so application debug records appear in the in-app log viewer.
+         Spring and other framework loggers remain at INFO via the root logger. -->
+    <logger name="net.transgressoft" level="DEBUG"/>
     <!-- JavaFX's PrismImageLoader emits empty WARN messages via JUL when constructing
          Image instances (one per FXML <Image> + the Stage icon). Images render
          correctly — but the bridged JUL log messages have no payload. Suppress. -->
@@ -18,5 +38,6 @@
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="RING_BUFFER"/>
     </root>
 </configuration>

--- a/src/test/java/net/transgressoft/musicott/logging/RingBufferAppenderTest.java
+++ b/src/test/java/net/transgressoft/musicott/logging/RingBufferAppenderTest.java
@@ -1,0 +1,95 @@
+package net.transgressoft.musicott.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RingBufferAppender}, pinning the exact-pattern encoding contract
+ * before the production class is created.
+ */
+@DisplayName("RingBufferAppender")
+class RingBufferAppenderTest {
+
+    LoggerContext loggerContext;
+    PatternLayoutEncoder encoder;
+    RingBufferAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        RingBufferHolder.INSTANCE.resetForTest();
+
+        loggerContext = new LoggerContext();
+
+        encoder = new PatternLayoutEncoder();
+        encoder.setContext(loggerContext);
+        encoder.setPattern("%-5level %logger{36} - %msg%n");
+        encoder.start();
+
+        appender = new RingBufferAppender();
+        appender.setContext(loggerContext);
+        appender.setEncoder(encoder);
+        appender.start();
+    }
+
+    @Test
+    @DisplayName("appends INFO event encoded with exact console pattern and no timestamp or thread")
+    void appendsInfoEventEncodedWithExactConsolePatternAndNoTimestampOrThread() {
+        ch.qos.logback.classic.Logger logger = loggerContext.getLogger("net.transgressoft.test");
+        LoggingEvent event = new LoggingEvent(
+            "net.transgressoft.test",
+            logger,
+            Level.INFO,
+            "hello world",
+            null,
+            null
+        );
+
+        appender.doAppend(event);
+
+        List<String> snapshot = RingBufferHolder.INSTANCE.snapshot();
+        assertThat(snapshot).hasSize(1);
+
+        String line = snapshot.get(0);
+        // Pattern: %-5level %logger{36} - %msg%n
+        // Level left-padded to 5: "INFO " (INFO is 4 chars so it gets one trailing space)
+        assertThat(line).startsWith("INFO ");
+        assertThat(line).contains("net.transgressoft.test");
+        assertThat(line).contains(" - ");
+        assertThat(line).contains("hello world");
+        assertThat(line).endsWith("\n");
+        // No timestamp or thread token
+        assertThat(line).doesNotContainPattern("\\d{2}:\\d{2}:\\d{2}");
+        assertThat(line).doesNotContainPattern("\\[.*\\]");
+    }
+
+    @Test
+    @DisplayName("appending a WARN event increments RingBufferHolder warnErrorCount")
+    void appendingWarnEventIncrementsWarnErrorCount() {
+        long countBefore = RingBufferHolder.INSTANCE.warnErrorCount();
+
+        ch.qos.logback.classic.Logger logger = loggerContext.getLogger("net.transgressoft.test");
+        LoggingEvent event = new LoggingEvent(
+            "net.transgressoft.test",
+            logger,
+            Level.WARN,
+            "a warning message",
+            null,
+            null
+        );
+
+        appender.doAppend(event);
+
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount())
+            .as("WARN event routed through the appender must increment warnErrorCount")
+            .isEqualTo(countBefore + 1);
+    }
+}

--- a/src/test/java/net/transgressoft/musicott/logging/RingBufferHolderTest.java
+++ b/src/test/java/net/transgressoft/musicott/logging/RingBufferHolderTest.java
@@ -1,0 +1,178 @@
+package net.transgressoft.musicott.logging;
+
+import ch.qos.logback.classic.Level;
+import net.transgressoft.musicott.logging.RingBufferHolder.LogRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RingBufferHolder}, pinning the eviction cap, WARN/ERROR counter,
+ * newline normalisation, atomic seed-and-subscribe, level-carrying records, and test-isolation
+ * reset contracts.
+ */
+@DisplayName("RingBufferHolder")
+class RingBufferHolderTest {
+
+    @BeforeEach
+    void resetBuffer() {
+        RingBufferHolder.INSTANCE.resetForTest();
+    }
+
+    @Test
+    @DisplayName("evicts oldest record when buffer reaches capacity")
+    void evictsOldestRecordWhenBufferReachesCapacity() {
+        String firstLine = "INFO  net.transgressoft.first - first message\n";
+        RingBufferHolder.INSTANCE.add(firstLine, Level.INFO);
+
+        // Fill the buffer to capacity with subsequent lines
+        IntStream.rangeClosed(2, RingBufferHolder.MAX_RECORDS).forEach(i ->
+            RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.x - line " + i + "\n", Level.INFO)
+        );
+
+        assertThat(RingBufferHolder.INSTANCE.snapshot()).hasSize(RingBufferHolder.MAX_RECORDS);
+
+        // Adding one more record beyond capacity evicts the oldest
+        String newestLine = "INFO  net.transgressoft.x - newest line\n";
+        RingBufferHolder.INSTANCE.add(newestLine, Level.INFO);
+
+        List<String> snapshot = RingBufferHolder.INSTANCE.snapshot();
+        assertThat(snapshot).hasSize(RingBufferHolder.MAX_RECORDS);
+        assertThat(snapshot).doesNotContain(firstLine);
+        assertThat(snapshot.get(snapshot.size() - 1)).isEqualTo(newestLine);
+    }
+
+    @Test
+    @DisplayName("increments warn/error counter for WARN and ERROR but not DEBUG or INFO")
+    void incrementsWarnErrorCounterForWarnAndErrorButNotDebugOrInfo() {
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount()).isZero();
+
+        RingBufferHolder.INSTANCE.add("DEBUG net.transgressoft.x - debug msg\n", Level.DEBUG);
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.x - info msg\n", Level.INFO);
+
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount())
+            .as("DEBUG and INFO must not increment the warn/error counter")
+            .isZero();
+
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.x - warn msg\n", Level.WARN);
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount())
+            .as("WARN must increment the counter by 1")
+            .isEqualTo(1L);
+
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.x - error msg\n", Level.ERROR);
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount())
+            .as("ERROR must increment the counter to 2")
+            .isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("level filter snapshot returns only records at or above the requested level")
+    void levelFilterSnapshotReturnsOnlyRecordsAtOrAboveRequestedLevel() {
+        RingBufferHolder.INSTANCE.add("DEBUG net.transgressoft.x - debug line\n", Level.DEBUG);
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.x - info line\n", Level.INFO);
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.x - warn line\n", Level.WARN);
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.x - error line\n", Level.ERROR);
+
+        // Filter at WARN level: only WARN and ERROR tokens should pass
+        List<String> warnAndAbove = RingBufferHolder.INSTANCE.snapshot().stream()
+            .filter(line -> {
+                String token = line.stripLeading().split("\\s+")[0];
+                return Level.toLevel(token, Level.OFF).isGreaterOrEqual(Level.WARN);
+            })
+            .collect(Collectors.toList());
+
+        assertThat(warnAndAbove).hasSize(2);
+        assertThat(warnAndAbove).anyMatch(l -> l.contains("warn line"));
+        assertThat(warnAndAbove).anyMatch(l -> l.contains("error line"));
+        assertThat(warnAndAbove).noneMatch(l -> l.contains("debug line"));
+        assertThat(warnAndAbove).noneMatch(l -> l.contains("info line"));
+    }
+
+    @Test
+    @DisplayName("appends a trailing newline to lines that lack one")
+    void appendsTrailingNewlineToLinesThatLackOne() {
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.x - no newline", Level.WARN);
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.x - has newline\n", Level.INFO);
+
+        List<String> snapshot = RingBufferHolder.INSTANCE.snapshot();
+        assertThat(snapshot.get(0))
+            .as("a line stored without a newline is normalised to end with one")
+            .isEqualTo("WARN  net.transgressoft.x - no newline\n");
+        assertThat(snapshot.get(1))
+            .as("an already-terminated line is stored unchanged")
+            .isEqualTo("INFO  net.transgressoft.x - has newline\n");
+    }
+
+    @Test
+    @DisplayName("snapshotRecords preserves the level of each record")
+    void snapshotRecordsPreservesTheLevelOfEachRecord() {
+        RingBufferHolder.INSTANCE.add("DEBUG net.transgressoft.x - d\n", Level.DEBUG);
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.x - e\n", Level.ERROR);
+
+        List<LogRecord> records = RingBufferHolder.INSTANCE.snapshotRecords();
+        assertThat(records).hasSize(2);
+        assertThat(records.get(0).level()).isEqualTo(Level.DEBUG);
+        assertThat(records.get(1).level()).isEqualTo(Level.ERROR);
+    }
+
+    @Test
+    @DisplayName("attachAndSnapshot delivers each record exactly once across the seed handoff")
+    void attachAndSnapshotDeliversEachRecordExactlyOnceAcrossTheSeedHandoff() {
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.x - before attach\n", Level.INFO);
+
+        List<LogRecord> tailed = new ArrayList<>();
+        List<LogRecord> seed = RingBufferHolder.INSTANCE.attachAndSnapshot(tailed::add);
+
+        // The pre-existing record is in the seed snapshot and must NOT also be tailed.
+        assertThat(seed).hasSize(1);
+        assertThat(seed.get(0).text()).contains("before attach");
+        assertThat(tailed).isEmpty();
+
+        // A record added after attach is delivered to the listener and is NOT in the seed.
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.x - after attach\n", Level.WARN);
+        assertThat(tailed).hasSize(1);
+        assertThat(tailed.get(0).text()).contains("after attach");
+        assertThat(tailed.get(0).level()).isEqualTo(Level.WARN);
+    }
+
+    @Test
+    @DisplayName("removeLiveTailListener only clears the currently registered listener")
+    void removeLiveTailListenerOnlyClearsTheCurrentlyRegisteredListener() {
+        List<LogRecord> current = new ArrayList<>();
+        Consumer<LogRecord> listener = current::add;
+        RingBufferHolder.INSTANCE.attachAndSnapshot(listener);
+
+        // A stale caller trying to remove a different listener must not detach the active one.
+        RingBufferHolder.INSTANCE.removeLiveTailListener(r -> {});
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.x - still tailed\n", Level.ERROR);
+        assertThat(current).as("active listener survives a mismatched remove").hasSize(1);
+
+        // Removing the actual listener reference detaches it; no further records are tailed.
+        RingBufferHolder.INSTANCE.removeLiveTailListener(listener);
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.x - not tailed\n", Level.ERROR);
+        assertThat(current).as("listener stops receiving records once removed").hasSize(1);
+    }
+
+    @Test
+    @DisplayName("resetForTest empties the buffer and zeroes the warn/error counter")
+    void resetForTestEmptiesBufferAndZeroesCounter() {
+        RingBufferHolder.INSTANCE.add("ERROR net.transgressoft.x - some error\n", Level.ERROR);
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.x - some warning\n", Level.WARN);
+
+        assertThat(RingBufferHolder.INSTANCE.snapshot()).isNotEmpty();
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount()).isGreaterThan(0L);
+
+        RingBufferHolder.INSTANCE.resetForTest();
+
+        assertThat(RingBufferHolder.INSTANCE.snapshot()).isEmpty();
+        assertThat(RingBufferHolder.INSTANCE.warnErrorCount()).isZero();
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,10 +6,20 @@
         </encoder>
     </appender>
 
+    <appender name="RING_BUFFER" class="net.transgressoft.musicott.logging.RingBufferAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+    </appender>
+
     <logger name="org.springframework" level="INFO"/>
-    <logger name="net.transgressoft" level="INFO"/>
+    <logger name="net.transgressoft" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="RING_BUFFER"/>
     </root>
 </configuration>

--- a/src/testFixtures/java/net/transgressoft/musicott/test/ApplicationTestBase.java
+++ b/src/testFixtures/java/net/transgressoft/musicott/test/ApplicationTestBase.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -12,6 +13,7 @@ import org.testfx.api.FxToolkit;
 import org.testfx.framework.junit5.ApplicationTest;
 import org.testfx.util.WaitForAsyncUtils;
 
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -65,6 +67,32 @@ public abstract class ApplicationTestBase<T extends Parent> extends ApplicationT
     }
 
     protected abstract T javaFxComponent();
+
+    /**
+     * Polls the open windows for up to five seconds for a showing {@link Stage} whose title
+     * matches {@code title}, pumping the FX event queue between polls. Returns the stage once it
+     * appears, or {@code null} if it never shows within the deadline.
+     *
+     * @param title the exact stage title to match
+     * @return the matching showing stage, or {@code null} if none appears within the deadline
+     */
+    protected Stage waitForDialogStage(String title) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
+        while (System.currentTimeMillis() < deadline) {
+            waitForFxEvents();
+            Optional<Stage> match = Window.getWindows().stream()
+                    .filter(Stage.class::isInstance)
+                    .map(Stage.class::cast)
+                    .filter(s -> title.equals(s.getTitle()))
+                    .filter(Stage::isShowing)
+                    .findFirst();
+            if (match.isPresent()) {
+                return match.get();
+            }
+            Thread.sleep(50);
+        }
+        return null;
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/uiTest/java/net/transgressoft/musicott/view/LogViewerWindowUIT.java
+++ b/src/uiTest/java/net/transgressoft/musicott/view/LogViewerWindowUIT.java
@@ -1,0 +1,269 @@
+package net.transgressoft.musicott.view;
+
+import net.transgressoft.commons.fx.music.FXMusicLibrary;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioItem;
+import net.transgressoft.commons.fx.music.audio.ObservableAudioLibrary;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylist;
+import net.transgressoft.commons.fx.music.playlist.ObservablePlaylistHierarchy;
+import net.transgressoft.commons.music.m3u.M3uImportService;
+import net.transgressoft.musicott.events.StatusMessageUpdateEvent;
+import net.transgressoft.musicott.logging.RingBufferHolder;
+import net.transgressoft.musicott.test.ApplicationTestBase;
+import net.transgressoft.musicott.test.JavaFxSpringTest;
+import net.transgressoft.musicott.test.JavaFxSpringTestConfiguration;
+import net.transgressoft.musicott.view.custom.PlaylistTreeView;
+import net.transgressoft.musicott.view.custom.alerts.AlertFactory;
+
+import ch.qos.logback.classic.Level;
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.scene.Node;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+import net.rgielen.fxweaver.core.FxControllerAndView;
+import net.rgielen.fxweaver.core.FxWeaver;
+import net.rgielen.fxweaver.spring.InjectionPointLazyFxControllerAndViewResolver;
+import net.rgielen.fxweaver.spring.SpringFxWeaver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Scope;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testfx.api.FxRobot;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.springframework.context.annotation.ComponentScan.Filter;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+/**
+ * UI test proving the end-to-end flow where a warning status signal in the navigation bar
+ * opens the "Application Logs" window. When a completed operation produces warnings or errors,
+ * the status label turns amber and becomes clickable; clicking it publishes
+ * {@link net.transgressoft.musicott.events.OpenLogViewerEvent} which the
+ * {@link LogViewerController} handles to open the viewer stage.
+ *
+ * @author Octavio Calleya
+ */
+@JavaFxSpringTest(classes = LogViewerWindowUITConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("Application log viewer window")
+class LogViewerWindowUIT extends ApplicationTestBase<VBox> {
+
+    @Autowired
+    FxControllerAndView<NavigationController, VBox> navigationControllerAndView;
+
+    @Autowired
+    FxControllerAndView<LogViewerController, ?> logViewerControllerAndView;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    protected VBox javaFxComponent() {
+        return navigationControllerAndView.getView().get();
+    }
+
+    @Override
+    @BeforeEach
+    protected void beforeEach() {
+        RingBufferHolder.INSTANCE.resetForTest();
+        // Trigger FXML loading for LogViewerController before any test interacts with it.
+        // The FxControllerAndView is prototype-scoped and lazy; accessing the controller here
+        // causes FxWeaver to load the FXML and inject @FXML fields into the singleton @Controller
+        // bean, so showWindow() can construct the Scene without a NullPointerException on root.
+        logViewerControllerAndView.getController();
+        super.beforeEach();
+    }
+
+    @AfterEach
+    void closeLogViewerStage() {
+        LogViewerController controller = logViewerControllerAndView.getController();
+        Platform.runLater(() -> {
+            if (controller.stage != null && controller.stage.isShowing()) {
+                controller.stage.hide();
+            }
+            controller.stage = null;
+        });
+        waitForFxEvents();
+    }
+
+    @Test
+    @DisplayName("clicking the amber warning status label opens the Application Logs window")
+    void clickingAmberWarningLabelOpensLogViewerWindow(FxRobot fxRobot) throws Exception {
+        waitForFxEvents();
+
+        // Add a WARN record so the amber signal can appear when a completion event is published
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.test - import warning\n", Level.WARN);
+
+        // Drive setStatusMessage directly on the NavigationController to set the amber state —
+        // this avoids the Spring event dispatch indirection and makes the test deterministic.
+        NavigationController navController = navigationControllerAndView.getController();
+        StatusMessageUpdateEvent warnEvent = new StatusMessageUpdateEvent("Import finished", 1, this);
+        // setStatusMessage internally calls Platform.runLater; call it from the test thread so
+        // the outer scheduling + the inner label update both drain within two waitForFxEvents pumps.
+        navController.setStatusMessage(warnEvent);
+        // First pump: schedules the inner Platform.runLater inside setStatusMessage.
+        waitForFxEvents();
+        // Second pump: executes the inner Platform.runLater that updates statusLabel style.
+        waitForFxEvents();
+
+        // Find the amber status label by its fx:id via the NavigationController's scene
+        Label statusLabel = (Label) navigationControllerAndView.getView().get().lookup("#statusLabel");
+        assertThat(statusLabel).as("amber status label").isNotNull();
+        assertThat(statusLabel.getStyle()).as("amber style").contains("255, 160, 50");
+        assertThat(statusLabel.getText()).contains("warning");
+
+        fxRobot.clickOn(statusLabel);
+        waitForFxEvents();
+
+        // Poll for the Application Logs stage to appear
+        Stage logStage = waitForDialogStage("Application Logs");
+        assertThat(logStage).as("Application Logs stage").isNotNull();
+        assertThat(logStage.isShowing()).isTrue();
+
+        // Verify the viewer's controls are rendered inside the opened stage
+        TextArea textArea = (TextArea) logStage.getScene().getRoot().lookup(".text-area");
+        assertThat(textArea).as("log text area").isNotNull();
+        assertThat(textArea.isEditable()).isFalse();
+
+        @SuppressWarnings("unchecked")
+        ComboBox<String> levelCombo = (ComboBox<String>) logStage.getScene().getRoot().lookup(".combo-box");
+        assertThat(levelCombo).as("level filter combo").isNotNull();
+        assertThat(levelCombo.getItems()).containsExactly("TRACE", "DEBUG", "INFO", "WARN", "ERROR");
+    }
+
+    @Test
+    @DisplayName("opening log viewer via menu item shows the Application Logs window with log content")
+    void openingLogViewerViaEventShowsWindowWithContent(FxRobot fxRobot) throws Exception {
+        waitForFxEvents();
+
+        // Pre-populate the buffer so there is content to show when the window opens
+        RingBufferHolder.INSTANCE.add("INFO  net.transgressoft.test - application started\n", Level.INFO);
+        RingBufferHolder.INSTANCE.add("WARN  net.transgressoft.test - configuration warning\n", Level.WARN);
+
+        // Open the viewer directly via the event (same path as the menu item)
+        LogViewerController controller = logViewerControllerAndView.getController();
+        Platform.runLater(controller::showWindow);
+        waitForFxEvents();
+
+        Stage logStage = waitForDialogStage("Application Logs");
+        assertThat(logStage).as("Application Logs stage").isNotNull();
+        assertThat(logStage.isShowing()).isTrue();
+
+        // The text area should show the pre-open buffer content at INFO+ level
+        TextArea textArea = (TextArea) logStage.getScene().getRoot().lookup(".text-area");
+        assertThat(textArea).isNotNull();
+        assertThat(textArea.getText()).contains("application started");
+        assertThat(textArea.getText()).contains("configuration warning");
+    }
+
+}
+
+/**
+ * Spring test configuration for {@link LogViewerWindowUIT}. Mounts both
+ * {@link NavigationController} (which owns the amber status label and publishes
+ * {@link net.transgressoft.musicott.events.OpenLogViewerEvent} on click) and
+ * {@link LogViewerController} (which handles that event and opens the viewer stage).
+ * Both beans must be in the same application context for the event listener to fire.
+ */
+@JavaFxSpringTestConfiguration(includeFilters = {
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                NavigationController.class,
+                PlaylistTreeView.class,
+                LogViewerController.class
+        })
+})
+class LogViewerWindowUITConfiguration {
+
+    @Bean
+    public FXMusicLibrary musicLibrary() {
+        return FXMusicLibrary.builder().build();
+    }
+
+    @Bean
+    public ObservablePlaylistHierarchy playlistRepository(FXMusicLibrary musicLibrary) {
+        var repository = musicLibrary.playlistHierarchy();
+        repository.createPlaylistDirectory("ROOT_PLAYLIST");
+        return repository;
+    }
+
+    @Bean
+    public ObjectProperty<Optional<ObservablePlaylist>> selectedPlaylistProperty() {
+        return new SimpleObjectProperty<>(this, "selected log viewer uit playlist", Optional.empty());
+    }
+
+    @Bean
+    public ObservableAudioLibrary audioRepository() {
+        return mock(ObservableAudioLibrary.class);
+    }
+
+    @Bean
+    public ApplicationEventPublisher applicationEventPublisher(ConfigurableApplicationContext applicationContext) {
+        // Delegate to the real context publisher so @EventListener on LogViewerController fires
+        // when NavigationController's amber label click publishes OpenLogViewerEvent.
+        // Wrapping avoids Spring trying to stop/destroy the context itself as a Lifecycle bean.
+        return applicationContext::publishEvent;
+    }
+
+    @Bean
+    public AlertFactory alertFactory() {
+        return mock(AlertFactory.class);
+    }
+
+    @Bean
+    public Supplier<DirectoryChooser> directoryChooserSupplier() {
+        return () -> mock(DirectoryChooser.class);
+    }
+
+    @Bean
+    public Supplier<FileChooser> fileChooserSupplier() {
+        return () -> mock(FileChooser.class);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService() {
+        return mock(M3uImportService.class);
+    }
+
+    @Bean
+    public KeyCombination.Modifier operativeSystemKeyModifier() {
+        return KeyCombination.CONTROL_DOWN;
+    }
+
+    @Bean
+    public Supplier<Stage> stageSupplier() {
+        return Stage::new;
+    }
+
+    @Bean(destroyMethod = "")
+    public FxWeaver fxWeaver(ConfigurableApplicationContext applicationContext) {
+        return new SpringFxWeaver(applicationContext);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public <C, V extends Node> FxControllerAndView<C, V> controllerAndView(FxWeaver fxWeaver, InjectionPoint injectionPoint) {
+        return new InjectionPointLazyFxControllerAndViewResolver(fxWeaver).resolve(injectionPoint);
+    }
+}


### PR DESCRIPTION
Closes #77.

Adds a resizable, modeless window (View → Show Application Logs) that displays captured application log records, so users can inspect what happened without leaving the app.

## What it does
- **Log capture** — a bounded (5,000-record) in-memory ring buffer fed by a custom logback appender captures `DEBUG`+ application records from boot. Each record keeps its level so filtering is exact.
- **Viewer window** — read-only, selectable, scrollable text area with a level-filter combo (`TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`, default `INFO`), live tailing of new records while open, and an export button that writes the held buffer to a chosen `*.log` file. Modeless, so it coexists with the main window and the error dialog.
- **Actionable status signal** — when a completed operation (import, export, metadata edit, …) produced WARN/ERROR records, the status label turns into a clickable amber "… — N warning(s)" that opens the viewer; clean runs keep the existing success message. Every error shown in the error dialog is also guaranteed to be in the buffer, making the viewer a complete record.
- **Console stays readable** — the console appender is filtered to `INFO`+ while the ring buffer captures `DEBUG`+.

## Notes
- The WARN/ERROR delta on the status label is a best-effort signal derived from a process-wide counter: it is exact for serialized operations (imports) but may over-count if unrelated logging overlaps. Documented on `StatusMessageUpdateEvent`.
- New `@FxmlView` windows opened via an application event must be prewarmed in `PrimaryStageInitializer` so their `@FXML` fields are injected; `LogViewerController` is prewarmed alongside the error-dialog and edit windows.

## Testing
- Full `gradle build` green across all four source sets (unit, integration, UI, e2e).
- Coverage added: ring-buffer/appender unit tests (eviction, counter, newline normalisation, atomic seed-and-subscribe, level-carrying records), `LogViewerControllerIT` (open/filter/export/pre-open capture/live-tail), `StatusSignalIT`, `LogViewerWindowUIT`, and `PrimaryStageInitializerIT` (auxiliary-view prewarm contract).

## Follow-ups (filed separately)
- octaviospain/music-commons#193 — right-size log levels (per-entity `created…` records → TRACE) and add missing diagnostic logs.
- #81 — same logging audit within this repo.
- #82 — redesign status/progress messaging (single status label is too small for longer text); explore ControlsFX `Notifications` + `NotificationPane` and alternatives.