### PR TITLE
#89 Fix version shown in splash and About windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,15 +103,22 @@ scmVersion {
 }
 
 group = 'net.transgressoft'
-version = scmVersion.version
+// The release CI (and the AUR PKGBUILD) pass -PreleaseVersion so the reported version is the exact
+// release version. Git-less builds (source tarballs) can't resolve a tag, so without this override
+// scmVersion falls back to a '<next>-<branch>-SNAPSHOT' string. Local/dev builds omit the property.
+version = project.findProperty('releaseVersion') ?: scmVersion.version
 description = 'musicott'
 
-// Generate META-INF/build-info.properties at build time so Spring's BuildProperties
-// bean is autoconfigured. AboutWindowAlert reads buildProperties.getVersion() to
-// display the runtime version (sourced from scmVersion.version above) instead of
-// a hardcoded literal.
+// Generate META-INF/build-info.properties at build time. BuildVersionReader reads its build.version
+// to show the runtime version on the splash and About screens. The version is bound explicitly
+// (evaluated now) rather than via buildInfo()'s default lazy provider, which axion-release re-resolves
+// to its own SNAPSHOT string and would ignore the -PreleaseVersion override.
 springBoot {
-    buildInfo()
+    buildInfo {
+        properties {
+            version = (project.findProperty('releaseVersion') ?: project.version).toString()
+        }
+    }
 }
 
 // Stabilise transitive kotlinx versions — Spring Boot's kotlin BOM and music-commons can

--- a/src/integrationTest/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlertIT.java
+++ b/src/integrationTest/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlertIT.java
@@ -21,17 +21,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
 import org.testfx.api.FxRobot;
 
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -41,7 +37,8 @@ import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
  * Integration test verifying the full rendered state of {@link AboutWindowAlert}: the logo
  * sits on top of a FlowPane carrying the version line, GitHub hyperlink, and license line; no
  * stray "Message" content-text label leaks from {@link Alert.AlertType#INFORMATION}; the version
- * string is sourced from Spring's {@link BuildProperties} bean; and the dialog window carries
+ * string is rendered from the value supplied to the alert (in production this comes from
+ * {@link net.transgressoft.musicott.splash.BuildVersionReader}); and the dialog window carries
  * the application icon.
  */
 @JavaFxSpringTest(classes = AboutWindowAlertITConfiguration.class)
@@ -49,7 +46,7 @@ import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
 class AboutWindowAlertIT extends ApplicationTestBase<Pane> {
 
     @Autowired
-    AlertFactory alertFactory;
+    SimpleWebRedirectionService webRedirectionService;
 
     Alert aboutAlert;
 
@@ -65,7 +62,9 @@ class AboutWindowAlertIT extends ApplicationTestBase<Pane> {
     protected void beforeEach() {
         super.beforeEach();
         Platform.runLater(() -> {
-            aboutAlert = (Alert) alertFactory.aboutWindowAlert();
+            // Construct directly with a fixed version so the rendered version line is deterministic;
+            // production sources this from BuildVersionReader.read(), exercised by SplashVersionIT.
+            aboutAlert = new AboutWindowAlert(webRedirectionService, "1.0.0-test");
             aboutAlert.initOwner(testStage);
             aboutAlert.show();
         });
@@ -146,21 +145,5 @@ class AboutWindowAlertITConfiguration {
         // under headless TestFX. The IT never clicks the hyperlink, so a Mockito mock is sufficient.
         // Pattern precedent: ErrorDialogControllerTest.java.
         return mock(SimpleWebRedirectionService.class);
-    }
-
-    @Bean
-    BuildProperties buildProperties() {
-        Properties props = new Properties();
-        props.setProperty("group", "net.transgressoft");
-        props.setProperty("artifact", "musicott");
-        props.setProperty("name", "musicott");
-        props.setProperty("version", "1.0.0-test");
-        return new BuildProperties(props);
-    }
-
-    @Bean
-    AlertFactory alertFactory(SimpleWebRedirectionService webRedirectionService,
-                              ObjectProvider<BuildProperties> buildPropertiesProvider) {
-        return new AlertFactory(webRedirectionService, buildPropertiesProvider);
     }
 }

--- a/src/main/java/net/transgressoft/musicott/logging/RingBufferHolder.java
+++ b/src/main/java/net/transgressoft/musicott/logging/RingBufferHolder.java
@@ -6,6 +6,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
@@ -51,14 +52,16 @@ public final class RingBufferHolder {
     private final AtomicLong warnErrorCount = new AtomicLong(0);
 
     /**
-     * Live-tail listener called for each new record; {@code volatile} so the appender thread
-     * always sees the latest assignment without holding the buffer lock. Registered and cleared
-     * under {@link #lock} so it stays consistent with the seed snapshot returned by
-     * {@link #attachAndSnapshot}.
+     * Live-tail listener called for each new record, held in an {@link AtomicReference} for safe
+     * reference publication across threads. Every access happens under {@link #lock}, which provides
+     * the visibility and atomicity: {@link #add} reads the reference under the lock so it stays
+     * consistent with the seed snapshot returned by {@link #attachAndSnapshot}, then invokes the
+     * listener outside the lock to avoid deadlocking with a concurrent registration.
      */
-    private volatile Consumer<LogRecord> liveTailListener;
+    private final AtomicReference<Consumer<LogRecord>> liveTailListener = new AtomicReference<>();
 
-    private RingBufferHolder() {}
+    private RingBufferHolder() {
+    }
 
     /**
      * A single captured log record: the pre-encoded, newline-terminated text together with the
@@ -67,7 +70,8 @@ public final class RingBufferHolder {
      * @param text  the encoded log line, always ending in a newline
      * @param level the logback level of the originating event
      */
-    public record LogRecord(String text, Level level) {}
+    public record LogRecord(String text, Level level) {
+    }
 
     /**
      * Appends {@code line} to the buffer, evicting the oldest record if the buffer is already
@@ -84,22 +88,22 @@ public final class RingBufferHolder {
             warnErrorCount.incrementAndGet();
         }
         String normalised = line.endsWith("\n") ? line : line + "\n";
-        LogRecord record = new LogRecord(normalised, level);
+        LogRecord logRecord = new LogRecord(normalised, level);
         Consumer<LogRecord> listener;
         lock.lock();
         try {
             if (buffer.size() == MAX_RECORDS) {
                 buffer.pollFirst();
             }
-            buffer.addLast(record);
-            listener = liveTailListener;
+            buffer.addLast(logRecord);
+            listener = liveTailListener.get();
         } finally {
             lock.unlock();
         }
         // Invoke listener outside the lock to prevent deadlock if the FX thread
         // attempts a snapshot() while the listener is dispatching.
         if (listener != null) {
-            listener.accept(record);
+            listener.accept(logRecord);
         }
     }
 
@@ -113,8 +117,8 @@ public final class RingBufferHolder {
         lock.lock();
         try {
             List<String> texts = new ArrayList<>(buffer.size());
-            for (LogRecord record : buffer) {
-                texts.add(record.text());
+            for (LogRecord logRecord : buffer) {
+                texts.add(logRecord.text());
             }
             return texts;
         } finally {
@@ -151,7 +155,7 @@ public final class RingBufferHolder {
     public List<LogRecord> attachAndSnapshot(Consumer<LogRecord> listener) {
         lock.lock();
         try {
-            this.liveTailListener = listener;
+            this.liveTailListener.set(listener);
             return new ArrayList<>(buffer);
         } finally {
             lock.unlock();
@@ -181,9 +185,7 @@ public final class RingBufferHolder {
     public void removeLiveTailListener(Consumer<LogRecord> listener) {
         lock.lock();
         try {
-            if (this.liveTailListener == listener) {
-                this.liveTailListener = null;
-            }
+            this.liveTailListener.compareAndSet(listener, null);
         } finally {
             lock.unlock();
         }
@@ -199,7 +201,7 @@ public final class RingBufferHolder {
         try {
             buffer.clear();
             warnErrorCount.set(0);
-            liveTailListener = null;
+            liveTailListener.set(null);
         } finally {
             lock.unlock();
         }

--- a/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
+++ b/src/main/java/net/transgressoft/musicott/view/ArtistViewController.java
@@ -98,7 +98,7 @@ public class ArtistViewController implements Searchable<String> {
 
     @Autowired
     public ArtistViewController(ObservableAudioLibrary audioLibrary, ApplicationContext applicationContext,
-                                SearchCoordinator searchCoordinator) {
+            SearchCoordinator searchCoordinator) {
         this.audioRepository = audioLibrary;
         this.applicationContext = applicationContext;
         this.searchCoordinator = searchCoordinator;
@@ -111,9 +111,10 @@ public class ArtistViewController implements Searchable<String> {
         artistRandomButton.visibleProperty().bind(map(nameLabel.textProperty().isEmpty().not(), Function.identity()));
         artistRandomButton.setOnAction(_ -> applicationContext.publishEvent(new PlayRandomFromContextEvent(this)));
         selectedArtistProperty = new SimpleObjectProperty<>(this, "selected artist", Optional.empty());
-        nameLabel.textProperty().bind(Bindings.createStringBinding(() ->
-                        selectedArtistProperty.get().isPresent() ? selectedArtistProperty.get().get().getArtistName() : "",
-                selectedArtistProperty));
+        nameLabel.textProperty()
+                .bind(Bindings.createStringBinding(
+                        () -> selectedArtistProperty.get().isPresent() ? selectedArtistProperty.get().get().getArtistName() : "",
+                        selectedArtistProperty));
 
         searchCoordinator.register(NavigationMode.ARTISTS, this);
 
@@ -175,11 +176,11 @@ public class ArtistViewController implements Searchable<String> {
     // method reference to bind; narrowing to the final `Artist` type breaks compilation.
     @SuppressWarnings("java:S4968")
     private void selectedArtistListener(ObservableValue<? extends ObservableArtistCatalog> obs,
-                                        ObservableArtistCatalog oldArtistCatalog,
-                                        ObservableArtistCatalog newArtistCatalog) {
+            ObservableArtistCatalog oldArtistCatalog,
+            ObservableArtistCatalog newArtistCatalog) {
         if (newArtistCatalog != null) {
             // if the selected artistCatalog is not already selected
-            if (! nameLabel.getText().equals(newArtistCatalog.getArtistName())) {
+            if (!nameLabel.getText().equals(newArtistCatalog.getArtistName())) {
                 selectedArtistProperty.set(Optional.of(newArtistCatalog));
                 refreshAlbumRowsForArtist(newArtistCatalog.getArtist());
             }
@@ -201,6 +202,10 @@ public class ArtistViewController implements Searchable<String> {
         }
     }
 
+    // Defensive null guard on artist.getName(): Sonar trusts the music-commons API's nominal non-null
+    // type and flags the guard as always-true, but imported/partial catalogs can carry a null name and
+    // one such artist must not NPE the search filter. Same rationale as AudioItemTableViewBase.
+    @SuppressWarnings("java:S2589")
     private void replaceAlbumRowsForArtist(Artist artist, Map<AlbumTrackGroup, Integer> albumSetsWithDisc) {
         albumListRowMap.clear();
         albumRowsBackingList.clear();
@@ -225,8 +230,7 @@ public class ArtistViewController implements Searchable<String> {
                 filteredAlbumRows.setPredicate(null);
             } else {
                 // Artist matched only via track content: filter each row to matching tracks only
-                albumRowsBackingList.forEach(row ->
-                        row.filterTracks(item -> audioItemMatchesQuery(item, q)));
+                albumRowsBackingList.forEach(row -> row.filterTracks(item -> audioItemMatchesQuery(item, q)));
                 filteredAlbumRows.setPredicate(row -> row.hasTracksMatching(item -> audioItemMatchesQuery(item, q)));
             }
         }
@@ -276,13 +280,13 @@ public class ArtistViewController implements Searchable<String> {
 
         // Build result map preserving TreeMap order: album group → disc number (0 = no label)
         var result = new LinkedHashMap<AlbumTrackGroup, Integer>();
-        grouped.forEach((key, items) ->
-                result.put(new AlbumTrackGroup(key.albumName(), items), key.disc()));
+        grouped.forEach((key, items) -> result.put(new AlbumTrackGroup(key.albumName(), items), key.disc()));
         return result;
     }
 
     private static int normalizeDisc(Number discNumber) {
-        if (discNumber == null) return 1;
+        if (discNumber == null)
+            return 1;
         int v = discNumber.intValue();
         return v <= 0 ? 1 : v;
     }
@@ -337,8 +341,8 @@ public class ArtistViewController implements Searchable<String> {
 
     private String getTotalArtistTracksString() {
         int totalArtistTracks = albumRowsBackingList.stream()
-            .mapToInt(trackSet -> trackSet.containedAudioItemsProperty().size())
-            .sum();
+                .mapToInt(trackSet -> trackSet.containedAudioItemsProperty().size())
+                .sum();
         String appendix = totalArtistTracks == 1 ? " track" : " tracks";
         return totalArtistTracks + appendix;
     }
@@ -372,8 +376,8 @@ public class ArtistViewController implements Searchable<String> {
 
     public ObservableList<ObservableAudioItem> getSelectedTracks() {
         return albumRowsBackingList.stream()
-            .flatMap(entry -> entry.selectedAudioItemsProperty().stream())
-            .collect(toCollection(FXCollections::observableArrayList));
+                .flatMap(entry -> entry.selectedAudioItemsProperty().stream())
+                .collect(toCollection(FXCollections::observableArrayList));
     }
 
     public void findAudioItemInArtistViewAndSelect(ObservableAudioItem audioItem) {
@@ -381,8 +385,9 @@ public class ArtistViewController implements Searchable<String> {
         Optional<ObservableArtistCatalog> selectedArtistCatalog = selectedArtistProperty.getValue();
         if (selectedArtistCatalog.isPresent() && !artistsInvolved.contains(selectedArtistCatalog.get().getArtist())) {
             var newArtist = artistsInvolved.stream().findFirst()
-                .orElseThrow(() -> new IllegalStateException("AudioItem has no artists"));
-            Optional<ObservableArtistCatalog> artistCatalog = (Optional<ObservableArtistCatalog>) audioRepository.getArtistCatalog(newArtist);
+                    .orElseThrow(() -> new IllegalStateException("AudioItem has no artists"));
+            Optional<ObservableArtistCatalog> artistCatalog = (Optional<ObservableArtistCatalog>) audioRepository
+                    .getArtistCatalog(newArtist);
             selectedArtistProperty.setValue(artistCatalog);
             artistCatalog.ifPresent(catalog -> {
                 artistsListView.getSelectionModel().select(catalog);

--- a/src/main/java/net/transgressoft/musicott/view/EditController.java
+++ b/src/main/java/net/transgressoft/musicott/view/EditController.java
@@ -45,11 +45,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-
 /**
  * @author Octavio Calleya
  */
-@FxmlView ("/fxml/EditController.fxml")
+@FxmlView("/fxml/EditController.fxml")
 @Controller
 public class EditController {
 
@@ -162,7 +161,7 @@ public class EditController {
 
     private void setNumericValidationFilters() {
         EventHandler<KeyEvent> nonNumericFilter = event -> {
-            if (! event.getCharacter().matches("\\d"))
+            if (!event.getCharacter().matches("\\d"))
                 event.consume();
         };
         trackNumTextField.addEventFilter(KeyEvent.KEY_TYPED, nonNumericFilter);
@@ -191,7 +190,8 @@ public class EditController {
         logger.debug("Choosing cover image");
         FileChooser chooser = new FileChooser();
         chooser.setTitle("Open file(s)...");
-        FileChooser.ExtensionFilter filter = new FileChooser.ExtensionFilter("Image files (*.png, *.jpg, *.jpeg)", "*.png", "*.jpg", "*.jpeg");
+        FileChooser.ExtensionFilter filter = new FileChooser.ExtensionFilter("Image files (*.png, *.jpg, *.jpeg)", "*.png", "*.jpg",
+                "*.jpeg");
         chooser.getExtensionFilters().addAll(filter);
         File newCoverImageFile = chooser.showOpenDialog(stage);
         if (newCoverImageFile != null) {
@@ -199,8 +199,7 @@ public class EditController {
                 newCoverImageBytes = Files.readAllBytes(Paths.get(newCoverImageFile.getPath()));
                 Optional<Image> optionalImage = Optional.of(new Image(new ByteArrayInputStream(newCoverImageBytes)));
                 optionalImage.ifPresent(coverImage::setImage);
-            }
-            catch (IOException exception) {
+            } catch (IOException exception) {
                 logger.error("Error changing cover image", exception);
                 applicationEventPublisher.publishEvent(new ExceptionEvent(exception, this));
             }
@@ -221,8 +220,7 @@ public class EditController {
         try {
             newCoverImageBytes = Files.readAllBytes(Paths.get(draggedImage.getPath()));
             image = Optional.of(new Image(new ByteArrayInputStream(newCoverImageBytes)));
-        }
-        catch (IOException exception) {
+        } catch (IOException exception) {
             image = Optional.empty();
             newCoverImageBytes = null;
             logger.error("Error trying to set image", exception);
@@ -270,10 +268,10 @@ public class EditController {
     @EventListener
     public void editAudioItemsEventListener(OpenAudioItemEditorView event) {
         List<ObservableAudioItem> invalidAudioItems = event.audioItems.stream()
-            .filter(track -> ! track.getPath().toFile().exists())
-            .toList();
+                .filter(track -> !track.getPath().toFile().exists())
+                .toList();
 
-        if (! invalidAudioItems.isEmpty())
+        if (!invalidAudioItems.isEmpty())
             applicationEventPublisher.publishEvent(new InvalidAudioItemsForEditionEvent(invalidAudioItems, this));
         else
             editAudioItems(event.audioItems);
@@ -286,7 +284,7 @@ public class EditController {
      * @param audioItemSelection The audio items to edit
      */
     public void editAudioItems(Set<ObservableAudioItem> audioItemSelection) {
-        if (! audioItemSelection.isEmpty()) {
+        if (!audioItemSelection.isEmpty()) {
             this.audioItemSelection = audioItemSelection;
             if (audioItemSelection.size() > 1) {
                 if (multipleEditionConfirmationAlert == null) {
@@ -333,11 +331,15 @@ public class EditController {
         newCoverImageBytes = null;
 
         titleTextField.textProperty().set(commonTitle());
-        artistTextField.textProperty().set(initialArtistText = commonArtist());
-        albumTextField.textProperty().set(initialAlbumText = commonAlbum());
-        genreTextField.textProperty().set(initialGenreText = commonGenre());
+        initialArtistText = commonArtist();
+        artistTextField.textProperty().set(initialArtistText);
+        initialAlbumText = commonAlbum();
+        albumTextField.textProperty().set(initialAlbumText);
+        initialGenreText = commonGenre();
+        genreTextField.textProperty().set(initialGenreText);
         commentsTextField.textProperty().set(commonComments());
-        albumArtistTextField.textProperty().set(initialAlbumArtistText = commonAlbumArtist());
+        initialAlbumArtistText = commonAlbumArtist();
+        albumArtistTextField.textProperty().set(initialAlbumArtistText);
         labelTextField.textProperty().set(commonLabel());
         trackNumTextField.textProperty().set(commonTrackNumber());
         discNumTextField.textProperty().set(commonDiscNumber());
@@ -347,16 +349,15 @@ public class EditController {
         commonCover = commonCoverImage();
         commonCover.ifPresentOrElse(
                 coverBytes -> coverImage.setImage(new Image(new ByteArrayInputStream(coverBytes))),
-                () -> coverImage.setImage(defaultCoverImage)
-        );
+                () -> coverImage.setImage(defaultCoverImage));
 
-        if (! commonCompilation())
+        if (!commonCompilation())
             isCompilationCheckBox.setIndeterminate(true);
         else
             // editAudioItems guards audioItemSelection.isEmpty() before assigning; the set is non-empty here.
             isCompilationCheckBox.setSelected(audioItemSelection.stream().findFirst()
-                .orElseThrow(() -> new IllegalStateException(AUDIO_ITEM_SELECTION_EMPTY))
-                .getAlbum().isCompilation());
+                    .orElseThrow(() -> new IllegalStateException(AUDIO_ITEM_SELECTION_EMPTY))
+                    .getAlbum().isCompilation());
     }
 
     private String commonString(List<String> list) {
@@ -382,7 +383,7 @@ public class EditController {
 
     private String commonAlbum() {
         Set<String> changedAlbums = audioItemSelection.stream()
-                .filter(audioItem -> ! audioItem.getAlbum().getName().isEmpty())
+                .filter(audioItem -> !audioItem.getAlbum().getName().isEmpty())
                 .map(audioItem -> audioItem.getAlbum().getName())
                 .collect(Collectors.toSet());
         // editAudioItems guards audioItemSelection.isEmpty() before assigning; the set is non-empty here.
@@ -439,7 +440,7 @@ public class EditController {
 
     private Optional<byte[]> commonCoverImage() {
         Optional<byte[]> optionalCoverBytes = Optional.empty();
-        if (! commonAlbum().isEmpty()) {
+        if (!commonAlbum().isEmpty()) {
             Optional<ObservableAudioItem> audioItem = audioItemSelection.stream()
                     .filter(t -> t.getCoverImageProperty().get().isPresent())
                     .findFirst();
@@ -458,23 +459,26 @@ public class EditController {
     }
 
     private AudioItemMetadataChange getEditionResult() {
-       String title = getEditionFieldResult(titleTextField);
-       String artistName = getClearableFieldResult(artistTextField, initialArtistText);
-       Artist artist = artistName != null ? Artist.of(artistName) : null;
-       String albumName = getClearableFieldResult(albumTextField, initialAlbumText);
-       String albumArtistName = getClearableFieldResult(albumArtistTextField, initialAlbumArtistText);
-       Artist albumArtist = albumArtistName != null ? Artist.of(albumArtistName) : null;
-       Boolean isCompilation = isCompilationCheckBox.isIndeterminate() ? null : isCompilationCheckBox.isSelected();
-       Short year = getEditionFieldResult(yearTextField) != null ? Short.valueOf(getEditionFieldResult(yearTextField)) : null;
-       String labelValue = getEditionFieldResult(labelTextField);
-       net.transgressoft.commons.music.audio.Label label = labelValue != null ? net.transgressoft.commons.music.audio.Label.of(labelValue) : null;
-       Set<Genre> genres = getEditionGenres(initialGenreText);
-       String comments = getEditionFieldResult(commentsTextField);
-       Short trackNum = getEditionFieldResult(trackNumTextField) != null ? Short.valueOf(getEditionFieldResult(trackNumTextField)) : null;
-       Short discNum = getEditionFieldResult(discNumTextField) != null ? Short.valueOf(getEditionFieldResult(discNumTextField)) : null;
-       Float bpm = getEditionFieldResult(bpmTextField) != null ? Float.valueOf(getEditionFieldResult(bpmTextField)) : null;
+        String title = getEditionFieldResult(titleTextField);
+        String artistName = getClearableFieldResult(artistTextField, initialArtistText);
+        Artist artist = artistName != null ? Artist.of(artistName) : null;
+        String albumName = getClearableFieldResult(albumTextField, initialAlbumText);
+        String albumArtistName = getClearableFieldResult(albumArtistTextField, initialAlbumArtistText);
+        Artist albumArtist = albumArtistName != null ? Artist.of(albumArtistName) : null;
+        Boolean isCompilation = isCompilationCheckBox.isIndeterminate() ? null : isCompilationCheckBox.isSelected();
+        Short year = getEditionFieldResult(yearTextField) != null ? Short.valueOf(getEditionFieldResult(yearTextField)) : null;
+        String labelValue = getEditionFieldResult(labelTextField);
+        net.transgressoft.commons.music.audio.Label label = labelValue != null
+                ? net.transgressoft.commons.music.audio.Label.of(labelValue)
+                : null;
+        Set<Genre> genres = getEditionGenres(initialGenreText);
+        String comments = getEditionFieldResult(commentsTextField);
+        Short trackNum = getEditionFieldResult(trackNumTextField) != null ? Short.valueOf(getEditionFieldResult(trackNumTextField)) : null;
+        Short discNum = getEditionFieldResult(discNumTextField) != null ? Short.valueOf(getEditionFieldResult(discNumTextField)) : null;
+        Float bpm = getEditionFieldResult(bpmTextField) != null ? Float.valueOf(getEditionFieldResult(bpmTextField)) : null;
 
-       return new AudioItemMetadataChange(title, artist, albumName, albumArtist, isCompilation, year, label, newCoverImageBytes, genres, comments, trackNum, discNum, bpm);
+        return new AudioItemMetadataChange(title, artist, albumName, albumArtist, isCompilation, year, label, newCoverImageBytes, genres,
+                comments, trackNum, discNum, bpm);
     }
 
     private String getEditionFieldResult(TextInputControl textField) {
@@ -511,6 +515,9 @@ public class EditController {
      * {@link #getEditionFieldResult(TextInputControl)}, emptying a genre field that had content is an
      * explicit clear rather than a skip.
      */
+    // False positive: null is a meaningful sentinel ("leave genres untouched") that the change record
+    // distinguishes from an empty set ("clear genres"). Returning an empty collection would conflate them.
+    @SuppressWarnings("java:S1168")
     private Set<Genre> getEditionGenres(String initialValue) {
         String value = genreTextField.getText();
         if (value == null || value.equals("-")) {
@@ -547,12 +554,10 @@ public class EditController {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof AudioItemMetadataChange(
-                    String oTitle, Artist oArtist, String oAlbumName, Artist oAlbumArtist,
-                    Boolean oIsCompilation, Short oYear, net.transgressoft.commons.music.audio.Label oLabel,
-                    byte[] oCoverImageBytes, Set<Genre> oGenres, String oComments,
-                    Short oTrakNum, Short oDiscNum, Float oBpm))) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof AudioItemMetadataChange(String oTitle, Artist oArtist, String oAlbumName, Artist oAlbumArtist, Boolean oIsCompilation, Short oYear, net.transgressoft.commons.music.audio.Label oLabel, byte[] oCoverImageBytes, Set<Genre> oGenres, String oComments, Short oTrakNum, Short oDiscNum, Float oBpm)))
+                return false;
             return Objects.equals(title, oTitle)
                     && Objects.equals(artist, oArtist)
                     && Objects.equals(albumName, oAlbumName)

--- a/src/main/java/net/transgressoft/musicott/view/LogViewerController.java
+++ b/src/main/java/net/transgressoft/musicott/view/LogViewerController.java
@@ -111,9 +111,9 @@ public class LogViewerController {
 
     @Autowired
     public LogViewerController(Supplier<Stage> stageSupplier,
-                                Supplier<FileChooser> fileChooserSupplier,
-                                ApplicationEventPublisher eventPublisher,
-                                KeyCombination.Modifier operativeSystemKeyModifier) {
+            Supplier<FileChooser> fileChooserSupplier,
+            ApplicationEventPublisher eventPublisher,
+            KeyCombination.Modifier operativeSystemKeyModifier) {
         this.stageSupplier = stageSupplier;
         this.fileChooserSupplier = fileChooserSupplier;
         this.eventPublisher = eventPublisher;
@@ -235,7 +235,7 @@ public class LogViewerController {
      */
     private void renderFull(List<LogRecord> records) {
         String filtered = records.stream()
-                .filter(record -> passesFilter(record.level()))
+                .filter(logRecord -> passesFilter(logRecord.level()))
                 .map(LogRecord::text)
                 .collect(Collectors.joining());
         logTextArea.setText(filtered);
@@ -247,8 +247,8 @@ public class LogViewerController {
      * a single FX-thread flush per burst; filtering is deferred to the flush so the level filter
      * is only ever read on the FX thread.
      */
-    private void onLiveTailRecord(LogRecord record) {
-        pendingRecords.offer(record);
+    private void onLiveTailRecord(LogRecord logRecord) {
+        pendingRecords.offer(logRecord);
         if (flushScheduled.compareAndSet(false, true)) {
             Platform.runLater(this::flushPending);
         }
@@ -258,10 +258,10 @@ public class LogViewerController {
     private void flushPending() {
         flushScheduled.set(false);
         StringBuilder sb = new StringBuilder();
-        LogRecord record;
-        while ((record = pendingRecords.poll()) != null) {
-            if (passesFilter(record.level())) {
-                sb.append(record.text());
+        LogRecord logRecord;
+        while ((logRecord = pendingRecords.poll()) != null) {
+            if (passesFilter(logRecord.level())) {
+                sb.append(logRecord.text());
             }
         }
         if (!sb.isEmpty()) {
@@ -350,7 +350,8 @@ public class LogViewerController {
      * @return {@code true} if a record at {@code level} should be shown given the current filter
      */
     boolean passesFilter(Level level) {
-        if (level == null) return false;
+        if (level == null)
+            return false;
         Level threshold = Level.toLevel(currentLevelFilter, Level.INFO);
         return level.isGreaterOrEqual(threshold);
     }

--- a/src/main/java/net/transgressoft/musicott/view/MainController.java
+++ b/src/main/java/net/transgressoft/musicott/view/MainController.java
@@ -73,6 +73,8 @@ import static org.fxmisc.easybind.EasyBind.subscribe;
 public class MainController {
 
     private static final int HOVER_COVER_SIZE = 100;
+    private static final String BANNER_STYLE_SUCCESS = "success";
+    private static final String BANNER_STYLE_WARNING = "warning";
 
     private final Logger logger = LoggerFactory.getLogger(getClass().getName());
 
@@ -175,19 +177,19 @@ public class MainController {
 
     @Autowired
     public MainController(ObservableAudioLibrary audioRepository,
-                          ObservablePlaylistHierarchy playlistRepository,
-                          PlayerService playerService,
-                          PlayerController playerController,
-                          NavigationController navigationController,
-                          ArtistViewController artistViewController,
-                          AlbumViewController albumViewController,
-                          GenreViewController genreViewController,
-                          AlertFactory alertFactory,
-                          MediaImportService mediaImportService,
-                          ItunesImportWizard itunesImportWizard,
-                          ApplicationContext applicationContext,
-                          KeyCombination.Modifier operativeSystemKeyModifier,
-                          SearchCoordinator searchCoordinator) {
+            ObservablePlaylistHierarchy playlistRepository,
+            PlayerService playerService,
+            PlayerController playerController,
+            NavigationController navigationController,
+            ArtistViewController artistViewController,
+            AlbumViewController albumViewController,
+            GenreViewController genreViewController,
+            AlertFactory alertFactory,
+            MediaImportService mediaImportService,
+            ItunesImportWizard itunesImportWizard,
+            ApplicationContext applicationContext,
+            KeyCombination.Modifier operativeSystemKeyModifier,
+            SearchCoordinator searchCoordinator) {
         this.audioRepository = audioRepository;
         this.playlistRepository = playlistRepository;
         this.playerService = playerService;
@@ -216,25 +218,26 @@ public class MainController {
         playlistImageView.imageProperty().bind(playlistImageProperty);
 
         navigationController.setOnNewPlaylistAction(e -> changeViewToPlaylistCreationMode(playlistRepository::createPlaylist));
-        navigationController.setOnNewFolderPlaylistAction(e -> changeViewToPlaylistCreationMode(playlistRepository::createPlaylistDirectory));
+        navigationController
+                .setOnNewFolderPlaylistAction(e -> changeViewToPlaylistCreationMode(playlistRepository::createPlaylistDirectory));
         navigationController.navigationModeProperty().addListener((obs, oldMode, newMode) -> {
             switch (newMode) {
-                case ALL_AUDIO_ITEMS:
+                case ALL_AUDIO_ITEMS :
                     showAllAudioItemsView();
                     break;
-                case ARTISTS:
+                case ARTISTS :
                     showArtistsView();
                     break;
-                case ALBUMS:
+                case ALBUMS :
                     showAlbumsView();
                     break;
-                case GENRES:
+                case GENRES :
                     showGenresView();
                     break;
-                case PLAYLIST:
+                case PLAYLIST :
                     showPlaylistView();
                     break;
-                default:
+                default :
             }
         });
 
@@ -254,8 +257,7 @@ public class MainController {
             }
         });
 
-        searchTextField.textProperty().addListener((observable, oldValue, newValue) ->
-                searchCoordinator.onQuery(newValue));
+        searchTextField.textProperty().addListener((observable, oldValue, newValue) -> searchCoordinator.onQuery(newValue));
 
         audioItemContextMenu = new AudioItemTableViewContextMenu();
 
@@ -315,7 +317,7 @@ public class MainController {
         }));
 
         playlistTitleLabel.setOnMouseClicked(event -> {
-            if (event.getClickCount() == 2) {   // double click to edit the playlist name
+            if (event.getClickCount() == 2) { // double click to edit the playlist name
                 replacePlaylistTitleLabelByTextField();
                 playlistTitleTextField.setText(playlistTitleLabel.getText());
             }
@@ -351,7 +353,7 @@ public class MainController {
     }
 
     private boolean isValidPlaylistName(String newName) {
-        return ! newName.isEmpty() && ! navigationController.containsPlaylistName(newName);
+        return !newName.isEmpty() && !navigationController.containsPlaylistName(newName);
     }
 
     private void initializeMiniatureCoverImageView() {
@@ -361,13 +363,11 @@ public class MainController {
         miniatureCoverImageView.setFitWidth(HOVER_COVER_SIZE);
         miniatureCoverImageView.setFitHeight(HOVER_COVER_SIZE);
         miniatureCoverImageView.translateXProperty().bind(
-            map(tableStackPane.widthProperty(),
-                width -> (width.doubleValue() / 2) - (HOVER_COVER_SIZE / 2.0) - 10
-            ));
+                map(tableStackPane.widthProperty(),
+                        width -> (width.doubleValue() / 2) - (HOVER_COVER_SIZE / 2.0) - 10));
         miniatureCoverImageView.translateYProperty().bind(
-            map(tableStackPane.heightProperty(),
-                height -> (height.doubleValue() / 2) - (HOVER_COVER_SIZE / 2.0) - 27
-            ));
+                map(tableStackPane.heightProperty(),
+                        height -> (height.doubleValue() / 2) - (HOVER_COVER_SIZE / 2.0) - 27));
     }
 
     /**
@@ -473,7 +473,7 @@ public class MainController {
                 var recursiveItems = playlist.getAudioItemsRecursiveProperty();
                 mainAudioItemTable.setSourceItems(recursiveItems);
 
-                boolean hasItems = ! recursiveItems.isEmpty();
+                boolean hasItems = !recursiveItems.isEmpty();
                 miniatureCoverImageView.setVisible(hasItems);
                 playlistTracksNumberLabel.setVisible(hasItems);
                 playlistSizeLabel.setVisible(hasItems);
@@ -489,24 +489,23 @@ public class MainController {
                 });
 
                 playlistItemsSubscription = subscribe(recursiveItems, items -> {
-                    boolean notEmpty = ! items.isEmpty();
+                    boolean notEmpty = !items.isEmpty();
                     miniatureCoverImageView.setVisible(notEmpty);
                     playlistTracksNumberLabel.setVisible(notEmpty);
                     playlistSizeLabel.setVisible(notEmpty);
                 });
             } else {
                 playlistCoverSubscription = subscribe(playlist.getCoverImageProperty(),
-                    playlistCover -> playlistImageProperty.set(playlistCover.orElse(defaultPlaylistImage))
-                );
+                        playlistCover -> playlistImageProperty.set(playlistCover.orElse(defaultPlaylistImage)));
 
                 mainAudioItemTable.setSourceItems(playlist.getAudioItemsProperty());
-                boolean hasItems = ! playlist.getAudioItemsProperty().isEmpty();
+                boolean hasItems = !playlist.getAudioItemsProperty().isEmpty();
                 miniatureCoverImageView.setVisible(hasItems);
                 playlistTracksNumberLabel.setVisible(hasItems);
                 playlistSizeLabel.setVisible(hasItems);
 
                 playlistItemsSubscription = subscribe(playlist.getAudioItemsProperty(), audioItems -> {
-                    boolean notEmpty = ! audioItems.isEmpty();
+                    boolean notEmpty = !audioItems.isEmpty();
                     miniatureCoverImageView.setVisible(notEmpty);
                     playlistTracksNumberLabel.setVisible(notEmpty);
                     playlistSizeLabel.setVisible(notEmpty);
@@ -580,8 +579,7 @@ public class MainController {
         showTablePane();
 
         playlistTitleTextField.clear();
-        playlistTitleTextField.setOnKeyPressed(keyEvent ->
-                onPlaylistTitleTextFieldKeyPressed(keyEvent, playlistCreationFunction));
+        playlistTitleTextField.setOnKeyPressed(keyEvent -> onPlaylistTitleTextFieldKeyPressed(keyEvent, playlistCreationFunction));
     }
 
     private void onPlaylistTitleTextFieldKeyPressed(KeyEvent event, Function<String, ObservablePlaylist> playlistCreationFunction) {
@@ -593,8 +591,7 @@ public class MainController {
                 var newPlaylist = playlistCreationFunction.apply(newPlaylistName);
 
                 subscribe(newPlaylist.getCoverImageProperty(),
-                    playlistCover -> playlistImageProperty.set(playlistCover.orElse(defaultPlaylistImage))
-                );
+                        playlistCover -> playlistImageProperty.set(playlistCover.orElse(defaultPlaylistImage)));
                 replacePlaylistTextFieldByTitleLabel();
                 // Necessary to enable changing the name of the playlist afterward
                 playlistTitleTextField.setOnKeyPressed(this::changePlaylistNameTextFieldHandler);
@@ -606,7 +603,7 @@ public class MainController {
             } finally {
                 event.consume();
             }
-        // If the user presses Escape, we cancel the creation of the playlist
+            // If the user presses Escape, we cancel the creation of the playlist
         } else if (event.getCode() == KeyCode.ESCAPE) {
             replacePlaylistTextFieldByTitleLabel();
             selectedPlaylistProperty.get().ifPresentOrElse(navigationController::selectPlaylist, navigationController::selectFirstPlaylist);
@@ -758,7 +755,7 @@ public class MainController {
                 chooser.setTitle("Open file(s)...");
                 chooser.getExtensionFilters().addAll(buildAudioExtensionFilters());
                 var filesToOpen = chooser.showOpenMultipleDialog(rootBorderPane.getScene().getWindow());
-                if (filesToOpen != null && ! filesToOpen.isEmpty()) {
+                if (filesToOpen != null && !filesToOpen.isEmpty()) {
                     mediaImportService.importFiles(filesToOpen);
                 }
             });
@@ -814,8 +811,7 @@ public class MainController {
                 String wildcardExtension = extensionMap.get(type);
                 filters.add(new ExtensionFilter(
                         extension + " files (*." + extension + ")",
-                        wildcardExtension
-                ));
+                        wildcardExtension));
             }
 
             return filters;
@@ -842,13 +838,12 @@ public class MainController {
                 }
             });
 
-            showApplicationLogsMenuItem.setOnAction(e ->
-                applicationContext.publishEvent(new OpenLogViewerEvent(this)));
+            showApplicationLogsMenuItem.setOnAction(e -> applicationContext.publishEvent(new OpenLogViewerEvent(this)));
         }
 
         private void bindShowHideTableInfo() {
             showHideTableInfoPaneMenuItem.disableProperty().bind(
-                map(navigationController.navigationModeProperty(), menu -> !menu.equals(PLAYLIST)));
+                    map(navigationController.navigationModeProperty(), menu -> !menu.equals(PLAYLIST)));
         }
 
         private void initMenuBarItems() {
@@ -931,12 +926,11 @@ public class MainController {
             // inside a text field too, by default.
             // Menus are enabled again when the search text field lost focus or the edition was completed, which is handled in
             // trackEditingFinishedEventListener
-            editMenuItem.setOnAction(e ->
-                selectedAudioItems().ifPresent(audioItems -> {
-                    applicationContext.publishEvent(new OpenAudioItemEditorView(new HashSet<>(audioItems), this));
-                    selectAllMenuItem.setDisable(true);
-                    unselectMenuItem.setDisable(true);
-                }));
+            editMenuItem.setOnAction(e -> selectedAudioItems().ifPresent(audioItems -> {
+                applicationContext.publishEvent(new OpenAudioItemEditorView(new HashSet<>(audioItems), this));
+                selectAllMenuItem.setDisable(true);
+                unselectMenuItem.setDisable(true);
+            }));
             searchTextField.focusedProperty().addListener((observable, oldValue, newValue) -> {
                 if (Boolean.TRUE.equals(newValue)) {
                     selectAllMenuItem.setDisable(true);
@@ -970,16 +964,16 @@ public class MainController {
         private void selectAllTracks(ActionEvent event) {
             var mode = navigationController.navigationModeProperty().get();
             switch (mode) {
-                case ALL_AUDIO_ITEMS, PLAYLIST:
+                case ALL_AUDIO_ITEMS, PLAYLIST :
                     mainAudioItemTable.getSelectionModel().selectAll();
                     break;
-                case ARTISTS:
+                case ARTISTS :
                     artistViewController.selectAllTracks();
                     break;
-                case ALBUMS:
+                case ALBUMS :
                     albumViewController.selectAllTracks();
                     break;
-                case GENRES:
+                case GENRES :
                     genreViewController.selectAllTracks();
                     break;
             }
@@ -988,16 +982,16 @@ public class MainController {
         private void unselectTracks(ActionEvent event) {
             var mode = navigationController.navigationModeProperty().get();
             switch (mode) {
-                case ALL_AUDIO_ITEMS, PLAYLIST:
+                case ALL_AUDIO_ITEMS, PLAYLIST :
                     mainAudioItemTable.getSelectionModel().clearSelection();
                     break;
-                case ARTISTS:
+                case ARTISTS :
                     artistViewController.deselectAllTracks();
                     break;
-                case ALBUMS:
+                case ALBUMS :
                     albumViewController.deselectAllTracks();
                     break;
-                case GENRES:
+                case GENRES :
                     genreViewController.deselectAllTracks();
                     break;
             }
@@ -1037,8 +1031,8 @@ public class MainController {
     }
 
     private void showOutcomeBanner(String message) {
-        notificationPane.getStyleClass().removeAll("warning", "success");
-        notificationPane.getStyleClass().add("success");
+        notificationPane.getStyleClass().removeAll(BANNER_STYLE_WARNING, BANNER_STYLE_SUCCESS);
+        notificationPane.getStyleClass().add(BANNER_STYLE_SUCCESS);
         notificationPane.getActions().clear();
         Label icon = new Label("✓");
         icon.setStyle("-fx-text-fill: rgb(99, 255, 109); -fx-font-weight: bold;");
@@ -1047,8 +1041,8 @@ public class MainController {
     }
 
     private void showWarnErrorBanner(String message) {
-        notificationPane.getStyleClass().removeAll("success", "warning");
-        notificationPane.getStyleClass().add("warning");
+        notificationPane.getStyleClass().removeAll(BANNER_STYLE_SUCCESS, BANNER_STYLE_WARNING);
+        notificationPane.getStyleClass().add(BANNER_STYLE_WARNING);
         Action openLogAction = new Action("Open Log Viewer",
                 ae -> applicationContext.publishEvent(new OpenLogViewerEvent(this)));
         Label icon = new Label("⚠");
@@ -1136,21 +1130,21 @@ public class MainController {
 
             MenuItem playMenuItem = new MenuItem("Play");
             playMenuItem.setOnAction(event -> {
-                if (! selection.isEmpty()) {
+                if (!selection.isEmpty()) {
                     applicationContext.publishEvent(new PlayItemEvent(selection, this));
                 }
             });
 
             MenuItem editMenuItem = new MenuItem("Edit");
             editMenuItem.setOnAction(event -> {
-                if (! selection.isEmpty()) {
+                if (!selection.isEmpty()) {
                     applicationContext.publishEvent(new OpenAudioItemEditorView(new HashSet<>(selection), this));
                 }
             });
 
             MenuItem deleteMenuItem = new MenuItem("Delete");
             deleteMenuItem.setOnAction(event -> {
-                if (! selection.isEmpty()) {
+                if (!selection.isEmpty()) {
                     new DeleteAudioItemsConfirmationAlert().showAndWait().ifPresent(response -> {
                         if (response == ButtonType.OK) {
                             var selectionSet = new HashSet<>(selection);
@@ -1163,15 +1157,14 @@ public class MainController {
 
             MenuItem addToQueueMenuItem = new MenuItem("Add to play queue");
             addToQueueMenuItem.setOnAction(event -> {
-                if (! selection.isEmpty())
+                if (!selection.isEmpty())
                     applicationContext.publishEvent(new AddToPlayQueueEvent(selection, this));
             });
 
             deleteFromPlaylistMenuItem = new MenuItem("Delete from playlist");
             deleteFromPlaylistMenuItem.setId("deleteFromPlaylistMenuItem");
-            deleteFromPlaylistMenuItem.setOnAction(event ->
-                    selectedPlaylistProperty.get().ifPresent(audioPlaylist ->
-                            audioPlaylist.getAudioItemsProperty().removeAll(selection)));
+            deleteFromPlaylistMenuItem.setOnAction(event -> selectedPlaylistProperty.get()
+                    .ifPresent(audioPlaylist -> audioPlaylist.getAudioItemsProperty().removeAll(selection)));
 
             getItems().addAll(playMenuItem, editMenuItem, deleteMenuItem, addToQueueMenuItem, new SeparatorMenuItem());
             getItems().addAll(deleteFromPlaylistMenuItem, addToPlaylistMenu);
@@ -1187,14 +1180,14 @@ public class MainController {
 
             // Populate "Add to Playlist" submenu unconditionally in all navigation views
             navigationController.playlistsProperty().stream()
-                    .filter(p -> ! p.isDirectory())
+                    .filter(p -> !p.isDirectory())
                     .forEach(this::addPlaylistToMenuList);
             addToPlaylistMenu.getItems().addAll(playlistsInMenu);
 
             // "Delete from playlist" only makes sense when viewing a specific non-folder playlist
             var selectedPlaylist = selectedPlaylistProperty.get();
             deleteFromPlaylistMenuItem.setVisible(
-                selectedPlaylist.isPresent() && ! selectedPlaylist.get().isDirectory());
+                    selectedPlaylist.isPresent() && !selectedPlaylist.get().isDirectory());
 
             super.show(anchor, screenX, screenY);
         }
@@ -1202,9 +1195,10 @@ public class MainController {
         private void addPlaylistToMenuList(ObservablePlaylist playlist) {
             Optional<ObservablePlaylist> selectedPlaylist = selectedPlaylistProperty.get();
             // In playlist view, exclude the current playlist from the submenu (can't add tracks to itself)
-            if (selectedPlaylist.isEmpty() || ! selectedPlaylist.get().equals(playlist)) {
+            if (selectedPlaylist.isEmpty() || !selectedPlaylist.get().equals(playlist)) {
                 MenuItem playlistMenuItem = new MenuItem(playlist.getName());
-                playlistMenuItem.setOnAction(event -> playlist.getAudioItemsProperty().addAll(mainAudioItemTable.getSelectionModel().getSelectedItems()));
+                playlistMenuItem.setOnAction(
+                        event -> playlist.getAudioItemsProperty().addAll(mainAudioItemTable.getSelectionModel().getSelectedItems()));
                 playlistsInMenu.add(playlistMenuItem);
             }
         }

--- a/src/main/java/net/transgressoft/musicott/view/NavigationController.java
+++ b/src/main/java/net/transgressoft/musicott/view/NavigationController.java
@@ -63,16 +63,12 @@ import static org.fxmisc.easybind.EasyBind.subscribe;
  *
  * @author Octavio Calleya
  */
-@FxmlView ("/fxml/NavigationController.fxml")
+@FxmlView("/fxml/NavigationController.fxml")
 @Controller
 public class NavigationController {
 
     public enum NavigationMode {
-        ALL_AUDIO_ITEMS("All tracks"),
-        ARTISTS("Artists"),
-        ALBUMS("Albums"),
-        GENRES("Genres"),
-        PLAYLIST("Playlists");
+        ALL_AUDIO_ITEMS("All tracks"), ARTISTS("Artists"), ALBUMS("Albums"), GENRES("Genres"), PLAYLIST("Playlists");
 
         final String name;
 
@@ -116,13 +112,13 @@ public class NavigationController {
 
     @Autowired
     public NavigationController(PlaylistTreeView playlistTreeView,
-                                KeyCombination.Modifier operativeSystemKeyModifier,
-                                ApplicationEventPublisher applicationEventPublisher,
-                                FXMusicLibrary musicLibrary,
-                                AlertFactory alertFactory,
-                                Supplier<DirectoryChooser> directoryChooserSupplier,
-                                Supplier<FileChooser> fileChooserSupplier,
-                                M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService) {
+            KeyCombination.Modifier operativeSystemKeyModifier,
+            ApplicationEventPublisher applicationEventPublisher,
+            FXMusicLibrary musicLibrary,
+            AlertFactory alertFactory,
+            Supplier<DirectoryChooser> directoryChooserSupplier,
+            Supplier<FileChooser> fileChooserSupplier,
+            M3uImportService<ObservableAudioItem, ObservablePlaylist> m3uImportService) {
         this.playlistTreeView = playlistTreeView;
         this.operativeSystemKeyModifier = operativeSystemKeyModifier;
         this.applicationEventPublisher = applicationEventPublisher;
@@ -162,11 +158,10 @@ public class NavigationController {
         // When a playlist is selected, switch navigation mode and clear the nav-list selection
         // so re-clicking a nav mode always re-fires (no stale same-value skip).
         subscribe(selectedPlaylistProperty(),
-                  playlist -> playlist.ifPresent(p -> {
-                      navigationMenuListView.getSelectionModel().clearSelection();
-                      navigationModeProperty.set(NavigationMode.PLAYLIST);
-                  })
-        );
+                playlist -> playlist.ifPresent(p -> {
+                    navigationMenuListView.getSelectionModel().clearSelection();
+                    navigationModeProperty.set(NavigationMode.PLAYLIST);
+                }));
 
         // When switching to a non-playlist nav mode, clear the playlist tree.
         subscribe(navigationModeProperty, mode -> {
@@ -320,7 +315,9 @@ public class NavigationController {
             applicationEventPublisher.publishEvent(
                     new StatusMessageUpdateEvent("Exported " + exportedCount + " playlist(s)", delta, this));
         } else {
-            logger.warn("Playlist export failed for {} playlist(s): {}", failures.size(), String.join("; ", failures));
+            if (logger.isWarnEnabled()) {
+                logger.warn("Playlist export failed for {} playlist(s): {}", failures.size(), String.join("; ", failures));
+            }
             applicationEventPublisher.publishEvent(
                     new ErrorEvent("Export failed", String.join("\n", failures), this));
         }
@@ -372,7 +369,8 @@ public class NavigationController {
                         if (ex != null) {
                             logger.error("M3U import failed", ex);
                             applicationEventPublisher.publishEvent(
-                                    new ErrorEvent("Import failed", ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage(), this));
+                                    new ErrorEvent("Import failed", ex.getCause() != null ? ex.getCause().getMessage() : ex.getMessage(),
+                                            this));
                         } else {
                             musicLibrary.playlistHierarchy().addPlaylistsToDirectory(Set.of(playlist), PlaylistTreeView.ROOT_PLAYLIST_NAME);
                             logger.info("Imported playlist '{}' from M3U file", playlist.getName());
@@ -381,7 +379,9 @@ public class NavigationController {
                             int delta = (int) (RingBufferHolder.INSTANCE.warnErrorCount() - m3uMark);
                             applicationEventPublisher.publishEvent(
                                     new StatusMessageUpdateEvent(
-                                            "Imported playlist '" + playlist.getName() + "' (" + playlist.getAudioItemsRecursive().size() + " tracks)", delta, this));
+                                            "Imported playlist '" + playlist.getName() + "' (" + playlist.getAudioItemsRecursive().size()
+                                                    + " tracks)",
+                                            delta, this));
                         }
                     }));
         });
@@ -431,7 +431,7 @@ public class NavigationController {
             setId("navigationModeListView");
             setPrefWidth(USE_COMPUTED_SIZE);
 
-            NavigationMode[] navigationModes = { ALL_AUDIO_ITEMS, ARTISTS, ALBUMS, GENRES};
+            NavigationMode[] navigationModes = {ALL_AUDIO_ITEMS, ARTISTS, ALBUMS, GENRES};
             double listHeight = navigationModes.length * NAV_CELL_HEIGHT;
             setFixedCellSize(NAV_CELL_HEIGHT);
             setMinHeight(listHeight);
@@ -489,13 +489,13 @@ public class NavigationController {
         }
 
         private void updatePseudoClassStates(NavigationMode mode, boolean isSelected) {
-            pseudoClassStateChanged(audioItems, mode.equals(ALL_AUDIO_ITEMS) && ! isSelected);
+            pseudoClassStateChanged(audioItems, mode.equals(ALL_AUDIO_ITEMS) && !isSelected);
             pseudoClassStateChanged(audioItemsSelected, mode.equals(ALL_AUDIO_ITEMS) && isSelected);
-            pseudoClassStateChanged(artists, mode.equals(ARTISTS) && ! isSelected);
+            pseudoClassStateChanged(artists, mode.equals(ARTISTS) && !isSelected);
             pseudoClassStateChanged(artistsSelected, mode.equals(ARTISTS) && isSelected);
-            pseudoClassStateChanged(albums, mode.equals(ALBUMS) && ! isSelected);
+            pseudoClassStateChanged(albums, mode.equals(ALBUMS) && !isSelected);
             pseudoClassStateChanged(albumsSelected, mode.equals(ALBUMS) && isSelected);
-            pseudoClassStateChanged(genres, mode.equals(GENRES) && ! isSelected);
+            pseudoClassStateChanged(genres, mode.equals(GENRES) && !isSelected);
             pseudoClassStateChanged(genresSelected, mode.equals(GENRES) && isSelected);
         }
 

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlert.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/AboutWindowAlert.java
@@ -1,6 +1,7 @@
 package net.transgressoft.musicott.view.custom.alerts;
 
 import net.transgressoft.musicott.services.SimpleWebRedirectionService;
+import net.transgressoft.musicott.splash.BuildVersionReader;
 import net.transgressoft.musicott.view.custom.ApplicationImage;
 
 import javafx.geometry.Pos;
@@ -10,7 +11,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
-import org.springframework.boot.info.BuildProperties;
 
 import java.time.Year;
 import java.time.ZoneId;
@@ -23,22 +23,29 @@ import static net.transgressoft.musicott.services.SimpleWebRedirectionService.GI
 public class AboutWindowAlert extends ApplicationAlertBase {
 
     private static final String ABOUT_MUSICOTT_SECOND_LINE = "\nLicensed under GNU GPLv3. This product includes "
-        + "software developed by other open source projects.";
+            + "software developed by other open source projects.";
 
     /**
      * @param webRedirectionService service used by the GitHub hyperlink action
-     * @param buildProperties Spring's BuildProperties bean — may be null when the
-     *                        bootBuildInfo task did not run (e.g. an IDE invocation
-     *                        that bypassed Gradle resource processing). Falls back
-     *                        to "dev" as the displayed version string.
      */
-    public AboutWindowAlert(SimpleWebRedirectionService webRedirectionService, BuildProperties buildProperties) {
+    public AboutWindowAlert(SimpleWebRedirectionService webRedirectionService) {
+        this(webRedirectionService, BuildVersionReader.read());
+    }
+
+    /**
+     * @param webRedirectionService service used by the GitHub hyperlink action
+     * @param version               already-resolved version string ("dev" when the
+     *                              build-info resource is absent); the app uses the
+     *                              single-argument constructor, which sources this from
+     *                              {@link BuildVersionReader#read()} — the same reader the
+     *                              splash uses, so both screens always agree
+     */
+    AboutWindowAlert(SimpleWebRedirectionService webRedirectionService, String version) {
         super(AlertType.INFORMATION);
         setHeaderText(null);
 
-        String version = (buildProperties != null) ? buildProperties.getVersion() : "dev";
         String firstLine = "Version " + version + ".\nCopyright © 2015-"
-            + Year.now(ZoneId.systemDefault()).getValue() + "\nOctavio Calleya.";
+                + Year.now(ZoneId.systemDefault()).getValue() + "\nOctavio Calleya.";
 
         Label aboutLabel1 = new Label(firstLine);
         Label aboutLabel2 = new Label(ABOUT_MUSICOTT_SECOND_LINE);

--- a/src/main/java/net/transgressoft/musicott/view/custom/alerts/AlertFactory.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/alerts/AlertFactory.java
@@ -5,9 +5,7 @@ import javafx.scene.control.Dialog;
 import javafx.scene.control.MenuBar;
 import net.transgressoft.commons.music.itunes.ImportResult;
 import net.transgressoft.musicott.services.SimpleWebRedirectionService;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Component;
 
 /**
@@ -19,17 +17,14 @@ import org.springframework.stereotype.Component;
 public class AlertFactory {
 
     private final SimpleWebRedirectionService webRedirectionService;
-    private final ObjectProvider<BuildProperties> buildPropertiesProvider;
 
     @Autowired
-    public AlertFactory(SimpleWebRedirectionService webRedirectionService,
-                        ObjectProvider<BuildProperties> buildPropertiesProvider) {
+    public AlertFactory(SimpleWebRedirectionService webRedirectionService) {
         this.webRedirectionService = webRedirectionService;
-        this.buildPropertiesProvider = buildPropertiesProvider;
     }
 
     public Alert aboutWindowAlert() {
-        return new AboutWindowAlert(webRedirectionService, buildPropertiesProvider.getIfAvailable());
+        return new AboutWindowAlert(webRedirectionService);
     }
 
     /**

--- a/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
+++ b/src/main/java/net/transgressoft/musicott/view/custom/table/AudioItemTableViewBase.java
@@ -29,7 +29,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -225,7 +224,7 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         return event -> {
             if (event.getCode() == KeyCode.ENTER) {
                 ObservableList<ObservableAudioItem> selection = getSelectionModel().getSelectedItems();
-                if (selection != null && ! selection.isEmpty())
+                if (selection != null && !selection.isEmpty())
                     applicationEventPublisher.publishEvent(new PlayItemEvent(selection, event.getSource()));
             } else if (event.getCode() == KeyCode.SPACE)
                 applicationEventPublisher.publishEvent(new PauseEvent(event.getSource()));
@@ -302,22 +301,6 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         currentSourceItems = sourceItems;
     }
 
-    /**
-     * Returns a {@link Predicate} that evaluates the match of a given {@code String} to a given {@link ObservableAudioItem}
-     *
-     * @param query The {@code String} to match against the audio item
-     *
-     * @return The {@code Predicate}
-     */
-    private Predicate<ObservableAudioItem> filterAudioItemPredicate(String query) {
-        return audioItem -> {
-            var result = query == null || query.isEmpty();
-            if (! result)
-                result = audioItemContainsQuery(audioItem, query.toLowerCase());
-            return result;
-        };
-    }
-
     // Defensive null guards on title / artist / album metadata: imported tracks can ship with null
     // fields (partial catalogs), and one malformed item must not NPE the whole query filter. Sonar
     // trusts the music-commons API's nominal non-null types and flags each guard as gratuitous.
@@ -383,12 +366,12 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         }
 
         private void playAudioItemOnMouseClickedHandler(MouseEvent event) {
-            if (! isEmpty() && getItem() != null && event.getClickCount() == 2)
+            if (!isEmpty() && getItem() != null && event.getClickCount() == 2)
                 applicationEventPublisher.publishEvent(new PlayItemEvent(Collections.singletonList(getItem()), event.getSource()));
         }
 
         private void onDragDetectedMovingAudioItemHandler(MouseEvent event) {
-            if (! isEmpty()) {
+            if (!isEmpty()) {
                 var dragBoard = startDragAndDrop(TransferMode.COPY);
                 dragBoard.setDragView(DRAGBOARD_IMAGE);
 
@@ -411,8 +394,8 @@ public abstract class AudioItemTableViewBase extends TableView<ObservableAudioIt
         private Consumer<ObservableAudioItem> onAudioItemChangedHandler() {
             return item -> {
                 if (item != null) {
-                    pseudoClassStateChanged(unplayableRow, ! AudioItemPlayer.Companion.isPlayable(getItem()));
-                    pseudoClassStateChanged(notInDiskRow, ! item.getPath().toFile().exists());
+                    pseudoClassStateChanged(unplayableRow, !AudioItemPlayer.Companion.isPlayable(getItem()));
+                    pseudoClassStateChanged(notInDiskRow, !item.getPath().toFile().exists());
                 } else {
                     pseudoClassStateChanged(notInDiskRow, false);
                     pseudoClassStateChanged(unplayableRow, false);

--- a/src/main/kotlin/net/transgressoft/musicott/search/SearchCoordinator.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/search/SearchCoordinator.kt
@@ -86,7 +86,10 @@ class SearchCoordinator(
      * @param mode the navigation mode this [Searchable] handles
      * @param searchable the view implementing [Searchable] for [mode]
      */
-    fun register(mode: NavigationMode, searchable: Searchable<*>) {
+    fun register(
+        mode: NavigationMode,
+        searchable: Searchable<*>
+    ) {
         searchables[mode] = searchable
         logger.debug { "Registered Searchable for mode $mode: ${searchable::class.simpleName}" }
     }
@@ -104,72 +107,124 @@ class SearchCoordinator(
         val gen = generation.incrementAndGet()
         val trimmed = query.trim()
 
-        currentJob = scope.launch {
-            if (trimmed.isBlank()) {
+        currentJob =
+            scope.launch {
+                if (trimmed.isBlank()) {
+                    resetAllViews(gen)
+                    return@launch
+                }
+
+                delay(debounceMillis)
+
+                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Searching...", this@SearchCoordinator))
+
+                val lowerQuery = trimmed.lowercase()
+
+                // Filter EVERY registered view, not just the visible one, so all navigation modes stay
+                // in sync — switching modes shows an already-filtered view. A stable copy guards against
+                // concurrent registrations during the scan; distinct() ensures a single Searchable
+                // registered under several modes (e.g. the audio table under ALL_AUDIO_ITEMS and
+                // PLAYLIST) is scanned once rather than once per mode.
+                @Suppress("UNCHECKED_CAST")
+                val targets =
+                    searchables.values
+                        .distinct()
+                        .map { it as Searchable<Any> }
+                        .toList()
+
+                // Snapshot each view's backing collection on the FX thread so the subsequent off-thread
+                // scan reads a stable list rather than a live ObservableList that concurrent
+                // import/edit operations may structurally modify.
                 withContext(fxDispatcher) {
-                    if (generation.get() == gen) {
-                        // Distinct instances only: a single Searchable registered under several modes
-                        // (e.g. the audio table under ALL_AUDIO_ITEMS and PLAYLIST) is reset once.
-                        searchables.values.distinct().forEach { searchable ->
-                            @Suppress("UNCHECKED_CAST")
-                            (searchable as? Searchable<Any>)?.applyMatchIds("", emptySet())
-                        }
-                        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
+                    targets.forEach { it.prepareSnapshot() }
+                }
+
+                val results = computeResults(targets, lowerQuery, gen) ?: return@launch
+                applyResults(results, lowerQuery, gen)
+            }
+    }
+
+    /**
+     * Resets every registered view to show all items. Runs on the FX thread and is generation-guarded
+     * so a newer query issued while this reset was queued wins.
+     */
+    private suspend fun resetAllViews(gen: Long) {
+        withContext(fxDispatcher) {
+            if (generation.get() == gen) {
+                // Distinct instances only: a single Searchable registered under several modes
+                // (e.g. the audio table under ALL_AUDIO_ITEMS and PLAYLIST) is reset once.
+                searchables.values.distinct().forEach { searchable ->
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        (searchable as? Searchable<Any>)?.applyMatchIds("", emptySet())
+                    } catch (e: Exception) {
+                        // Isolate per-view failures so one throwing view neither aborts the reset of the
+                        // others nor skips the trailing status-clear publish.
+                        logger.error(e) { "Reset failed for ${searchable::class.simpleName}" }
                     }
                 }
-                return@launch
+                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
             }
+        }
+    }
 
-            delay(debounceMillis)
-
-            applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Searching...", this@SearchCoordinator))
-
-            val lowerQuery = trimmed.lowercase()
-
-            // Filter EVERY registered view, not just the visible one, so all navigation modes stay
-            // in sync — switching modes shows an already-filtered view. A stable copy guards against
-            // concurrent registrations during the scan; distinct() ensures a single Searchable
-            // registered under several modes (e.g. the audio table under ALL_AUDIO_ITEMS and
-            // PLAYLIST) is scanned once rather than once per mode.
-            @Suppress("UNCHECKED_CAST")
-            val targets = searchables.values.distinct().map { it as Searchable<Any> }.toList()
-
-            // Snapshot each view's backing collection on the FX thread so the subsequent off-thread
-            // scan reads a stable list rather than a live ObservableList that concurrent
-            // import/edit operations may structurally modify.
-            withContext(fxDispatcher) {
-                targets.forEach { it.prepareSnapshot() }
-            }
-
-            val results = try {
-                withContext(dispatcher) {
-                    targets.map { searchable -> searchable to searchable.computeMatchIds(lowerQuery) }
-                }
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.error(e) { "Search failed for query='$lowerQuery'" }
-                // Clear the "Searching…" status the failed run published, so it does not linger
-                // until the next query. Guarded by generation so a newer query's status wins.
-                withContext(fxDispatcher) {
-                    if (generation.get() == gen) {
-                        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
+    /**
+     * Runs the off-thread match scan for every target. Returns the per-view id sets, or `null` when the
+     * scan failed (after clearing the lingering "Searching…" status). Cancellation propagates.
+     */
+    private suspend fun computeResults(
+        targets: List<Searchable<Any>>,
+        lowerQuery: String,
+        gen: Long
+    ): List<Pair<Searchable<Any>, Set<Any>>>? =
+        try {
+            withContext(dispatcher) {
+                targets.map { searchable ->
+                    try {
+                        searchable to searchable.computeMatchIds(lowerQuery)
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // Isolate per-target failures: one throwing view yields an empty match set
+                        // (its rows hide) rather than discarding every other view's results.
+                        logger.error(e) { "computeMatchIds failed for ${searchable::class.simpleName}" }
+                        searchable to emptySet()
                     }
                 }
-                return@launch
             }
-
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "Search failed for query='$lowerQuery'" }
+            // Clear the "Searching…" status the failed run published, so it does not linger
+            // until the next query. Guarded by generation so a newer query's status wins.
             withContext(fxDispatcher) {
                 if (generation.get() == gen) {
-                    results.forEach { (searchable, ids) ->
-                        try {
-                            searchable.applyMatchIds(lowerQuery, ids)
-                        } catch (e: Exception) {
-                            logger.error(e) { "Apply search results failed for query='$lowerQuery'" }
-                        }
-                    }
                     applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
                 }
+            }
+            null
+        }
+
+    /**
+     * Applies the precomputed id sets to each view on the FX thread, generation-guarded so a slower
+     * earlier query never overwrites a newer query's results.
+     */
+    private suspend fun applyResults(
+        results: List<Pair<Searchable<Any>, Set<Any>>>,
+        lowerQuery: String,
+        gen: Long
+    ) {
+        withContext(fxDispatcher) {
+            if (generation.get() == gen) {
+                results.forEach { (searchable, ids) ->
+                    try {
+                        searchable.applyMatchIds(lowerQuery, ids)
+                    } catch (e: Exception) {
+                        logger.error(e) { "Apply search results failed for query='$lowerQuery'" }
+                    }
+                }
+                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("", this@SearchCoordinator))
             }
         }
     }

--- a/src/main/kotlin/net/transgressoft/musicott/search/Searchable.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/search/Searchable.kt
@@ -25,7 +25,6 @@ package net.transgressoft.musicott.search
  *           (e.g. [Int] for audio items, [String] for album or genre names)
  */
 interface Searchable<ID : Any> {
-
     /**
      * Captures an immutable snapshot of the backing collection on the JavaFX Application Thread.
      *
@@ -36,7 +35,9 @@ interface Searchable<ID : Any> {
      * The default implementation is a no-op; views whose backing data is not a live observable list
      * (or is replaced atomically via `setAll`) do not need to override this method.
      */
-    fun prepareSnapshot() {}
+    fun prepareSnapshot() {
+        // No-op default: views whose backing data is not a live observable list have nothing to snapshot.
+    }
 
     /**
      * Computes the set of item identifiers that match [query].
@@ -63,5 +64,8 @@ interface Searchable<ID : Any> {
      * @param query the search text that produced [ids]; a blank string signals a reset (show all)
      * @param ids the set of identifiers computed by [computeMatchIds]; empty means no matches when query is non-blank
      */
-    fun applyMatchIds(query: String, ids: @JvmSuppressWildcards Set<ID>)
+    fun applyMatchIds(
+        query: String,
+        ids: @JvmSuppressWildcards Set<ID>
+    )
 }

--- a/src/main/kotlin/net/transgressoft/musicott/service/MediaImportService.kt
+++ b/src/main/kotlin/net/transgressoft/musicott/service/MediaImportService.kt
@@ -1,18 +1,18 @@
-/******************************************************************************
- * Copyright (C) 2025  Octavio Calleya Garcia                                 *
- * *
- * This program is free software: you can redistribute it and/or modify       *
- * it under the terms of the GNU General Public License as published by       *
- * the Free Software Foundation, either version 3 of the License, or          *
- * (at your option) any later version.                                        *
- * *
- * This program is distributed in the hope that it will be useful,            *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
- * GNU General Public License for more details.                               *
- * *
- * You should have received a copy of the GNU General Public License          *
- * along with this program.  If not, see <https:></https:>//www.gnu.org/licenses/>.     *
+/*
+ * Copyright (C) 2025  Octavio Calleya Garcia
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package net.transgressoft.musicott.service
 
@@ -100,7 +100,8 @@ class MediaImportService(
             }
 
         logger.debug { "Dispatching async file batch import: ${paths.size} file(s)" }
-        audioLibrary.createFromFileBatchAsync(paths)
+        audioLibrary
+            .createFromFileBatchAsync(paths)
             .whenComplete(completeImport(progressSubscription, mark))
     }
 
@@ -122,19 +123,22 @@ class MediaImportService(
                 }
             }
 
-        val extensions = AudioFileType.values()
-            .map(AudioFileType::extension)
-            .toSet()
+        val extensions =
+            AudioFileType
+                .values()
+                .map(AudioFileType::extension)
+                .toSet()
 
-        CompletableFuture.supplyAsync { findAcceptedFiles(directory, extensions) }
+        CompletableFuture
+            .supplyAsync { findAcceptedFiles(directory, extensions) }
             .thenCompose(audioLibrary::createFromFileBatchAsync)
             .whenComplete(completeImport(progressSubscription, mark))
     }
 
     private fun completeImport(
         progressSubscription: LirpEventSubscription<in LirpEntity, CrudEvent.Type, CrudEvent<Int, ObservableAudioItem>>,
-        mark: Long):
-            BiConsumer<in @UnknownNullability List<ObservableAudioItem>, in @UnknownNullability Throwable?> =
+        mark: Long
+    ): BiConsumer<in @UnknownNullability List<ObservableAudioItem>, in @UnknownNullability Throwable?> =
         { result, ex ->
             logger.debug { "Import async pipeline completing" }
             progressSubscription.cancel()
@@ -142,7 +146,7 @@ class MediaImportService(
                 logger.error(ex.message, ex)
                 applicationEventPublisher.publishEvent(ExceptionEvent(ex, this))
             } else {
-                logger.info { "Import finished: ${result?.size ?: 0} item(s) added" }
+                logger.info { "Import finished: ${result.size} item(s) added" }
             }
             val delta = (RingBufferHolder.INSTANCE.warnErrorCount() - mark).toInt()
             applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Import process completed", delta, this))
@@ -179,42 +183,51 @@ class MediaImportService(
     ): CompletableFuture<ImportResult> {
         if (!tryStartImport()) return CompletableFuture.completedFuture(null)
 
-        val library = lastParsedLibrary
-            ?: run { finishImport(); throw IllegalStateException("No iTunes library parsed. Call parseLibrary() first.") }
+        val library =
+            lastParsedLibrary
+                ?: run {
+                    finishImport()
+                    throw IllegalStateException("No iTunes library parsed. Call parseLibrary() first.")
+                }
         val mark = RingBufferHolder.INSTANCE.warnErrorCount()
         applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Importing from iTunes...", this))
 
-        val future = coreItunesImportService.importAsync(
-            selectedPlaylists,
-            library,
-            policy
-        ) { progress ->
-            Platform.runLater {
-                // Guard against an empty import surfacing Infinity / NaN to the status bar.
-                val fraction = if (progress.totalItems > 0) {
-                    progress.itemsProcessed.toDouble() / progress.totalItems
-                } else {
-                    0.0
+        val future =
+            coreItunesImportService
+                .importAsync(
+                    selectedPlaylists,
+                    library,
+                    policy
+                ) { progress ->
+                    Platform.runLater {
+                        // Guard against an empty import surfacing Infinity / NaN to the status bar.
+                        val fraction =
+                            if (progress.totalItems > 0) {
+                                progress.itemsProcessed.toDouble() / progress.totalItems
+                            } else {
+                                0.0
+                            }
+                        applicationEventPublisher.publishEvent(StatusProgressUpdateEvent(fraction, this))
+                        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Importing: ${progress.currentFile}", this))
+                    }
+                }.whenComplete { result, ex ->
+                    Platform.runLater {
+                        currentImportFuture = null
+                        if (ex != null) {
+                            logger.error(ex.message, ex)
+                            applicationEventPublisher.publishEvent(ExceptionEvent(ex, this))
+                        } else if (result != null) {
+                            logger.info {
+                                "iTunes import finished: ${result.imported.size} track(s) imported, ${result.unresolved.size} unresolved"
+                            }
+                            alertFactory.itunesImportResultAlert(result).showAndWait()
+                        }
+                        val delta = (RingBufferHolder.INSTANCE.warnErrorCount() - mark).toInt()
+                        applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("iTunes import completed", delta, this))
+                        applicationEventPublisher.publishEvent(StatusProgressUpdateEvent(0.0, this))
+                        finishImport()
+                    }
                 }
-                applicationEventPublisher.publishEvent(StatusProgressUpdateEvent(fraction, this))
-                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("Importing: ${progress.currentFile}", this))
-            }
-        }.whenComplete { result, ex ->
-            Platform.runLater {
-                currentImportFuture = null
-                if (ex != null) {
-                    logger.error(ex.message, ex)
-                    applicationEventPublisher.publishEvent(ExceptionEvent(ex, this))
-                } else if (result != null) {
-                    logger.info { "iTunes import finished: ${result.imported.size} track(s) imported, ${result.unresolved.size} unresolved" }
-                    alertFactory.itunesImportResultAlert(result).showAndWait()
-                }
-                val delta = (RingBufferHolder.INSTANCE.warnErrorCount() - mark).toInt()
-                applicationEventPublisher.publishEvent(StatusMessageUpdateEvent("iTunes import completed", delta, this))
-                applicationEventPublisher.publishEvent(StatusProgressUpdateEvent(0.0, this))
-                finishImport()
-            }
-        }
 
         currentImportFuture = future
         return future
@@ -239,26 +252,31 @@ class MediaImportService(
         importing.set(false)
     }
 
-    private fun findAcceptedFiles(directory: File, acceptedExtensions: Set<String>): List<Path> {
-        val paths = try {
-            Files.walk(directory.toPath()).use { pathStream ->
-                pathStream
-                    .filter(Files::isRegularFile)
-                    .filter { it.extension.lowercase() in acceptedExtensions }
-                    .toList()
+    private fun findAcceptedFiles(
+        directory: File,
+        acceptedExtensions: Set<String>
+    ): List<Path> {
+        val paths =
+            try {
+                Files.walk(directory.toPath()).use { pathStream ->
+                    pathStream
+                        .filter(Files::isRegularFile)
+                        .filter { it.extension.lowercase() in acceptedExtensions }
+                        .toList()
+                }
+            } catch (exception: IOException) {
+                logger.error("Error scanning directory: {}", exception.message, exception)
+                applicationEventPublisher.publishEvent(ExceptionEvent(exception, this))
+                return emptyList()
             }
-        } catch (exception: IOException) {
-            logger.error("Error scanning directory: {}", exception.message, exception)
-            applicationEventPublisher.publishEvent(ExceptionEvent(exception, this))
-            return emptyList()
-        }
 
         logger.debug { "Directory scan found ${paths.size} accepted audio file(s)" }
-        val message = if (paths.isEmpty()) {
-            "No supported audio files found"
-        } else {
-            "Found ${paths.size} audio files"
-        }
+        val message =
+            if (paths.isEmpty()) {
+                "No supported audio files found"
+            } else {
+                "Found ${paths.size} audio files"
+            }
         applicationEventPublisher.publishEvent(StatusMessageUpdateEvent(message, this))
 
         totalFiles = paths.size


### PR DESCRIPTION
Closes #89.

## Problem

The splash screen and Help → About dialog showed the wrong version — `1.0.0-master-SNAPSHOT` on the splash and `version dev` in About — most visibly on the AUR build, which builds from a git-less source tarball.

## Changes

- **`build.gradle`**: bind `buildInfo`'s version explicitly, honoring a `-PreleaseVersion` Gradle property, so CI and the AUR PKGBUILD stamp the exact release version into `build-info.properties`. The default `buildInfo()` binding let axion-release's lazy version win over the override. `project.version` also honors the property for consistent jar naming.
- **`AboutWindowAlert` / `AlertFactory`**: the About dialog now reads the version from the same classpath `build-info.properties` reader the splash uses (`BuildVersionReader`), instead of Spring's `BuildProperties` bean — which is never created because the app boots without auto-configuration, so About always fell back to `"dev"`.
- **`AboutWindowAlertIT`**: construct the dialog with a fixed version directly instead of a hand-defined `BuildProperties` bean that masked the production bug.

Local/dev builds keep the axion-derived version so a dev build stays distinguishable from a release.

## Testing

- `AboutWindowAlertIT` and `SplashVersionIT` pass.
- Verified `gradle jpackageImage -PreleaseVersion=1.0.0` embeds `build.version=1.0.0`; the resulting app-image shows `1.0.0` on both the splash and About screens.
- Confirmed a plain dev build (no property) still shows the axion `-SNAPSHOT` version.